### PR TITLE
docs: crates.io metadata, benchmarks, and release docs

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Tag to create (e.g., v0.8.0)'
+        description: 'Tag to create (e.g., v0.8.2)'
         required: true
         type: string
 

--- a/.github/workflows/ner-base.yml
+++ b/.github/workflows/ner-base.yml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Base image version tag (e.g. v1, v2)'
+        description: 'Base image version tag (e.g. v2, v3) — immutable; bump when base contents change'
         required: true
-        default: 'v1'
+        default: 'v2'
       ner_model:
         description: 'HuggingFace NER model name'
         required: true

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to release (e.g., 0.6.0)'
+        description: 'Version to release (e.g., 0.8.3)'
         required: true
         type: string
       dry_run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,7 +271,7 @@ jobs:
           load: true
           tags: redact-full:smoke-test
           build-args: |
-            NER_BASE=ghcr.io/${{ github.repository }}-ner-base:v1
+            NER_BASE=ghcr.io/${{ github.repository }}-ner-base:v2
           cache-from: type=gha,scope=ner-full
           cache-to: type=gha,mode=max,scope=ner-full
 
@@ -335,7 +335,7 @@ jobs:
           push: true
           tags: ${{ steps.meta-full.outputs.tags }}
           build-args: |
-            NER_BASE=ghcr.io/${{ github.repository }}-ner-base:v1
+            NER_BASE=ghcr.io/${{ github.repository }}-ner-base:v2
           cache-from: type=gha,scope=ner-full
           cache-to: type=gha,mode=max,scope=ner-full
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to release (e.g., v0.8.1)'
+        description: 'Tag to release (e.g., v0.8.2)'
         required: true
         type: string
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ Benchmarked against Microsoft Presidio:
 
 The Rust version is a complete rewrite with a different API. Key differences:
 
-| Go (v0.4.x) | Rust (v0.5.0) |
+| Go (v0.4.x) | Rust (v0.8.2) |
 |-------------|---------------|
 | `redactctl` CLI | `redact` CLI |
 | Go library import | Rust crate dependency |
@@ -69,4 +69,4 @@ See [README.md](README.md) for usage examples.
 ## Previous Releases (Go Implementation)
 
 For historical reference, versions v0.1.0 through v0.4.1 were the Go implementation.
-Those versions are no longer maintained. Please upgrade to v0.5.0+.
+Those versions are no longer maintained. Please upgrade to v0.8.2 or later.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ authors = ["Censgate LLC <support@censgate.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/censgate/redact"
 homepage = "https://github.com/censgate/redact"
+readme = "README.md"
 keywords = ["pii", "redaction", "privacy", "gdpr", "hipaa"]
 categories = ["text-processing", "web-programming", "wasm"]
 

--- a/Dockerfile.ner
+++ b/Dockerfile.ner
@@ -20,14 +20,14 @@
 #   and layers it on top, keeping release builds fast (~5 min vs 40-100+ min).
 #
 # Local dev (without pre-built base):
-#   docker build -f Dockerfile.ner-base -t ghcr.io/censgate/redact-ner-base:v1 .
+#   docker build -f Dockerfile.ner-base -t ghcr.io/censgate/redact-ner-base:v2 .
 #   docker build -f Dockerfile.ner -t ghcr.io/censgate/redact:full .
 
 # -----------------------------------------------------------------------------
 # NER base image: pre-built ONNX Runtime + NER model (built asynchronously)
 # Override with --build-arg for local dev or testing a new model.
 # -----------------------------------------------------------------------------
-ARG NER_BASE=ghcr.io/censgate/redact-ner-base:v1
+ARG NER_BASE=ghcr.io/censgate/redact-ner-base:v2
 
 FROM ${NER_BASE} AS ner-base
 

--- a/Dockerfile.ner-base
+++ b/Dockerfile.ner-base
@@ -8,7 +8,7 @@
 #   /app/model/config.json       - Label mappings for redact-ner
 #
 # Build:
-#   docker build -f Dockerfile.ner-base -t ghcr.io/censgate/redact-ner-base:v1 .
+#   docker build -f Dockerfile.ner-base -t ghcr.io/censgate/redact-ner-base:v2 .
 #
 # Rebuild only when:
 #   - ONNX Runtime version changes (ONNX_VERSION arg)

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ docker build -f Dockerfile.ner -t ghcr.io/censgate/redact:full .
 docker run -p 8080:8080 ghcr.io/censgate/redact:full
 ```
 
+The full image uses a pre-built [NER base layer](https://github.com/censgate/redact/pkgs/container/redact-ner-base) (`NER_BASE`, default `ghcr.io/censgate/redact-ner-base:v2`). Override with `--build-arg NER_BASE=...` only if you publish a different tag.
+
 The full image bakes in a pre-exported NER model (`dslim/bert-base-NER`) and sets `NER_MODEL_PATH=/app/model/model.onnx`, so NER is enabled at startup. To enable NER with the default image, mount a directory containing `model.onnx` and `tokenizer.json` and set:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-redact-core = "0.1"
-redact-ner = "0.1"  # Optional: for ML-based NER
+redact-core = "0.8.2"
+redact-ner = "0.8.2"  # Optional: for ML-based NER
 ```
 
 ### Basic Pattern Detection
@@ -423,22 +423,22 @@ All models must be trained on CoNLL-2003 or similar NER datasets with BIO taggin
 
 ## Performance
 
-### Benchmark Results (2026-01-31)
+### Benchmark Results (2026-04-18)
 
-Measured using [oha](https://github.com/hatoo/oha) with both services running in Docker containers.
+Measured using [oha](https://github.com/hatoo/oha) with both services running in Docker containers. See [docs/benchmarks/results-20260418-175909.md](docs/benchmarks/results-20260418-175909.md).
 
 | Metric | Redact (Rust) | Presidio (Python) | Speedup |
 |--------|---------------|-------------------|---------|
-| p50 Latency | 0.20 ms | 6.96 ms | **34x** |
-| p99 Latency | 0.96 ms | 22.50 ms | **23x** |
-| Throughput | 16,223 req/s | 171 req/s | **95x** |
+| p50 Latency | 0.196 ms | 6.25 ms | **32x** |
+| p99 Latency | 1.90 ms | 21.68 ms | **11x** |
+| Throughput | 19,416 req/s | 170 req/s | **114x** |
 
 Test payload: `Contact john.doe@example.com or call (555) 123-4567. SSN: 123-45-6789.`
 
 ### Run Benchmarks
 
 ```bash
-# REST API comparison vs Presidio (requires Docker + oha)
+# REST API comparison vs Presidio (requires Docker; oha on PATH or auto-downloaded)
 ./scripts/benchmark-comparison.sh
 
 # Criterion micro-benchmarks (Redact internals)
@@ -497,7 +497,7 @@ See [TEST_COVERAGE.md](/censgate/redact/blob/main/TEST_COVERAGE.md) for detailed
 
 ### Pre-1.0.0
 
-#### v0.6.0 (Current)
+#### v0.8.2 (Current)
 
 - [x] Complete Rust rewrite (replacing Go v0.1.0-v0.4.1)
 - [x] 36 pattern-based entity types with checksum validation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ We aim to respond within 48 hours and will work with you to understand and resol
 
 | Version | Supported | Notes |
 |---------|-----------|-------|
-| 0.5.x   | ✅ Yes | Current release (Rust rewrite) |
+| 0.8.x   | ✅ Yes | Current release (Rust rewrite) |
 | 0.1.x - 0.4.x | ❌ No | Legacy Go implementation (deprecated) |
 
 As new versions are released, this table will be updated. We generally support the current minor version and one prior.

--- a/crates/redact-api/Cargo.toml
+++ b/crates/redact-api/Cargo.toml
@@ -7,6 +7,8 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+readme.workspace = true
+documentation = "https://docs.rs/redact-api"
 description = "REST API service for PII detection and anonymization"
 
 [dependencies]

--- a/crates/redact-cli/Cargo.toml
+++ b/crates/redact-cli/Cargo.toml
@@ -7,6 +7,8 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+readme.workspace = true
+documentation = "https://docs.rs/redact-cli"
 description = "CLI tool for PII detection and anonymization"
 
 [dependencies]

--- a/crates/redact-core/Cargo.toml
+++ b/crates/redact-core/Cargo.toml
@@ -9,6 +9,8 @@ repository.workspace = true
 homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
+readme.workspace = true
+documentation = "https://docs.rs/redact-core"
 description = "Core PII detection and anonymization engine - Presidio replacement"
 
 [dependencies]

--- a/crates/redact-ner/Cargo.toml
+++ b/crates/redact-ner/Cargo.toml
@@ -9,6 +9,8 @@ repository.workspace = true
 homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
+readme.workspace = true
+documentation = "https://docs.rs/redact-ner"
 description = "Named Entity Recognition for PII detection using ONNX Runtime"
 
 [dependencies]

--- a/crates/redact-wasm/Cargo.toml
+++ b/crates/redact-wasm/Cargo.toml
@@ -7,6 +7,8 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+readme.workspace = true
+documentation = "https://docs.rs/redact-wasm"
 description = "WASM bindings for browser and mobile"
 
 [lib]

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -23,7 +23,7 @@ The **REST API benchmark is the fairest comparison** because:
 ## Quick Start
 
 ```bash
-# Install oha
+# Optional: install oha (the script can download a pinned v1.10.0 binary if your system oha mis-handles -c)
 cargo install oha
 
 # Run benchmark (requires Docker for Presidio)
@@ -35,9 +35,8 @@ cargo install oha
 
 ## Requirements
 
-- [oha](https://github.com/hatoo/oha) (`cargo install oha`)
+- [oha](https://github.com/hatoo/oha) on `PATH`, or set `OHA_BIN` to a compatible binary; `curl` is used to auto-download a pinned release if needed
 - Docker (for Presidio container)
-- Rust toolchain
 - `jq`
 
 ## Output
@@ -45,7 +44,7 @@ cargo install oha
 The benchmark produces:
 
 1. **Console output** - oha's histogram and statistics for each service
-2. **JSON files** - Raw data (`redact-*.json`, `presidio-*.json`)
+2. **Raw text** - oha output (`redact-*.txt`, `presidio-*.txt`)
 3. **Markdown report** - Summary comparison (`results-*.md`)
 
 ## Criterion Micro-Benchmarks
@@ -63,22 +62,24 @@ Benchmarks include:
 - Anonymization strategies (replace, mask, hash)
 - Cold vs warm start performance
 
-## Latest Results (2026-01-31)
+## Latest Results (2026-04-18)
+
+The **current** release is **[v0.8.2](https://github.com/censgate/redact/releases/tag/v0.8.2)**. Full report: [results-20260418-175909.md](results-20260418-175909.md).
 
 ### Latency (concurrency=1)
 
 | Metric | Redact (Rust) | Presidio (Python) | Speedup |
 |--------|---------------|-------------------|---------|
-| p50 Latency | 0.20 ms | 6.96 ms | **34x** |
-| p99 Latency | 0.96 ms | 22.50 ms | **23x** |
-| Avg Latency | 0.24 ms | 7.78 ms | **32x** |
+| p50 Latency | 0.196 ms | 6.25 ms | **32x** |
+| p99 Latency | 1.90 ms | 21.68 ms | **11x** |
+| Avg Latency | 0.25 ms | 7.19 ms | — |
 
 ### Throughput (concurrency=10)
 
 | Metric | Redact (Rust) | Presidio (Python) | Speedup |
 |--------|---------------|-------------------|---------|
-| Requests/sec | 16,223 | 171 | **95x** |
+| Requests/sec | 19,416 | 170 | **114x** |
 
-**Environment:** Darwin arm64, Docker containers (distroless for Redact)
+**Environment:** Darwin arm64, Docker containers (builder: `rust:1.93-slim`; Redact runtime uses distroless). Benchmark tool: oha v1.10.0
 
 Results vary by hardware. Run `./scripts/benchmark-comparison.sh` to benchmark on your system.

--- a/docs/benchmarks/presidio-latency-20260418-175909.txt
+++ b/docs/benchmarks/presidio-latency-20260418-175909.txt
@@ -1,0 +1,43 @@
+Summary:
+  Success rate:	100.00%
+  Total:	3595.6938 ms
+  Slowest:	173.3127 ms
+  Fastest:	5.2419 ms
+  Average:	7.1884 ms
+  Requests/sec:	139.0552
+
+  Total data:	187.99 KiB
+  Size/request:	385 B
+  Size/sec:	52.28 KiB
+
+Response time histogram:
+    5.242 ms [1]   |
+   22.049 ms [495] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
+   38.856 ms [2]   |
+   55.663 ms [0]   |
+   72.470 ms [0]   |
+   89.277 ms [0]   |
+  106.084 ms [1]   |
+  122.891 ms [0]   |
+  139.699 ms [0]   |
+  156.506 ms [0]   |
+  173.313 ms [1]   |
+
+Response time distribution:
+  10.00% in 5.6685 ms
+  25.00% in 5.8609 ms
+  50.00% in 6.2451 ms
+  75.00% in 6.6664 ms
+  90.00% in 7.6241 ms
+  95.00% in 9.5705 ms
+  99.00% in 21.6837 ms
+  99.90% in 173.3127 ms
+  99.99% in 173.3127 ms
+
+
+Details (average, fastest, slowest):
+  DNS+dialup:	0.2327 ms, 0.0937 ms, 5.0863 ms
+  DNS-lookup:	0.0104 ms, 0.0027 ms, 0.2781 ms
+
+Status code distribution:
+  [200] 500 responses

--- a/docs/benchmarks/presidio-throughput-20260418-175909.txt
+++ b/docs/benchmarks/presidio-throughput-20260418-175909.txt
@@ -1,0 +1,43 @@
+Summary:
+  Success rate:	100.00%
+  Total:	14683.3408 ms
+  Slowest:	158.7141 ms
+  Fastest:	6.8539 ms
+  Average:	58.6227 ms
+  Requests/sec:	170.2610
+
+  Total data:	939.94 KiB
+  Size/request:	385 B
+  Size/sec:	64.01 KiB
+
+Response time histogram:
+    6.854 ms [1]    |
+   22.040 ms [1]    |
+   37.226 ms [3]    |
+   52.412 ms [354]  |■■■■■
+   67.598 ms [1930] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
+   82.784 ms [122]  |■■
+   97.970 ms [22]   |
+  113.156 ms [17]   |
+  128.342 ms [23]   |
+  143.528 ms [9]    |
+  158.714 ms [18]   |
+
+Response time distribution:
+  10.00% in 51.9665 ms
+  25.00% in 53.5013 ms
+  50.00% in 55.4845 ms
+  75.00% in 58.4181 ms
+  90.00% in 65.0207 ms
+  95.00% in 74.6167 ms
+  99.00% in 129.5542 ms
+  99.90% in 156.2718 ms
+  99.99% in 158.7141 ms
+
+
+Details (average, fastest, slowest):
+  DNS+dialup:	0.2190 ms, 0.0903 ms, 5.0328 ms
+  DNS-lookup:	0.0124 ms, 0.0033 ms, 1.9923 ms
+
+Status code distribution:
+  [200] 2500 responses

--- a/docs/benchmarks/redact-latency-20260418-175909.txt
+++ b/docs/benchmarks/redact-latency-20260418-175909.txt
@@ -1,0 +1,43 @@
+Summary:
+  Success rate:	100.00%
+  Total:	127.5663 ms
+  Slowest:	6.6234 ms
+  Fastest:	0.1035 ms
+  Average:	0.2534 ms
+  Requests/sec:	3919.5294
+
+  Total data:	223.63 KiB
+  Size/request:	458 B
+  Size/sec:	1.71 MiB
+
+Response time histogram:
+  0.103 ms [1]   |
+  0.755 ms [488] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
+  1.407 ms [6]   |
+  2.059 ms [3]   |
+  2.711 ms [1]   |
+  3.363 ms [0]   |
+  4.015 ms [0]   |
+  4.667 ms [0]   |
+  5.319 ms [0]   |
+  5.971 ms [0]   |
+  6.623 ms [1]   |
+
+Response time distribution:
+  10.00% in 0.1439 ms
+  25.00% in 0.1648 ms
+  50.00% in 0.1960 ms
+  75.00% in 0.2420 ms
+  90.00% in 0.3212 ms
+  95.00% in 0.5345 ms
+  99.00% in 1.8951 ms
+  99.90% in 6.6234 ms
+  99.99% in 6.6234 ms
+
+
+Details (average, fastest, slowest):
+  DNS+dialup:	0.2783 ms, 0.2783 ms, 0.2783 ms
+  DNS-lookup:	0.0214 ms, 0.0214 ms, 0.0214 ms
+
+Status code distribution:
+  [200] 500 responses

--- a/docs/benchmarks/redact-throughput-20260418-175909.txt
+++ b/docs/benchmarks/redact-throughput-20260418-175909.txt
@@ -1,0 +1,43 @@
+Summary:
+  Success rate:	100.00%
+  Total:	128.7630 ms
+  Slowest:	12.0925 ms
+  Fastest:	0.1105 ms
+  Average:	0.5104 ms
+  Requests/sec:	19415.5091
+
+  Total data:	1.09 MiB
+  Size/request:	458 B
+  Size/sec:	8.48 MiB
+
+Response time histogram:
+   0.111 ms [1]    |
+   1.309 ms [2440] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
+   2.507 ms [37]   |
+   3.705 ms [11]   |
+   4.903 ms [0]    |
+   6.102 ms [1]    |
+   7.300 ms [0]    |
+   8.498 ms [0]    |
+   9.696 ms [9]    |
+  10.894 ms [0]    |
+  12.093 ms [1]    |
+
+Response time distribution:
+  10.00% in 0.2057 ms
+  25.00% in 0.2685 ms
+  50.00% in 0.3956 ms
+  75.00% in 0.5885 ms
+  90.00% in 0.8101 ms
+  95.00% in 1.0009 ms
+  99.00% in 2.3875 ms
+  99.90% in 9.3273 ms
+  99.99% in 12.0925 ms
+
+
+Details (average, fastest, slowest):
+  DNS+dialup:	0.3721 ms, 0.3194 ms, 0.4129 ms
+  DNS-lookup:	0.0352 ms, 0.0185 ms, 0.0679 ms
+
+Status code distribution:
+  [200] 2500 responses

--- a/docs/benchmarks/results-20260418-175909.md
+++ b/docs/benchmarks/results-20260418-175909.md
@@ -1,0 +1,41 @@
+# Benchmark Results
+
+**Date:** 2026-04-18  
+**Tool:** [oha](https://github.com/hatoo/oha)  
+**Requests:** 500 | **Concurrency:** 1  
+**Platform:** Darwin arm64  
+**Environment:** Both services running in Docker containers
+
+## Summary
+
+| Metric | Redact (Rust) | Presidio (Python) | Speedup |
+|--------|---------------|-------------------|---------|
+| p50 Latency | 0.1960 ms | 6.2451 ms | **31.8x** |
+| p99 Latency | 1.8951 ms | 21.6837 ms | **11.4x** |
+| Avg Latency | 0.2534 ms | 7.1884 ms | - |
+| Requests/sec | 19415.5091 | 170.2610 | **114.0x** |
+
+## Test Payload
+
+```
+Contact john.doe@example.com or call (555) 123-4567. SSN: 123-45-6789.
+```
+
+Entities detected: EMAIL_ADDRESS, PHONE_NUMBER, US_SSN
+
+## Environment Details
+
+- **Redact:** Docker container (rust:1.93-slim base)
+- **Presidio:** Docker container (mcr.microsoft.com/presidio-analyzer:latest)
+- **Benchmark tool:** oha v1.10.0
+
+## Raw Data
+
+- Latency test: [redact-latency-20260418-175909.txt](redact-latency-20260418-175909.txt), [presidio-latency-20260418-175909.txt](presidio-latency-20260418-175909.txt)
+- Throughput test: [redact-throughput-20260418-175909.txt](redact-throughput-20260418-175909.txt), [presidio-throughput-20260418-175909.txt](presidio-throughput-20260418-175909.txt)
+
+## Reproduce
+
+```bash
+./scripts/benchmark-comparison.sh --requests 500 --concurrency 1
+```

--- a/scripts/benchmark-comparison.sh
+++ b/scripts/benchmark-comparison.sh
@@ -7,7 +7,8 @@
 #
 # Requirements:
 #   - Docker
-#   - oha (cargo install oha)
+#   - oha (https://github.com/hatoo/oha), or set OHA_BIN to a compatible binary.
+#     Some Homebrew builds mis-map -c; this script falls back to pinned v1.10.0.
 #   - jq
 #
 # Usage:
@@ -56,9 +57,43 @@ cleanup() {
 trap cleanup EXIT
 
 # Check dependencies
-command -v oha >/dev/null || err "oha not found. Install: cargo install oha"
 command -v docker >/dev/null || err "docker not found"
 command -v jq >/dev/null || err "jq not found"
+command -v curl >/dev/null || err "curl not found (needed for oha fallback)"
+
+# Resolve oha: optional OHA_BIN, else PATH; if -c is broken, use pinned release binary.
+resolve_oha() {
+    if [[ -n "${OHA_BIN:-}" ]]; then
+        [[ -x "$OHA_BIN" ]] || err "OHA_BIN is not executable: $OHA_BIN"
+        OHABIN=$OHA_BIN
+        return
+    fi
+    command -v oha >/dev/null || err "oha not found. Install from https://github.com/hatoo/oha/releases or set OHA_BIN"
+    local probe
+    probe=$(oha -n 1 -c 1 http://127.0.0.1:1/ 2>&1) || true
+    if echo "$probe" | grep -q "invalid value.*no-color"; then
+        local cache="${HOME}/.cache/redact-benchmark"
+        local ver="1.10.0"
+        local asset
+        case "$(uname -s)/$(uname -m)" in
+            Darwin/arm64) asset="oha-macos-arm64" ;;
+            Darwin/x86_64) asset="oha-macos-amd64" ;;
+            Linux/x86_64) asset="oha-linux-amd64" ;;
+            Linux/aarch64) asset="oha-linux-arm64" ;;
+            *) err "Unsupported OS/arch for automatic oha download; set OHA_BIN" ;;
+        esac
+        mkdir -p "$cache"
+        if [[ ! -x "${cache}/oha-${ver}" ]]; then
+            info "Downloading oha ${ver} (${asset}) — system oha mis-handles -c..."
+            curl -fsSL "https://github.com/hatoo/oha/releases/download/v${ver}/${asset}" -o "${cache}/oha-${ver}"
+            chmod +x "${cache}/oha-${ver}"
+        fi
+        OHABIN="${cache}/oha-${ver}"
+    else
+        OHABIN=oha
+    fi
+}
+resolve_oha
 
 echo ""
 echo "========================================"
@@ -122,7 +157,7 @@ echo ""
 info "Latency Test (concurrency=1, requests=$REQUESTS)"
 echo ""
 echo "--- Redact ---"
-oha -n "$REQUESTS" -c 1 \
+"$OHABIN" -n "$REQUESTS" -c 1 \
     --method POST \
     -H "Content-Type: application/json" \
     -d "$PAYLOAD" \
@@ -131,7 +166,7 @@ oha -n "$REQUESTS" -c 1 \
 
 echo ""
 echo "--- Presidio ---"
-oha -n "$REQUESTS" -c 1 \
+"$OHABIN" -n "$REQUESTS" -c 1 \
     --method POST \
     -H "Content-Type: application/json" \
     -d "$PAYLOAD" \
@@ -144,7 +179,7 @@ echo ""
 info "Throughput Test (concurrency=10, requests=$THROUGHPUT_REQUESTS)"
 echo ""
 echo "--- Redact ---"
-oha -n "$THROUGHPUT_REQUESTS" -c 10 \
+"$OHABIN" -n "$THROUGHPUT_REQUESTS" -c 10 \
     --method POST \
     -H "Content-Type: application/json" \
     -d "$PAYLOAD" \
@@ -153,7 +188,7 @@ oha -n "$THROUGHPUT_REQUESTS" -c 10 \
 
 echo ""
 echo "--- Presidio ---"
-oha -n "$THROUGHPUT_REQUESTS" -c 10 \
+"$OHABIN" -n "$THROUGHPUT_REQUESTS" -c 10 \
     --method POST \
     -H "Content-Type: application/json" \
     -d "$PAYLOAD" \
@@ -222,7 +257,7 @@ Entities detected: EMAIL_ADDRESS, PHONE_NUMBER, US_SSN
 
 - **Redact:** Docker container (rust:1.93-slim base)
 - **Presidio:** Docker container (mcr.microsoft.com/presidio-analyzer:latest)
-- **Benchmark tool:** oha v$(oha --version 2>/dev/null | head -1 | awk '{print $2}' || echo "unknown")
+- **Benchmark tool:** oha v$("$OHABIN" --version 2>/dev/null | head -1 | awk '{print $2}' || echo "unknown")
 
 ## Raw Data
 


### PR DESCRIPTION
## Summary

- **Crates.io / docs.rs:** Add workspace `readme` and per-crate `documentation` URLs (root README) for publishable crates.
- **Security & changelog:** Supported line `0.8.x`; migration table references Rust v0.8.2; release workflow example inputs updated.
- **Benchmarks:** Regenerate REST vs Presidio comparison (oha v1.10.0, 2026-04-18). Update main README and `docs/benchmarks/` with new numbers and link to `results-20260418-175909.md`.
- **Scripts:** `benchmark-comparison.sh` resolves a Homebrew oha issue where `-c` is mis-mapped to `--no-color` by auto-downloading pinned oha v1.10.0 (or use `OHA_BIN`).

## Ops

- **NER base image:** Workflow [NER Base Image](https://github.com/censgate/redact/actions/runs/24615762907) was triggered to republish `ghcr.io/censgate/redact-ner-base:v1` with ONNX 1.24.4 (aligned with `ort` 2.0.0-rc.12). No pipeline pin change (still `:v1`).