### PR TITLE
chore: release v0.8.1

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -1,0 +1,62 @@
+name: Create Release Tag
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Tag to create (e.g., v0.8.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  create-tag:
+    name: Create Release Tag
+    if: >
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.pull_request.merged == true &&
+       startsWith(github.event.pull_request.head.ref, 'release/v'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine tag and commit
+        id: resolve
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.version }}"
+            TAG="${TAG#v}"
+            TAG="v${TAG}"
+            SHA=$(git rev-parse HEAD)
+          else
+            BRANCH="${{ github.event.pull_request.head.ref }}"
+            TAG="${BRANCH#release/}"
+            SHA="${{ github.event.pull_request.merge_commit_sha }}"
+          fi
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "sha=$SHA" >> $GITHUB_OUTPUT
+          echo "Will create tag $TAG at $SHA"
+
+      - name: Verify tag does not exist
+        run: |
+          if git tag -l "${{ steps.resolve.outputs.tag }}" | grep -q .; then
+            echo "::error::Tag ${{ steps.resolve.outputs.tag }} already exists"
+            exit 1
+          fi
+
+      - name: Create tag
+        run: |
+          gh api repos/${{ github.repository }}/git/refs \
+            -f ref="refs/tags/${{ steps.resolve.outputs.tag }}" \
+            -f sha="${{ steps.resolve.outputs.sha }}"
+          echo "Created tag ${{ steps.resolve.outputs.tag }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           gh pr create \
             --title "chore: release v${{ env.VERSION }}" \
-            --body "Automated release PR. After merging, create tag: git tag -a v${{ env.VERSION }} -m Release && git push origin v${{ env.VERSION }}" \
+            --body "Automated release PR. Merging will automatically create the \`v${{ env.VERSION }}\` tag and trigger the release workflow." \
             --base main \
             --head release/v${{ env.VERSION }}
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2220,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "redact-api"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2237,7 +2237,7 @@ dependencies = [
 
 [[package]]
 name = "redact-cli"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2253,7 +2253,7 @@ dependencies = [
 
 [[package]]
 name = "redact-core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2275,7 +2275,7 @@ dependencies = [
 
 [[package]]
 name = "redact-examples"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "redact-api",
@@ -2287,7 +2287,7 @@ dependencies = [
 
 [[package]]
 name = "redact-ner"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "ndarray",
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "redact-wasm"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "js-sys",
  "redact-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.88"
 authors = ["Censgate LLC <support@censgate.com>"]

--- a/crates/redact-api/Cargo.toml
+++ b/crates/redact-api/Cargo.toml
@@ -10,8 +10,8 @@ homepage.workspace = true
 description = "REST API service for PII detection and anonymization"
 
 [dependencies]
-redact-core = { path = "../redact-core", version = "0.8.0" }
-redact-ner = { path = "../redact-ner", version = "0.8.0" }
+redact-core = { path = "../redact-core", version = "0.8.1" }
+redact-ner = { path = "../redact-ner", version = "0.8.1" }
 axum = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true }

--- a/crates/redact-cli/Cargo.toml
+++ b/crates/redact-cli/Cargo.toml
@@ -10,8 +10,8 @@ homepage.workspace = true
 description = "CLI tool for PII detection and anonymization"
 
 [dependencies]
-redact-core = { path = "../redact-core", version = "0.8.0" }
-redact-ner = { path = "../redact-ner", version = "0.8.0" }
+redact-core = { path = "../redact-core", version = "0.8.1" }
+redact-ner = { path = "../redact-ner", version = "0.8.1" }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/redact-ner/Cargo.toml
+++ b/crates/redact-ner/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 description = "Named Entity Recognition for PII detection using ONNX Runtime"
 
 [dependencies]
-redact-core = { path = "../redact-core", version = "0.8.0" }
+redact-core = { path = "../redact-core", version = "0.8.1" }
 ort = { workspace = true }
 ndarray = { workspace = true }
 tokenizers = "0.22"


### PR DESCRIPTION
## Summary

- Bump version to `0.8.1` — the `v0.8.0` tag cannot be recreated due to a GitHub immutable release reference left behind from the failed release attempt
- Add `create-release-tag.yml` workflow that automatically creates the git tag when a `release/v*` PR is merged, eliminating the need for manual `git push origin v*` which is blocked by repository rulesets
- Update `prepare-release.yml` PR body to reflect the new automated tagging flow

## What happened with v0.8.0

The v0.8.0 release workflow ran on Apr 9 and successfully published:
- All 4 crates to crates.io (redact-core, redact-ner, redact-api, redact-cli)
- Docker images to GHCR (both regular and full+NER)
- Built all 5 platform binaries

However, the "Create Release" job failed at the "Publish release" step. The tag was then deleted, but GitHub's backend retains an immutable reference that prevents the `v0.8.0` tag name from being reused.

## After merge

Merging this PR will automatically create the `v0.8.1` tag (via the new `create-release-tag.yml` workflow), which triggers the full release pipeline.

Made with [Cursor](https://cursor.com)