### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Redact Service CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/censgate/redact/security/code-scanning/1](https://github.com/censgate/redact/security/code-scanning/1)

To fix the problem, we need to add a `permissions` block to the workflow to restrict the permissions of the GITHUB_TOKEN. Since this CI job only needs to read the repository contents (e.g., perform checkout, download dependencies, run tests), the minimal required permission is `contents: read`. This can be added either at the root level (applying to all jobs), or specifically to the `test` job. The simplest and most maintainable fix is to add a root-level `permissions` block below the workflow name, so that any future jobs will also inherit these minimal permissions. This involves editing `.github/workflows/ci.yml` to add:

```yaml
permissions:
  contents: read
```

directly beneath the `name:` key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
