### PR TITLE
chore: release v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] - 2026-04-17
+
+### Fixed
+
+- Replace stale BUSL-1.1 per-file copyright headers with Apache-2.0 across all source files (fixes #50)
+
 ## [0.5.0] - 2026-01-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2491,9 +2491,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2796,7 +2796,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 rust-version = "1.88"
 authors = ["Censgate LLC <support@censgate.com>"]

--- a/crates/redact-api/src/handlers.rs
+++ b/crates/redact-api/src/handlers.rs
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Censgate LLC.
-// Licensed under the Business Source License 1.1 (BUSL-1.1).
-// See the LICENSE file in the project root for license details,
-// including the Additional Use Grant, Change Date, and Change License.
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
 
 use crate::models::{
     AnalyzeRequest, AnalyzeResponse, AnonymizeRequest, AnonymizeResponse, EntityResult,

--- a/crates/redact-api/src/lib.rs
+++ b/crates/redact-api/src/lib.rs
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Censgate LLC.
-// Licensed under the Business Source License 1.1 (BUSL-1.1).
-// See the LICENSE file in the project root for license details,
-// including the Additional Use Grant, Change Date, and Change License.
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
 
 pub mod handlers;
 pub mod models;

--- a/crates/redact-api/src/main.rs
+++ b/crates/redact-api/src/main.rs
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Censgate LLC.
-// Licensed under the Business Source License 1.1 (BUSL-1.1).
-// See the LICENSE file in the project root for license details,
-// including the Additional Use Grant, Change Date, and Change License.
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
 
 use redact_api::server::{ApiServer, ServerConfig};
 use redact_core::{

--- a/crates/redact-api/src/models.rs
+++ b/crates/redact-api/src/models.rs
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Censgate LLC.
-// Licensed under the Business Source License 1.1 (BUSL-1.1).
-// See the LICENSE file in the project root for license details,
-// including the Additional Use Grant, Change Date, and Change License.
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
 
 use redact_core::AnonymizationStrategy;
 use serde::{Deserialize, Serialize};

--- a/crates/redact-api/src/routes.rs
+++ b/crates/redact-api/src/routes.rs
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Censgate LLC.
-// Licensed under the Business Source License 1.1 (BUSL-1.1).
-// See the LICENSE file in the project root for license details,
-// including the Additional Use Grant, Change Date, and Change License.
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
 
 use crate::handlers::{analyze, anonymize, health, AppState};
 use axum::{

--- a/crates/redact-api/src/server.rs
+++ b/crates/redact-api/src/server.rs
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Censgate LLC.
-// Licensed under the Business Source License 1.1 (BUSL-1.1).
-// See the LICENSE file in the project root for license details,
-// including the Additional Use Grant, Change Date, and Change License.
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
 
 use crate::handlers::AppState;
 use crate::routes::create_router;

--- a/crates/redact-cli/src/main.rs
+++ b/crates/redact-cli/src/main.rs
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Censgate LLC.
-// Licensed under the Business Source License 1.1 (BUSL-1.1).
-// See the LICENSE file in the project root for license details,
-// including the Additional Use Grant, Change Date, and Change License.
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
 
 //! CLI tool for PII detection and anonymization
 //! Replacement for redactctl

--- a/crates/redact-core/src/anonymizers/encrypt.rs
+++ b/crates/redact-core/src/anonymizers/encrypt.rs
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Censgate LLC.
-// Licensed under the Business Source License 1.1 (BUSL-1.1).
-// See the LICENSE file in the project root for license details,
-// including the Additional Use Grant, Change Date, and Change License.
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
 
 use super::{apply_anonymization, Anonymizer, AnonymizerConfig};
 use crate::types::{AnonymizedResult, RecognizerResult, Token};

--- a/crates/redact-core/src/anonymizers/hash.rs
+++ b/crates/redact-core/src/anonymizers/hash.rs
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Censgate LLC.
-// Licensed under the Business Source License 1.1 (BUSL-1.1).
-// See the LICENSE file in the project root for license details,
-// including the Additional Use Grant, Change Date, and Change License.
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
 
 use super::{apply_anonymization, Anonymizer, AnonymizerConfig};
 use crate::types::{AnonymizedResult, RecognizerResult};

--- a/crates/redact-core/src/anonymizers/mask.rs
+++ b/crates/redact-core/src/anonymizers/mask.rs
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Censgate LLC.
-// Licensed under the Business Source License 1.1 (BUSL-1.1).
-// See the LICENSE file in the project root for license details,
-// including the Additional Use Grant, Change Date, and Change License.
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
 
 use super::{apply_anonymization, Anonymizer, AnonymizerConfig};
 use crate::types::{AnonymizedResult, RecognizerResult};

--- a/crates/redact-core/src/anonymizers/mod.rs
+++ b/crates/redact-core/src/anonymizers/mod.rs
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Censgate LLC.
-// Licensed under the Business Source License 1.1 (BUSL-1.1).
-// See the LICENSE file in the project root for license details,
-// including the Additional Use Grant, Change Date, and Change License.
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
 
 pub mod encrypt;
 pub mod hash;

--- a/crates/redact-core/src/anonymizers/registry.rs
+++ b/crates/redact-core/src/anonymizers/registry.rs
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Censgate LLC.
-// Licensed under the Business Source License 1.1 (BUSL-1.1).
-// See the LICENSE file in the project root for license details,
-// including the Additional Use Grant, Change Date, and Change License.
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
 
 use super::{
     encrypt::EncryptAnonymizer, hash::HashAnonymizer, mask::MaskAnonymizer,

--- a/crates/redact-core/src/anonymizers/replace.rs
+++ b/crates/redact-core/src/anonymizers/replace.rs
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Censgate LLC.
-// Licensed under the Business Source License 1.1 (BUSL-1.1).
-// See the LICENSE file in the project root for license details,
-// including the Additional Use Grant, Change Date, and Change License.
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
 
 use super::{apply_anonymization, Anonymizer, AnonymizerConfig};
 use crate::types::{AnonymizedResult, RecognizerResult};

--- a/crates/redact-core/src/engine/mod.rs
+++ b/crates/redact-core/src/engine/mod.rs
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Censgate LLC.
-// Licensed under the Business Source License 1.1 (BUSL-1.1).
-// See the LICENSE file in the project root for license details,
-// including the Additional Use Grant, Change Date, and Change License.
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
 
 use crate::anonymizers::{AnonymizerConfig, AnonymizerRegistry};
 use crate::recognizers::{pattern::PatternRecognizer, RecognizerRegistry};

--- a/crates/redact-core/src/lib.rs
+++ b/crates/redact-core/src/lib.rs
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Censgate LLC.
-// Licensed under the Business Source License 1.1 (BUSL-1.1).
-// See the LICENSE file in the project root for license details,
-// including the Additional Use Grant, Change Date, and Change License.
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
 
 //! Redact Core - PII Detection and Anonymization Engine
 //!

--- a/crates/redact-core/src/policy/mod.rs
+++ b/crates/redact-core/src/policy/mod.rs
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Censgate LLC.
-// Licensed under the Business Source License 1.1 (BUSL-1.1).
-// See the LICENSE file in the project root for license details,
-// including the Additional Use Grant, Change Date, and Change License.
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
 
 use crate::types::{EntityType, RecognizerResult};
 use serde::{Deserialize, Serialize};

--- a/crates/redact-core/src/recognizers/mod.rs
+++ b/crates/redact-core/src/recognizers/mod.rs
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Censgate LLC.
-// Licensed under the Business Source License 1.1 (BUSL-1.1).
-// See the LICENSE file in the project root for license details,
-// including the Additional Use Grant, Change Date, and Change License.
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
 
 pub mod pattern;
 pub mod registry;

--- a/crates/redact-core/src/recognizers/pattern.rs
+++ b/crates/redact-core/src/recognizers/pattern.rs
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Censgate LLC.
-// Licensed under the Business Source License 1.1 (BUSL-1.1).
-// See the LICENSE file in the project root for license details,
-// including the Additional Use Grant, Change Date, and Change License.
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
 
 use super::{validation::validate_entity, Recognizer, RecognizerResult};
 use crate::types::EntityType;

--- a/crates/redact-core/src/recognizers/registry.rs
+++ b/crates/redact-core/src/recognizers/registry.rs
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Censgate LLC.
-// Licensed under the Business Source License 1.1 (BUSL-1.1).
-// See the LICENSE file in the project root for license details,
-// including the Additional Use Grant, Change Date, and Change License.
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
 
 use super::{Recognizer, RecognizerResult};
 use crate::types::EntityType;

--- a/crates/redact-core/src/recognizers/validation.rs
+++ b/crates/redact-core/src/recognizers/validation.rs
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Censgate LLC.
-// Licensed under the Business Source License 1.1 (BUSL-1.1).
-// See the LICENSE file in the project root for license details,
-// including the Additional Use Grant, Change Date, and Change License.
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
 
 //! Validation functions for PII patterns.
 //!

--- a/crates/redact-core/src/types/entity.rs
+++ b/crates/redact-core/src/types/entity.rs
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Censgate LLC.
-// Licensed under the Business Source License 1.1 (BUSL-1.1).
-// See the LICENSE file in the project root for license details,
-// including the Additional Use Grant, Change Date, and Change License.
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
 
 use serde::{Deserialize, Serialize};
 use std::fmt;

--- a/crates/redact-core/src/types/mod.rs
+++ b/crates/redact-core/src/types/mod.rs
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Censgate LLC.
-// Licensed under the Business Source License 1.1 (BUSL-1.1).
-// See the LICENSE file in the project root for license details,
-// including the Additional Use Grant, Change Date, and Change License.
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
 
 pub mod entity;
 pub mod result;

--- a/crates/redact-core/src/types/result.rs
+++ b/crates/redact-core/src/types/result.rs
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Censgate LLC.
-// Licensed under the Business Source License 1.1 (BUSL-1.1).
-// See the LICENSE file in the project root for license details,
-// including the Additional Use Grant, Change Date, and Change License.
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
 
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;

--- a/crates/redact-ner/src/lib.rs
+++ b/crates/redact-ner/src/lib.rs
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Censgate LLC.
-// Licensed under the Business Source License 1.1 (BUSL-1.1).
-// See the LICENSE file in the project root for license details,
-// including the Additional Use Grant, Change Date, and Change License.
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
 
 //! NER-based PII Recognition using ONNX Runtime
 //!

--- a/crates/redact-ner/src/recognizer.rs
+++ b/crates/redact-ner/src/recognizer.rs
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Censgate LLC.
-// Licensed under the Business Source License 1.1 (BUSL-1.1).
-// See the LICENSE file in the project root for license details,
-// including the Additional Use Grant, Change Date, and Change License.
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
 
 use anyhow::{anyhow, Result};
 use ort::session::builder::GraphOptimizationLevel;

--- a/crates/redact-ner/src/tokenizer_wrapper.rs
+++ b/crates/redact-ner/src/tokenizer_wrapper.rs
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Censgate LLC.
-// Licensed under the Business Source License 1.1 (BUSL-1.1).
-// See the LICENSE file in the project root for license details,
-// including the Additional Use Grant, Change Date, and Change License.
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
 
 /// Tokenizer wrapper for NER models
 ///

--- a/crates/redact-wasm/src/lib.rs
+++ b/crates/redact-wasm/src/lib.rs
@@ -1,7 +1,6 @@
-// Copyright (c) 2026 Censgate LLC.
-// Licensed under the Business Source License 1.1 (BUSL-1.1).
-// See the LICENSE file in the project root for license details,
-// including the Additional Use Grant, Change Date, and Change License.
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
 
 //! WASM bindings for Redact PII engine
 //! Placeholder - will provide browser/mobile bindings


### PR DESCRIPTION
## Summary

- Replace stale BUSL-1.1 per-file copyright headers with Apache-2.0 across all 25 Rust source files (fixes #50)
- Bump workspace version to `0.8.2`
- Add CHANGELOG entry for v0.8.2

The earlier Apache-2.0 adoption (PR #43) updated the root `LICENSE` file and `Cargo.toml` but left the per-file source headers pointing at BUSL-1.1, causing the conflict reported in #50.

## Test plan

- [ ] Verify no remaining `BUSL-1.1` references in `*.rs` files
- [ ] CI passes (build + tests)
- [ ] Merge triggers release pipeline to tag `v0.8.2` and publish artifacts

https://claude.ai/code/session_01JBSxBwpkvm8s4PAgCG5RAf