### PR TITLE
fix(deps): resolve security audit (openssl + rustls-webpki)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1782,9 +1782,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1814,9 +1814,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -2491,9 +2491,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

CI on [PR #56](https://github.com/censgate/redact/pull/56) failed in the **Security Audit** job, not because of the `openssl` bump itself but because `cargo audit` reported [**RUSTSEC-2026-0104**](https://rustsec.org/advisories/RUSTSEC-2026-0104) (`rustls-webpki` 0.103.12 — reachable panic in CRL parsing).

## Changes

- `openssl` 0.10.76 → 0.10.78, `openssl-sys` 0.9.112 → 0.9.114 (same as Dependabot #56)
- `rustls-webpki` 0.103.12 → 0.103.13 (advisory fix)

Lockfile-only updates via `cargo update -p rustls-webpki -p openssl -p openssl-sys`.

## Verification

- `cargo audit` — no vulnerabilities (warnings only: paste unmaintained, rand unsound)
- `cargo fmt`, `cargo clippy -D warnings`, `cargo test --workspace --all-features` — pass locally

Closes/supersedes the lockfile gap left when merging #56 alone.