### PR TITLE
Security: bump rand to 0.9.3 to fix GHSA-cq8v-f236-94qc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+- Bump `rand` to 0.9.3 to fix GHSA-cq8v-f236-94qc (unsoundness UB when custom logger accesses ThreadRng during reseeding)
+  - Updated transitive dependencies in `quinn-proto` and `tokenizers` that also depended on `rand 0.9.2`
+
 ## [0.8.2] - 2026-04-17
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2079,7 +2079,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2128,9 +2128,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -2912,7 +2912,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rayon",
  "rayon-cond",
  "regex",


### PR DESCRIPTION
## Security Fix: GHSA-cq8v-f236-94qc

Fixes Dependabot alert #10

### Summary
Bumps `rand` from 0.9.2 to 0.9.3 to address an unsoundness vulnerability.

### Vulnerability Details
- **GHSA:** GHSA-cq8v-f236-94qc
- **Severity:** Low
- **Affected:** rand 0.9.0-0.9.2
- **Patched:** 0.9.3+

### Risk Assessment
- CVSS: Low (no CVE assigned)
- REACHABILITY: rand used only in encrypt.rs for salt/nonce generation
- This fixes transitive rand 0.9.2 while workspace rand 0.10.1 is already patched

### Changes
- Cargo.lock: rand 0.9.2 → 0.9.3
- Added to CHANGELOG.md