### PR TITLE
feat(api): optional omit of entity literal text in responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,21 @@ Response:
 }
 ```
 
+By default, `results[].text` includes the detected literal text. Set
+`"include_text": false` on analyze or anonymize requests to omit literal entity
+text while retaining `entity_type`, `start`, `end`, `score`, and
+`recognizer_name`:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/analyze \
+  -H "Content-Type: application/json" \
+  -d '{
+    "text": "Email john@example.com, SSN 123-45-6789",
+    "language": "en",
+    "include_text": false
+  }'
+```
+
 ### Anonymize Endpoint
 
 ```bash
@@ -300,7 +315,8 @@ curl -X POST http://localhost:8080/api/v1/anonymize \
       "mask_char": "*",
       "mask_start_chars": 2,
       "mask_end_chars": 4
-    }
+    },
+    "include_text": false
   }'
 ```
 

--- a/crates/redact-api/src/handlers.rs
+++ b/crates/redact-api/src/handlers.rs
@@ -13,6 +13,7 @@ use axum::{
     Json,
 };
 use redact_core::{AnalyzerEngine, AnonymizerConfig, EntityType};
+use serde::Deserialize;
 use std::sync::Arc;
 
 /// Application state
@@ -74,6 +75,21 @@ pub async fn analyze(
     State(state): State<AppState>,
     Json(request): Json<AnalyzeRequest>,
 ) -> Result<Json<AnalyzeResponse>, ApiError> {
+    analyze_request(state, request, true).await
+}
+
+pub(crate) async fn analyze_api(
+    State(state): State<AppState>,
+    Json(request): Json<AnalyzeApiRequest>,
+) -> Result<Json<AnalyzeResponse>, ApiError> {
+    analyze_request(state, request.request, request.include_text).await
+}
+
+async fn analyze_request(
+    state: AppState,
+    request: AnalyzeRequest,
+    include_text: bool,
+) -> Result<Json<AnalyzeResponse>, ApiError> {
     // Validate input
     if request.text.is_empty() {
         return Err(ApiError::bad_request("Text cannot be empty"));
@@ -111,7 +127,7 @@ pub async fn analyze(
                 true
             }
         })
-        .map(EntityResult::from)
+        .map(|entity| entity_result(entity, include_text))
         .collect();
 
     // Sort by start position
@@ -128,6 +144,21 @@ pub async fn analyze(
 pub async fn anonymize(
     State(state): State<AppState>,
     Json(request): Json<AnonymizeRequest>,
+) -> Result<Json<AnonymizeResponse>, ApiError> {
+    anonymize_request(state, request, true).await
+}
+
+pub(crate) async fn anonymize_api(
+    State(state): State<AppState>,
+    Json(request): Json<AnonymizeApiRequest>,
+) -> Result<Json<AnonymizeResponse>, ApiError> {
+    anonymize_request(state, request.request, request.include_text).await
+}
+
+async fn anonymize_request(
+    state: AppState,
+    request: AnonymizeRequest,
+    include_text: bool,
 ) -> Result<Json<AnonymizeResponse>, ApiError> {
     // Validate input
     if request.text.is_empty() {
@@ -202,7 +233,7 @@ pub async fn anonymize(
     // Convert results
     let results: Vec<EntityResult> = detected_entities
         .into_iter()
-        .map(EntityResult::from)
+        .map(|entity| entity_result(entity, include_text))
         .collect();
 
     let tokens: Option<Vec<TokenInfo>> = anonymized
@@ -215,6 +246,38 @@ pub async fn anonymize(
         tokens,
         metadata: metadata.into(),
     }))
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct AnalyzeApiRequest {
+    #[serde(flatten)]
+    request: AnalyzeRequest,
+
+    /// Include detected entity literal text in results
+    #[serde(default = "default_include_text")]
+    include_text: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct AnonymizeApiRequest {
+    #[serde(flatten)]
+    request: AnonymizeRequest,
+
+    /// Include detected entity literal text in results
+    #[serde(default = "default_include_text")]
+    include_text: bool,
+}
+
+fn default_include_text() -> bool {
+    true
+}
+
+fn entity_result(entity: redact_core::RecognizerResult, include_text: bool) -> EntityResult {
+    let mut result = EntityResult::from(entity);
+    if !include_text {
+        result.text = None;
+    }
+    result
 }
 
 #[cfg(test)]

--- a/crates/redact-api/src/routes.rs
+++ b/crates/redact-api/src/routes.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See the LICENSE file
 // in the project root for license information.
 
-use crate::handlers::{analyze, anonymize, health, AppState};
+use crate::handlers::{analyze_api, anonymize_api, health, AppState};
 use axum::{
     routing::{get, post},
     Router,
@@ -12,8 +12,8 @@ use axum::{
 pub fn create_router(state: AppState) -> Router {
     Router::new()
         .route("/health", get(health))
-        .route("/api/v1/analyze", post(analyze))
-        .route("/api/v1/anonymize", post(anonymize))
+        .route("/api/v1/analyze", post(analyze_api))
+        .route("/api/v1/anonymize", post(anonymize_api))
         .with_state(state)
 }
 
@@ -21,10 +21,11 @@ pub fn create_router(state: AppState) -> Router {
 mod tests {
     use super::*;
     use axum::{
-        body::Body,
+        body::{to_bytes, Body},
         http::{Request, StatusCode},
     };
     use redact_core::AnalyzerEngine;
+    use serde_json::Value;
     use std::sync::Arc;
     use tower::util::ServiceExt;
 
@@ -70,5 +71,107 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(json["results"][0]["text"], "john@example.com");
+    }
+
+    #[tokio::test]
+    async fn test_analyze_route_omits_entity_text_when_include_text_false() {
+        let state = AppState {
+            engine: Arc::new(AnalyzerEngine::new()),
+        };
+        let app = create_router(state);
+
+        let body = r#"{"text":"Email: john@example.com","language":"en","include_text":false}"#;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/analyze")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: Value = serde_json::from_slice(&body).unwrap();
+        let result = &json["results"][0];
+
+        assert_eq!(result["entity_type"], "EMAIL_ADDRESS");
+        assert!(result["start"].is_number());
+        assert!(result["end"].is_number());
+        assert!(result["score"].is_number());
+        assert!(result["recognizer_name"].is_string());
+        assert!(result.get("text").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_anonymize_route_omits_entity_text_when_include_text_false() {
+        let state = AppState {
+            engine: Arc::new(AnalyzerEngine::new()),
+        };
+        let app = create_router(state);
+
+        let body = r#"{"text":"Email: john@example.com","language":"en","include_text":false}"#;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/anonymize")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: Value = serde_json::from_slice(&body).unwrap();
+        let result = &json["results"][0];
+
+        assert!(json["text"].as_str().unwrap().contains("[EMAIL_ADDRESS]"));
+        assert_eq!(result["entity_type"], "EMAIL_ADDRESS");
+        assert!(result["start"].is_number());
+        assert!(result["end"].is_number());
+        assert!(result["score"].is_number());
+        assert!(result["recognizer_name"].is_string());
+        assert!(result.get("text").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_anonymize_route_includes_entity_text_when_include_text_omitted() {
+        let state = AppState {
+            engine: Arc::new(AnalyzerEngine::new()),
+        };
+        let app = create_router(state);
+
+        let body = r#"{"text":"Email: john@example.com","language":"en"}"#;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/anonymize")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: Value = serde_json::from_slice(&body).unwrap();
+
+        assert!(json["text"].as_str().unwrap().contains("[EMAIL_ADDRESS]"));
+        assert_eq!(json["results"][0]["text"], "john@example.com");
     }
 }


### PR DESCRIPTION
## Summary
Adds response option to omit redacted entity **text** (indices + category/code only) for platform privacy adapter / safe logging.

Consumers set request field to skip returning literal substrings in `entities` (e.g. platform composing user messages after redaction).

## Related
- censgate/platform privacy adapter uses `REDACT_API_URL`

Made with [Cursor](https://cursor.com)