### PR TITLE
feat(api): ENG-67 /healthz alias + redact-full run notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,7 +281,7 @@ jobs:
           docker run -d --name smoke-test -p 8080:8080 redact-full:smoke-test
           echo "Waiting for server to start..."
           for i in $(seq 1 30); do
-            if curl -sf http://localhost:8080/health > /dev/null 2>&1; then
+            if curl -sf http://localhost:8080/healthz > /dev/null 2>&1; then
               echo "Server ready after ${i}s"
               break
             fi
@@ -294,7 +294,7 @@ jobs:
           done
 
           echo "--- Health check ---"
-          HEALTH=$(curl -sf http://localhost:8080/health)
+          HEALTH=$(curl -sf http://localhost:8080/healthz)
           echo "$HEALTH" | python3 -m json.tool
           RECOGNIZERS=$(echo "$HEALTH" | python3 -c "import sys,json; print(json.load(sys.stdin).get('recognizers',0))")
           if [ "$RECOGNIZERS" -lt 2 ]; then

--- a/Dockerfile.ner
+++ b/Dockerfile.ner
@@ -5,6 +5,8 @@
 # Run:
 #   docker run -p 8080:8080 ghcr.io/censgate/redact:full
 #
+# Health (HTTP 200): GET /healthz or GET /health — base URL only for PLATFORM_REDACT_API_URL (see README).
+#
 # The image bakes in the NER model (~420MB) at /app/model/:
 #   - model.onnx       (ONNX model file)
 #   - tokenizer.json   (HuggingFace tokenizer)

--- a/README.md
+++ b/README.md
@@ -135,6 +135,18 @@ docker run -p 8080:8080 ghcr.io/censgate/redact:full
 
 The full image uses a pre-built [NER base layer](https://github.com/censgate/redact/pkgs/container/redact-ner-base) (`NER_BASE`, default `ghcr.io/censgate/redact-ner-base:v2`). Override with `--build-arg NER_BASE=...` only if you publish a different tag.
 
+**Platform URL (`PLATFORM_REDACT_API_URL`)** — set this to the HTTP **origin only** (scheme + host + port, **no path**). Clients append `/api/v1/analyze` and `/api/v1/anonymize`. Container listens on **`8080`** by default (`PORT`). Example local compose mapping host `8081` → container `8080`: `http://localhost:8081`.
+
+**Health** — use **`GET /healthz`** or **`GET /health`** (both **HTTP 200**, JSON body includes `"status":"healthy"`).
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `HOST` | `0.0.0.0` | Bind address |
+| `PORT` | `8080` | Listen port inside the container |
+| `NER_MODEL_PATH` | *(unset)* / `/app/model/model.onnx` in full image | ONNX model path; full image enables NER when set |
+| `ORT_DYLIB_PATH` | *(unset)* / `/app/lib/libonnxruntime.so` in full image | ONNX Runtime `.so` for dynamic loading (`ort`) |
+| `ENABLE_TRACING` | `true` | Tower HTTP trace middleware |
+
 The full image bakes in a pre-exported NER model (`dslim/bert-base-NER`) and sets `NER_MODEL_PATH=/app/model/model.onnx`, so NER is enabled at startup. To enable NER with the default image, mount a directory containing `model.onnx` and `tokenizer.json` and set:
 
 ```bash
@@ -245,6 +257,7 @@ fn main() -> anyhow::Result<()> {
 ```bash
 cargo run --release --bin redact-api
 # Server listening on http://0.0.0.0:8080
+# GET /healthz or /health — readiness probe (HTTP 200, JSON)
 ```
 
 ### Analyze Endpoint

--- a/artifacts/eng-67/STATUS.md
+++ b/artifacts/eng-67/STATUS.md
@@ -1,0 +1,21 @@
+# ENG-67 — redact-full container + `/healthz`
+
+Worktree-local evidence for Linear ENG-67 (platform redact HTTP boundary).
+
+## Acceptance
+
+| # | Criterion | Status |
+|---|-----------|--------|
+| 1 | `Dockerfile.ner` produces a runnable **redact-full** image with **`GET /healthz` → HTTP 200** | **PASS** — smoke used locally built `redact-full:eng-67-local` |
+| 2 | Run notes document required env vars, container port (`8080`), and **`PLATFORM_REDACT_API_URL`** usage | **PASS** — README “Full image” + REST quick note |
+| 3 | Smoke transcript: `docker run` + `curl /healthz` | **PASS** — `commands.log`, `healthz-curl.log` |
+
+## Alignment with seemath compose (profile `redact`)
+
+Reference commit `5ff9342` (`agent/eng-67-compose-redact-profile`): service **`redact-full`** maps **`8081:8080`**. Set **`PLATFORM_REDACT_API_URL=http://localhost:8081`** when exercising from the host (origin only — no path).
+
+## Evidence files
+
+- `commands.log` — Docker build + run/remove transcript tail
+- `healthz-curl.log` — verbose `curl` against `/healthz` (shows **HTTP/1.1 200**)
+- `diff.patch` — patch vs `main` at capture time

--- a/artifacts/eng-67/commands.log
+++ b/artifacts/eng-67/commands.log
@@ -1,0 +1,569 @@
+#0 building with "orbstack" instance using docker driver
+
+#1 [internal] load build definition from Dockerfile.ner
+#1 transferring dockerfile: 4.97kB done
+#1 DONE 0.1s
+
+#2 [internal] load metadata for docker.io/library/rust:1.93-slim
+#2 ...
+
+#3 [internal] load metadata for gcr.io/distroless/cc-debian12:latest
+#3 DONE 0.5s
+
+#4 [internal] load metadata for ghcr.io/censgate/redact-ner-base:v2
+#4 ...
+
+#5 [auth] censgate/redact-ner-base:pull token for ghcr.io
+#5 DONE 0.0s
+
+#4 [internal] load metadata for ghcr.io/censgate/redact-ner-base:v2
+#4 ...
+
+#2 [internal] load metadata for docker.io/library/rust:1.93-slim
+#2 DONE 9.6s
+
+#4 [internal] load metadata for ghcr.io/censgate/redact-ner-base:v2
+#4 DONE 11.0s
+
+#6 [internal] load .dockerignore
+#6 transferring context:
+#6 transferring context: 2B done
+#6 DONE 0.6s
+
+#7 [builder 1/7] FROM docker.io/library/rust:1.93-slim@sha256:c0a38f5662afdb298898da1d70b909af4bda4e0acff2dc52aea6360a9b9c6956
+#7 DONE 0.0s
+
+#8 [stage-2 1/5] FROM gcr.io/distroless/cc-debian12:latest@sha256:847433844c7e04bcf07a3a0f0f5a8de554c6df6fa9e3e3ab14d3f6b73d780235
+#8 DONE 0.0s
+
+#9 [stage-2 2/5] WORKDIR /app
+#9 CACHED
+
+#10 [ner-base 1/1] FROM ghcr.io/censgate/redact-ner-base:v2@sha256:30c6081fcef34c3964114feb9b858e044fa1eaeb4470ba18823f036c83f9deeb
+#10 resolve ghcr.io/censgate/redact-ner-base:v2@sha256:30c6081fcef34c3964114feb9b858e044fa1eaeb4470ba18823f036c83f9deeb
+#10 ...
+
+#11 [internal] load build context
+#11 transferring context: 393.27kB 0.0s done
+#11 DONE 0.4s
+
+#10 [ner-base 1/1] FROM ghcr.io/censgate/redact-ner-base:v2@sha256:30c6081fcef34c3964114feb9b858e044fa1eaeb4470ba18823f036c83f9deeb
+#10 resolve ghcr.io/censgate/redact-ner-base:v2@sha256:30c6081fcef34c3964114feb9b858e044fa1eaeb4470ba18823f036c83f9deeb 0.3s done
+#10 ...
+
+#12 [builder 2/7] RUN apt-get update && apt-get install -y     pkg-config     libssl-dev     g++     cmake     && rm -rf /var/lib/apt/lists/*
+#12 CACHED
+
+#13 [builder 3/7] RUN if [ "arm64" = "arm64" ] && [ "linux/arm64" != "linux/arm64" ]; then         apt-get update && apt-get install -y             gcc-aarch64-linux-gnu             g++-aarch64-linux-gnu             libc6-dev-arm64-cross         && rm -rf /var/lib/apt/lists/*         && rustup target add aarch64-unknown-linux-gnu;     elif [ "arm64" = "amd64" ] && [ "linux/arm64" != "linux/amd64" ]; then         apt-get update && apt-get install -y             gcc-x86-64-linux-gnu             g++-x86-64-linux-gnu             libc6-dev-amd64-cross         && rm -rf /var/lib/apt/lists/*         && rustup target add x86_64-unknown-linux-gnu;     fi
+#13 CACHED
+
+#14 [builder 4/7] WORKDIR /app
+#14 CACHED
+
+#10 [ner-base 1/1] FROM ghcr.io/censgate/redact-ner-base:v2@sha256:30c6081fcef34c3964114feb9b858e044fa1eaeb4470ba18823f036c83f9deeb
+#10 sha256:c2a03fd11ac27ddfe49392b9224ffc35055930839eba0bb448c61dc2ecbca258 677B / 677B done
+#10 sha256:30c6081fcef34c3964114feb9b858e044fa1eaeb4470ba18823f036c83f9deeb 1.61kB / 1.61kB done
+#10 sha256:43aed29bd3b882c4d9f5b402f593233804cefbf0943e1cde6cf5140d41e24c97 674B / 674B done
+#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 0B / 399.78MB 0.1s
+#10 sha256:94ba357deed8ba5e3c4129407b302000435222f523e24a645f9630796a245221 0B / 7.28MB 0.1s
+#10 sha256:94ba357deed8ba5e3c4129407b302000435222f523e24a645f9630796a245221 4.19MB / 7.28MB 0.5s
+#10 extracting sha256:94ba357deed8ba5e3c4129407b302000435222f523e24a645f9630796a245221
+#10 sha256:94ba357deed8ba5e3c4129407b302000435222f523e24a645f9630796a245221 7.28MB / 7.28MB 0.5s done
+#10 extracting sha256:94ba357deed8ba5e3c4129407b302000435222f523e24a645f9630796a245221 0.2s done
+#10 ...
+
+#15 [builder 5/7] COPY Cargo.toml Cargo.lock ./
+#15 DONE 0.9s
+
+#10 [ner-base 1/1] FROM ghcr.io/censgate/redact-ner-base:v2@sha256:30c6081fcef34c3964114feb9b858e044fa1eaeb4470ba18823f036c83f9deeb
+#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 33.55MB / 399.78MB 1.1s
+#10 ...
+
+#16 [builder 6/7] COPY crates ./crates
+#16 DONE 0.5s
+
+#10 [ner-base 1/1] FROM ghcr.io/censgate/redact-ner-base:v2@sha256:30c6081fcef34c3964114feb9b858e044fa1eaeb4470ba18823f036c83f9deeb
+#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 65.01MB / 399.78MB 1.6s
+#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 91.23MB / 399.78MB 2.0s
+#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 119.54MB / 399.78MB 2.6s
+#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 144.70MB / 399.78MB 3.1s
+#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 170.92MB / 399.78MB 3.6s
+#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 196.08MB / 399.78MB 4.0s
+#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 219.15MB / 399.78MB 4.4s
+#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 248.51MB / 399.78MB 5.0s
+#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 270.53MB / 399.78MB 5.4s
+#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 291.50MB / 399.78MB 5.8s
+#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 319.82MB / 399.78MB 6.4s
+#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 343.93MB / 399.78MB 7.0s
+#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 374.34MB / 399.78MB 7.6s
+#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 395.31MB / 399.78MB 8.0s
+#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 399.78MB / 399.78MB 9.2s done
+#10 extracting sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf
+#10 ...
+
+#17 [builder 7/7] RUN case "arm64" in         arm64)             if [ "linux/arm64" = "linux/arm64" ]; then                 RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api;             else                 RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc -C target-cpu=neoverse-n1"                 cargo build --release --package redact-api --target aarch64-unknown-linux-gnu                 && cp target/aarch64-unknown-linux-gnu/release/redact-api target/release/;             fi ;;         amd64)             if [ "linux/arm64" = "linux/amd64" ]; then                 RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api;             else                 RUSTFLAGS="-C linker=x86_64-linux-gnu-gcc -C target-cpu=x86-64-v3"                 cargo build --release --package redact-api --target x86_64-unknown-linux-gnu                 && cp target/x86_64-unknown-linux-gnu/release/redact-api target/release/;             fi ;;         *) cargo build --release --package redact-api ;;     esac
+#17 1.049     Updating crates.io index
+#17 7.720  Downloading crates ...
+#17 7.937   Downloaded castaway v0.2.4
+#17 7.942   Downloaded cfg-if v1.0.4
+#17 7.998   Downloaded arrayref v0.3.9
+#17 8.003   Downloaded atomic-waker v1.1.2
+#17 8.005   Downloaded block-buffer v0.12.0
+#17 8.009   Downloaded onig v6.5.1
+#17 8.024   Downloaded aead v0.5.2
+#17 8.025   Downloaded cpufeatures v0.2.17
+#17 8.028   Downloaded darling_macro v0.20.11
+#17 8.032   Downloaded opaque-debug v0.3.1
+#17 8.053   Downloaded pkg-config v0.3.32
+#17 8.056   Downloaded once_cell v1.21.4
+#17 8.058   Downloaded percent-encoding v2.3.2
+#17 8.059   Downloaded crypto-common v0.1.7
+#17 8.061   Downloaded crypto-common v0.2.1
+#17 8.063   Downloaded openssl-macros v0.1.1
+#17 8.065   Downloaded cpufeatures v0.3.0
+#17 8.066   Downloaded openssl-probe v0.2.1
+#17 8.068   Downloaded macro_rules_attribute-proc_macro v0.2.2
+#17 8.068   Downloaded foreign-types v0.3.2
+#17 8.069   Downloaded form_urlencoded v1.2.2
+#17 8.070   Downloaded inout v0.1.4
+#17 8.072   Downloaded sync_wrapper v1.0.2
+#17 8.073   Downloaded http-body v1.0.1
+#17 8.075   Downloaded futures-core v0.3.32
+#17 8.079   Downloaded futures-task v0.3.32
+#17 8.082   Downloaded fnv v1.0.7
+#17 8.084   Downloaded macro_rules_attribute v0.2.2
+#17 8.091   Downloaded tower-service v0.3.3
+#17 8.091   Downloaded tokio-macros v2.7.0
+#17 8.091   Downloaded strsim v0.11.1
+#17 8.093   Downloaded hmac-sha256 v1.1.14
+#17 8.100   Downloaded lazy_static v1.5.0
+#17 8.100   Downloaded itoa v1.0.18
+#17 8.105   Downloaded tracing-serde v0.2.0
+#17 8.106   Downloaded matchers v0.2.0
+#17 8.108   Downloaded ident_case v1.0.1
+#17 8.108   Downloaded httpdate v1.0.3
+#17 8.109   Downloaded scopeguard v1.2.0
+#17 8.110   Downloaded rayon-cond v0.4.0
+#17 8.116   Downloaded mime v0.3.17
+#17 8.121   Downloaded version_check v0.9.5
+#17 8.125   Downloaded universal-hash v0.5.1
+#17 8.127   Downloaded utf8-zero v0.8.1
+#17 8.130   Downloaded serde_urlencoded v0.7.1
+#17 8.139   Downloaded rawpointer v0.2.1
+#17 8.139   Downloaded autocfg v1.5.0
+#17 8.140   Downloaded monostate-impl v0.1.18
+#17 8.143   Downloaded arrayvec v0.7.6
+#17 8.145   Downloaded unit-prefix v0.5.2
+#17 8.147   Downloaded signal-hook-registry v1.4.8
+#17 8.147   Downloaded rand_core v0.9.5
+#17 8.148   Downloaded num-integer v0.1.46
+#17 8.154   Downloaded zeroize v1.8.2
+#17 8.160   Downloaded rand_chacha v0.9.0
+#17 8.160   Downloaded num-complex v0.4.6
+#17 8.160   Downloaded dary_heap v0.3.8
+#17 8.161   Downloaded cmov v0.5.3
+#17 8.167   Downloaded tracing-attributes v0.1.31
+#17 8.169   Downloaded ppv-lite86 v0.2.21
+#17 8.180   Downloaded parking_lot v0.12.5
+#17 8.187   Downloaded ureq-proto v0.6.0
+#17 8.195   Downloaded uuid v1.23.0
+#17 8.204   Downloaded serde_derive v1.0.228
+#17 8.220   Downloaded zerocopy-derive v0.8.48
+#17 8.248   Downloaded zmij v1.0.21
+#17 8.253   Downloaded tower-http v0.6.8
+#17 8.260   Downloaded serde_json v1.0.149
+#17 8.268   Downloaded webpki-root-certs v1.0.6
+#17 8.269   Downloaded tokenizers v0.22.2
+#17 8.280   Downloaded tracing-subscriber v0.3.23
+#17 8.286   Downloaded portable-atomic v1.13.1
+#17 8.294   Downloaded vcpkg v0.2.15
+#17 8.344   Downloaded matchit v0.8.4
+#17 8.348   Downloaded unicode-width v0.2.2
+#17 8.351   Downloaded zerocopy v0.8.48
+#17 8.375   Downloaded syn v2.0.117
+#17 8.390   Downloaded matrixmultiply v0.3.10
+#17 8.393   Downloaded minimal-lexical v0.2.1
+#17 8.398   Downloaded memchr v2.8.0
+#17 8.403   Downloaded regex-syntax v0.8.10
+#17 8.417   Downloaded mio v1.2.0
+#17 8.432   Downloaded aes v0.8.4
+#17 8.438   Downloaded hyper-util v0.1.20
+#17 8.446   Downloaded tracing v0.1.44
+#17 8.465   Downloaded itertools v0.14.0
+#17 8.471   Downloaded esaxx-rs v0.1.10
+#17 8.474   Downloaded lzma-rust2 v0.15.7
+#17 8.484   Downloaded chrono v0.4.44
+#17 8.492   Downloaded spm_precompiled v0.1.4
+#17 8.503   Downloaded ndarray v0.17.2
+#17 8.514   Downloaded blake3 v1.8.4
+#17 8.520   Downloaded regex-automata v0.4.14
+#17 8.535   Downloaded futures-util v0.3.32
+#17 8.548   Downloaded axum v0.8.8
+#17 8.556   Downloaded onig_sys v69.9.1
+#17 8.577   Downloaded aho-corasick v1.1.4
+#17 8.585   Downloaded aes-gcm v0.10.3
+#17 8.587   Downloaded hyper v1.9.0
+#17 8.591   Downloaded http v1.4.0
+#17 8.594   Downloaded der v0.8.0
+#17 8.600   Downloaded log v0.4.29
+#17 8.605   Downloaded compact_str v0.9.0
+#17 8.612   Downloaded cc v1.2.59
+#17 8.615   Downloaded bytes v1.11.1
+#17 8.622   Downloaded base64 v0.22.1
+#17 8.625   Downloaded indicatif v0.18.4
+#17 8.629   Downloaded tokio v1.51.0
+#17 8.657   Downloaded httparse v1.10.1
+#17 8.659   Downloaded openssl v0.10.79
+#17 8.667   Downloaded getrandom v0.3.4
+#17 8.672   Downloaded darling_core v0.20.11
+#17 8.676   Downloaded half v2.7.1
+#17 8.676   Downloaded console v0.16.3
+#17 8.678   Downloaded getrandom v0.4.2
+#17 8.680   Downloaded derive_builder v0.20.2
+#17 8.684   Downloaded const-oid v0.10.2
+#17 8.684   Downloaded base64 v0.13.1
+#17 8.689   Downloaded libloading v0.9.0
+#17 8.693   Downloaded iana-time-zone v0.1.65
+#17 8.696   Downloaded hybrid-array v0.4.10
+#17 8.698   Downloaded getrandom v0.2.17
+#17 8.700   Downloaded rayon v1.11.0
+#17 8.716   Downloaded libc v0.2.184
+#17 8.750   Downloaded ureq v3.3.0
+#17 8.754   Downloaded regex v1.12.3
+#17 8.760   Downloaded hmac v0.13.0
+#17 8.760   Downloaded futures-channel v0.3.32
+#17 8.760   Downloaded ort v2.0.0-rc.12
+#17 8.764   Downloaded ctr v0.9.2
+#17 8.767   Downloaded crossbeam-epoch v0.9.18
+#17 8.767   Downloaded derive_builder_core v0.20.2
+#17 8.769   Downloaded darling v0.20.11
+#17 8.778   Downloaded crossbeam-utils v0.8.21
+#17 8.780   Downloaded bitflags v2.11.0
+#17 8.782   Downloaded ahash v0.8.12
+#17 8.785   Downloaded unicode-segmentation v1.13.2
+#17 8.790   Downloaded unicode-normalization-alignments v0.1.12
+#17 8.795   Downloaded typenum v1.19.0
+#17 8.795   Downloaded tower v0.5.3
+#17 8.804   Downloaded rand v0.10.1
+#17 8.809   Downloaded rand v0.9.3
+#17 8.815   Downloaded pbkdf2 v0.13.0-rc.10
+#17 8.815   Downloaded nom v7.1.3
+#17 ...
+
+#10 [ner-base 1/1] FROM ghcr.io/censgate/redact-ner-base:v2@sha256:30c6081fcef34c3964114feb9b858e044fa1eaeb4470ba18823f036c83f9deeb
+#10 extracting sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 5.2s
+#10 ...
+
+#17 [builder 7/7] RUN case "arm64" in         arm64)             if [ "linux/arm64" = "linux/arm64" ]; then                 RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api;             else                 RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc -C target-cpu=neoverse-n1"                 cargo build --release --package redact-api --target aarch64-unknown-linux-gnu                 && cp target/aarch64-unknown-linux-gnu/release/redact-api target/release/;             fi ;;         amd64)             if [ "linux/arm64" = "linux/amd64" ]; then                 RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api;             else                 RUSTFLAGS="-C linker=x86_64-linux-gnu-gcc -C target-cpu=x86-64-v3"                 cargo build --release --package redact-api --target x86_64-unknown-linux-gnu                 && cp target/x86_64-unknown-linux-gnu/release/redact-api target/release/;             fi ;;         *) cargo build --release --package redact-api ;;     esac
+#17 8.823   Downloaded anyhow v1.0.102
+#17 8.828   Downloaded unicode_categories v0.1.1
+#17 8.829   Downloaded rayon-core v1.13.0
+#17 8.833   Downloaded openssl-sys v0.9.115
+#17 8.838   Downloaded http-body-util v0.1.3
+#17 8.839   Downloaded find-msvc-tools v0.1.9
+#17 8.842   Downloaded chacha20 v0.10.0
+#17 8.842   Downloaded serde_core v1.0.228
+#17 8.843   Downloaded serde v1.0.228
+#17 8.846   Downloaded ryu v1.0.23
+#17 8.847   Downloaded sharded-slab v0.1.7
+#17 8.853   Downloaded rustls-pki-types v1.14.0
+#17 8.857   Downloaded proc-macro2 v1.0.106
+#17 8.860   Downloaded ort-sys v2.0.0-rc.12
+#17 8.866   Downloaded num-traits v0.2.19
+#17 8.871   Downloaded lock_api v0.4.14
+#17 8.875   Downloaded digest v0.11.2
+#17 8.875   Downloaded derive_builder_macro v0.20.2
+#17 8.877   Downloaded unicode-ident v1.0.24
+#17 8.883   Downloaded tracing-core v0.1.36
+#17 8.883   Downloaded socket2 v0.6.3
+#17 8.883   Downloaded smallvec v1.15.1
+#17 8.883   Downloaded either v1.15.0
+#17 8.887   Downloaded ctutils v0.4.2
+#17 8.892   Downloaded cipher v0.4.4
+#17 8.897   Downloaded native-tls v0.2.18
+#17 8.898   Downloaded crossbeam-deque v0.8.6
+#17 8.901   Downloaded constant_time_eq v0.4.2
+#17 8.901   Downloaded slab v0.4.12
+#17 8.905   Downloaded sha2 v0.11.0
+#17 8.910   Downloaded pem-rfc7468 v1.0.0
+#17 8.911   Downloaded parking_lot_core v0.9.12
+#17 8.913   Downloaded byteorder v1.5.0
+#17 8.917   Downloaded tracing-log v0.2.0
+#17 8.918   Downloaded thread_local v1.1.9
+#17 8.919   Downloaded thiserror-impl v2.0.18
+#17 8.922   Downloaded static_assertions v1.1.0
+#17 8.924   Downloaded serde_path_to_error v0.1.20
+#17 8.929   Downloaded rustversion v1.0.22
+#17 8.931   Downloaded rand_core v0.6.4
+#17 8.934   Downloaded polyval v0.6.2
+#17 8.934   Downloaded nu-ansi-term v0.50.3
+#17 8.936   Downloaded tower-layer v0.3.3
+#17 8.936   Downloaded thiserror v2.0.18
+#17 8.952   Downloaded shlex v1.3.0
+#17 8.952   Downloaded rand_core v0.10.0
+#17 8.956   Downloaded quote v1.0.45
+#17 8.963   Downloaded paste v1.0.15
+#17 8.963   Downloaded base64ct v1.8.3
+#17 8.963   Downloaded axum-core v0.5.6
+#17 8.973   Downloaded subtle v2.6.1
+#17 8.973   Downloaded socks v0.3.4
+#17 8.976   Downloaded pin-project-lite v0.2.17
+#17 8.984   Downloaded monostate v0.1.18
+#17 8.984   Downloaded ghash v0.5.1
+#17 8.984   Downloaded foreign-types-shared v0.1.1
+#17 8.984   Downloaded errno v0.3.14
+#17 8.984   Downloaded generic-array v0.14.7
+#17 9.163    Compiling libc v0.2.184
+#17 9.166    Compiling proc-macro2 v1.0.106
+#17 9.171    Compiling quote v1.0.45
+#17 9.171    Compiling unicode-ident v1.0.24
+#17 9.172    Compiling cfg-if v1.0.4
+#17 9.182    Compiling shlex v1.3.0
+#17 9.182    Compiling find-msvc-tools v0.1.9
+#17 9.182    Compiling typenum v1.19.0
+#17 9.182    Compiling version_check v0.9.5
+#17 9.182    Compiling serde_core v1.0.228
+#17 9.528    Compiling pkg-config v0.3.32
+#17 9.916    Compiling cc v1.2.59
+#17 9.926    Compiling itoa v1.0.18
+#17 10.35    Compiling once_cell v1.21.4
+#17 10.46    Compiling serde v1.0.228
+#17 10.53    Compiling generic-array v0.14.7
+#17 10.83    Compiling pin-project-lite v0.2.17
+#17 10.85    Compiling autocfg v1.5.0
+#17 10.99    Compiling vcpkg v0.2.15
+#17 10.99    Compiling memchr v2.8.0
+#17 11.03    Compiling smallvec v1.15.1
+#17 11.09    Compiling tracing-core v0.1.36
+#17 11.64    Compiling log v0.4.29
+#17 12.25    Compiling zerocopy v0.8.48
+#17 12.40    Compiling bytes v1.11.1
+#17 13.02    Compiling getrandom v0.2.17
+#17 13.06    Compiling num-traits v0.2.19
+#17 13.17    Compiling zeroize v1.8.2
+#17 13.24    Compiling httparse v1.10.1
+#17 13.34    Compiling syn v2.0.117
+#17 13.35    Compiling rand_core v0.6.4
+#17 13.39    Compiling openssl v0.10.79
+#17 13.40    Compiling foreign-types-shared v0.1.1
+#17 13.55    Compiling crypto-common v0.1.7
+#17 13.56    Compiling crossbeam-utils v0.8.21
+#17 13.60    Compiling foreign-types v0.3.2
+#17 13.65    Compiling hybrid-array v0.4.10
+#17 13.65    Compiling native-tls v0.2.18
+#17 13.76    Compiling ident_case v1.0.1
+#17 13.81    Compiling zmij v1.0.21
+#17 13.82    Compiling fnv v1.0.7
+#17 13.87    Compiling base64ct v1.8.3
+#17 13.89    Compiling parking_lot_core v0.9.12
+#17 13.94    Compiling futures-core v0.3.32
+#17 13.99    Compiling getrandom v0.3.4
+#17 14.09    Compiling bitflags v2.11.0
+#17 14.13    Compiling strsim v0.11.1
+#17 14.44    Compiling openssl-sys v0.9.115
+#17 14.56    Compiling pem-rfc7468 v1.0.0
+#17 14.61    Compiling http v1.4.0
+#17 14.98    Compiling rustls-pki-types v1.14.0
+#17 15.02    Compiling aho-corasick v1.1.4
+#17 15.07    Compiling scopeguard v1.2.0
+#17 15.08    Compiling openssl-probe v0.2.1
+#17 15.16    Compiling base64 v0.22.1
+#17 15.34    Compiling serde_json v1.0.149
+#17 15.42    Compiling byteorder v1.5.0
+#17 15.58    Compiling cmov v0.5.3
+#17 15.73    Compiling regex-syntax v0.8.10
+#17 15.82    Compiling ctutils v0.4.2
+#17 15.87    Compiling socks v0.3.4
+#17 15.90    Compiling webpki-root-certs v1.0.6
+#17 16.06    Compiling ureq-proto v0.6.0
+#17 16.20    Compiling crossbeam-epoch v0.9.18
+#17 16.32    Compiling lock_api v0.4.14
+#17 16.60    Compiling der v0.8.0
+#17 16.88    Compiling http-body v1.0.1
+#17 17.15    Compiling block-buffer v0.12.0
+#17 17.25    Compiling crypto-common v0.2.1
+#17 17.83    Compiling regex-automata v0.4.14
+#17 18.03    Compiling inout v0.1.4
+#17 18.16    Compiling cpufeatures v0.2.17
+#17 18.20    Compiling errno v0.3.14
+#17 18.24    Compiling utf8-zero v0.8.1
+#17 18.29    Compiling const-oid v0.10.2
+#17 18.48    Compiling percent-encoding v2.3.2
+#17 18.52    Compiling rand_core v0.10.0
+#17 18.53    Compiling getrandom v0.4.2
+#17 18.74    Compiling rayon-core v1.13.0
+#17 18.81    Compiling subtle v2.6.1
+#17 18.85    Compiling rustversion v1.0.22
+#17 18.91    Compiling signal-hook-registry v1.4.8
+#17 19.02    Compiling cipher v0.4.4
+#17 19.14    Compiling digest v0.11.2
+#17 19.44    Compiling universal-hash v0.5.1
+#17 19.61    Compiling darling_core v0.20.11
+#17 19.64    Compiling parking_lot v0.12.5
+#17 19.71    Compiling crossbeam-deque v0.8.6
+#17 20.04    Compiling onig_sys v69.9.1
+#17 20.10    Compiling socket2 v0.6.3
+#17 20.53    Compiling mio v1.2.0
+#17 20.79    Compiling matrixmultiply v0.3.10
+#17 20.89    Compiling lzma-rust2 v0.15.7
+#17 21.18    Compiling either v1.15.0
+#17 21.29    Compiling paste v1.0.15
+#17 21.29    Compiling opaque-debug v0.3.1
+#17 21.53    Compiling thiserror v2.0.18
+#17 21.75    Compiling hmac-sha256 v1.1.14
+#17 21.75    Compiling tower-service v0.3.3
+#17 21.87    Compiling ryu v1.0.23
+#17 21.95    Compiling portable-atomic v1.13.1
+#17 22.34    Compiling polyval v0.6.2
+#17 23.12    Compiling rand_core v0.9.5
+#17 23.34    Compiling esaxx-rs v0.1.10
+#17 23.41    Compiling blake3 v1.8.4
+#17 23.66    Compiling cpufeatures v0.3.0
+#17 23.77    Compiling ahash v0.8.12
+#17 23.77    Compiling tower-layer v0.3.3
+#17 24.02    Compiling anyhow v1.0.102
+#17 24.07    Compiling minimal-lexical v0.2.1
+#17 24.18    Compiling rawpointer v0.2.1
+#17 24.31    Compiling lazy_static v1.5.0
+#17 24.44    Compiling unicode-width v0.2.2
+#17 24.47    Compiling nom v7.1.3
+#17 24.85    Compiling regex v1.12.3
+#17 24.86    Compiling console v0.16.3
+#17 25.00    Compiling rayon v1.11.0
+#17 25.00    Compiling serde_derive v1.0.228
+#17 25.35    Compiling tracing-attributes v0.1.31
+#17 25.70    Compiling zerocopy-derive v0.8.48
+#17 26.34    Compiling openssl-macros v0.1.1
+#17 ...
+
+#10 [ner-base 1/1] FROM ghcr.io/censgate/redact-ner-base:v2@sha256:30c6081fcef34c3964114feb9b858e044fa1eaeb4470ba18823f036c83f9deeb
+#10 extracting sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 18.5s
+#10 ...
+
+#17 [builder 7/7] RUN case "arm64" in         arm64)             if [ "linux/arm64" = "linux/arm64" ]; then                 RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api;             else                 RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc -C target-cpu=neoverse-n1"                 cargo build --release --package redact-api --target aarch64-unknown-linux-gnu                 && cp target/aarch64-unknown-linux-gnu/release/redact-api target/release/;             fi ;;         amd64)             if [ "linux/arm64" = "linux/amd64" ]; then                 RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api;             else                 RUSTFLAGS="-C linker=x86_64-linux-gnu-gcc -C target-cpu=x86-64-v3"                 cargo build --release --package redact-api --target x86_64-unknown-linux-gnu                 && cp target/x86_64-unknown-linux-gnu/release/redact-api target/release/;             fi ;;         *) cargo build --release --package redact-api ;;     esac
+#17 27.16    Compiling darling_macro v0.20.11
+#17 27.31    Compiling tokio-macros v2.7.0
+#17 27.87    Compiling thiserror-impl v2.0.18
+#17 28.01    Compiling darling v0.20.11
+#17 28.13    Compiling derive_builder_core v0.20.2
+#17 29.07    Compiling tokio v1.51.0
+#17 29.70    Compiling tracing v0.1.44
+#17 29.87    Compiling monostate-impl v0.1.18
+#17 30.86    Compiling derive_builder_macro v0.20.2
+#17 30.94    Compiling castaway v0.2.4
+#17 31.77    Compiling sha2 v0.11.0
+#17 33.28    Compiling ureq v3.3.0
+#17 ...
+
+#10 [ner-base 1/1] FROM ghcr.io/censgate/redact-ner-base:v2@sha256:30c6081fcef34c3964114feb9b858e044fa1eaeb4470ba18823f036c83f9deeb
+#10 extracting sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 26.0s
+#10 ...
+
+#17 [builder 7/7] RUN case "arm64" in         arm64)             if [ "linux/arm64" = "linux/arm64" ]; then                 RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api;             else                 RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc -C target-cpu=neoverse-n1"                 cargo build --release --package redact-api --target aarch64-unknown-linux-gnu                 && cp target/aarch64-unknown-linux-gnu/release/redact-api target/release/;             fi ;;         amd64)             if [ "linux/arm64" = "linux/amd64" ]; then                 RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api;             else                 RUSTFLAGS="-C linker=x86_64-linux-gnu-gcc -C target-cpu=x86-64-v3"                 cargo build --release --package redact-api --target x86_64-unknown-linux-gnu                 && cp target/x86_64-unknown-linux-gnu/release/redact-api target/release/;             fi ;;         *) cargo build --release --package redact-api ;;     esac
+#17 34.29    Compiling ghash v0.5.1
+#17 34.79    Compiling itertools v0.14.0
+#17 34.95    Compiling hmac v0.13.0
+#17 34.99    Compiling aes v0.8.4
+#17 35.01    Compiling ctr v0.9.2
+#17 35.13    Compiling chacha20 v0.10.0
+#17 35.34    Compiling num-integer v0.1.46
+#17 35.57    Compiling num-complex v0.4.6
+#17 35.70    Compiling futures-channel v0.3.32
+#17 35.87    Compiling aead v0.5.2
+#17 36.04    Compiling constant_time_eq v0.4.2
+#17 36.05    Compiling arrayvec v0.7.6
+#17 36.09    Compiling iana-time-zone v0.1.65
+#17 36.44    Compiling macro_rules_attribute-proc_macro v0.2.2
+#17 36.56    Compiling sync_wrapper v1.0.2
+#17 36.59    Compiling static_assertions v1.1.0
+#17 36.69    Compiling unit-prefix v0.5.2
+#17 36.71    Compiling atomic-waker v1.1.2
+#17 36.79    Compiling base64 v0.13.1
+#17 36.81    Compiling arrayref v0.3.9
+#17 36.86    Compiling unicode-segmentation v1.13.2
+#17 36.89    Compiling slab v0.4.12
+#17 37.05    Compiling futures-task v0.3.32
+#17 37.22    Compiling httpdate v1.0.3
+#17 37.42    Compiling macro_rules_attribute v0.2.2
+#17 37.57    Compiling ort-sys v2.0.0-rc.12
+#17 37.57    Compiling spm_precompiled v0.1.4
+#17 37.68    Compiling form_urlencoded v1.2.2
+#17 37.69    Compiling futures-util v0.3.32
+#17 37.84    Compiling ppv-lite86 v0.2.21
+#17 37.98    Compiling half v2.7.1
+#17 38.29    Compiling rand_chacha v0.9.0
+#17 38.37    Compiling rayon-cond v0.4.0
+#17 38.44    Compiling indicatif v0.18.4
+#17 38.58    Compiling rand v0.9.3
+#17 38.81    Compiling compact_str v0.9.0
+#17 39.87    Compiling ndarray v0.17.2
+#17 40.01    Compiling chrono v0.4.44
+#17 40.30    Compiling aes-gcm v0.10.3
+#17 40.58    Compiling hyper v1.9.0
+#17 40.87    Compiling rand v0.10.1
+#17 40.95    Compiling pbkdf2 v0.13.0-rc.10
+#17 41.11    Compiling dary_heap v0.3.8
+#17 41.42    Compiling derive_builder v0.20.2
+#17 41.57    Compiling monostate v0.1.18
+#17 41.89    Compiling uuid v1.23.0
+#17 42.07    Compiling http-body-util v0.1.3
+#17 42.10    Compiling unicode-normalization-alignments v0.1.12
+#17 42.20    Compiling libloading v0.9.0
+#17 ...
+
+#10 [ner-base 1/1] FROM ghcr.io/censgate/redact-ner-base:v2@sha256:30c6081fcef34c3964114feb9b858e044fa1eaeb4470ba18823f036c83f9deeb
+#10 extracting sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 32.0s done
+#10 DONE 44.1s
+
+#17 [builder 7/7] RUN case "arm64" in         arm64)             if [ "linux/arm64" = "linux/arm64" ]; then                 RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api;             else                 RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc -C target-cpu=neoverse-n1"                 cargo build --release --package redact-api --target aarch64-unknown-linux-gnu                 && cp target/aarch64-unknown-linux-gnu/release/redact-api target/release/;             fi ;;         amd64)             if [ "linux/arm64" = "linux/amd64" ]; then                 RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api;             else                 RUSTFLAGS="-C linker=x86_64-linux-gnu-gcc -C target-cpu=x86-64-v3"                 cargo build --release --package redact-api --target x86_64-unknown-linux-gnu                 && cp target/x86_64-unknown-linux-gnu/release/redact-api target/release/;             fi ;;         *) cargo build --release --package redact-api ;;     esac
+#17 42.30    Compiling unicode_categories v0.1.1
+#17 42.51    Compiling mime v0.3.17
+#17 42.57    Compiling tower v0.5.3
+#17 42.66    Compiling hyper-util v0.1.20
+#17 43.26    Compiling axum-core v0.5.6
+#17 43.35    Compiling redact-core v0.8.3 (/app/crates/redact-core)
+#17 43.35    Compiling serde_urlencoded v0.7.1
+#17 43.65    Compiling tracing-serde v0.2.0
+#17 43.77    Compiling matchers v0.2.0
+#17 44.04    Compiling sharded-slab v0.1.7
+#17 44.10    Compiling serde_path_to_error v0.1.20
+#17 44.27    Compiling tracing-log v0.2.0
+#17 44.54    Compiling thread_local v1.1.9
+#17 44.64    Compiling matchit v0.8.4
+#17 44.81    Compiling nu-ansi-term v0.50.3
+#17 45.35    Compiling tower-http v0.6.8
+#17 45.55    Compiling tracing-subscriber v0.3.23
+#17 46.06    Compiling axum v0.8.8
+#17 47.78    Compiling onig v6.5.1
+#17 48.18    Compiling tokenizers v0.22.2
+#17 ...
+
+#18 [stage-2 3/5] COPY --from=ner-base /app/lib/libonnxruntime.so /app/lib/libonnxruntime.so
+#18 DONE 1.7s
+
+#17 [builder 7/7] RUN case "arm64" in         arm64)             if [ "linux/arm64" = "linux/arm64" ]; then                 RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api;             else                 RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc -C target-cpu=neoverse-n1"                 cargo build --release --package redact-api --target aarch64-unknown-linux-gnu                 && cp target/aarch64-unknown-linux-gnu/release/redact-api target/release/;             fi ;;         amd64)             if [ "linux/arm64" = "linux/amd64" ]; then                 RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api;             else                 RUSTFLAGS="-C linker=x86_64-linux-gnu-gcc -C target-cpu=x86-64-v3"                 cargo build --release --package redact-api --target x86_64-unknown-linux-gnu                 && cp target/x86_64-unknown-linux-gnu/release/redact-api target/release/;             fi ;;         *) cargo build --release --package redact-api ;;     esac
+#17 51.41    Compiling ort v2.0.0-rc.12
+#17 ...
+
+#19 [stage-2 4/5] COPY --from=ner-base /app/model/ /app/model/
+#19 DONE 1.5s
+
+#17 [builder 7/7] RUN case "arm64" in         arm64)             if [ "linux/arm64" = "linux/arm64" ]; then                 RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api;             else                 RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc -C target-cpu=neoverse-n1"                 cargo build --release --package redact-api --target aarch64-unknown-linux-gnu                 && cp target/aarch64-unknown-linux-gnu/release/redact-api target/release/;             fi ;;         amd64)             if [ "linux/arm64" = "linux/amd64" ]; then                 RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api;             else                 RUSTFLAGS="-C linker=x86_64-linux-gnu-gcc -C target-cpu=x86-64-v3"                 cargo build --release --package redact-api --target x86_64-unknown-linux-gnu                 && cp target/x86_64-unknown-linux-gnu/release/redact-api target/release/;             fi ;;         *) cargo build --release --package redact-api ;;     esac
+#17 54.87    Compiling redact-ner v0.8.3 (/app/crates/redact-ner)
+#17 55.74    Compiling redact-api v0.8.3 (/app/crates/redact-api)
+#17 100.2     Finished `release` profile [optimized] target(s) in 1m 39s
+#17 DONE 100.7s
+
+#20 [stage-2 5/5] COPY --from=builder /app/target/release/redact-api /usr/local/bin/redact-api
+#20 DONE 1.4s
+
+#21 exporting to image
+#21 exporting layers
+#21 exporting layers 2.0s done
+#21 writing image sha256:a5fe0292152cb6b9eede98d078b19c2de3dfd96e59a437bc6698250604641f54 0.0s done
+#21 naming to docker.io/library/redact-full:eng-67-local 0.1s done
+#21 DONE 2.3s
+
+=== smoke: docker run ===
+424aecbebd4254b0d0e62c2b7494fcd9cd19ce72ca309b9d88605e39495905a9
+eng67-redact-smoke

--- a/artifacts/eng-67/diff.patch
+++ b/artifacts/eng-67/diff.patch
@@ -1,0 +1,743 @@
+diff --git a/.github/workflows/release.yml b/.github/workflows/release.yml
+index 58b2f3b..cd7d5c7 100644
+--- a/.github/workflows/release.yml
++++ b/.github/workflows/release.yml
+@@ -281,7 +281,7 @@ jobs:
+           docker run -d --name smoke-test -p 8080:8080 redact-full:smoke-test
+           echo "Waiting for server to start..."
+           for i in $(seq 1 30); do
+-            if curl -sf http://localhost:8080/health > /dev/null 2>&1; then
++            if curl -sf http://localhost:8080/healthz > /dev/null 2>&1; then
+               echo "Server ready after ${i}s"
+               break
+             fi
+@@ -294,7 +294,7 @@ jobs:
+           done
+ 
+           echo "--- Health check ---"
+-          HEALTH=$(curl -sf http://localhost:8080/health)
++          HEALTH=$(curl -sf http://localhost:8080/healthz)
+           echo "$HEALTH" | python3 -m json.tool
+           RECOGNIZERS=$(echo "$HEALTH" | python3 -c "import sys,json; print(json.load(sys.stdin).get('recognizers',0))")
+           if [ "$RECOGNIZERS" -lt 2 ]; then
+diff --git a/Dockerfile.ner b/Dockerfile.ner
+index e0aa53d..e50155e 100644
+--- a/Dockerfile.ner
++++ b/Dockerfile.ner
+@@ -5,6 +5,8 @@
+ # Run:
+ #   docker run -p 8080:8080 ghcr.io/censgate/redact:full
+ #
++# Health (HTTP 200): GET /healthz or GET /health — base URL only for PLATFORM_REDACT_API_URL (see README).
++#
+ # The image bakes in the NER model (~420MB) at /app/model/:
+ #   - model.onnx       (ONNX model file)
+ #   - tokenizer.json   (HuggingFace tokenizer)
+diff --git a/README.md b/README.md
+index d5c94dd..94abd5a 100644
+--- a/README.md
++++ b/README.md
+@@ -135,6 +135,18 @@ docker run -p 8080:8080 ghcr.io/censgate/redact:full
+ 
+ The full image uses a pre-built [NER base layer](https://github.com/censgate/redact/pkgs/container/redact-ner-base) (`NER_BASE`, default `ghcr.io/censgate/redact-ner-base:v2`). Override with `--build-arg NER_BASE=...` only if you publish a different tag.
+ 
++**Platform URL (`PLATFORM_REDACT_API_URL`)** — set this to the HTTP **origin only** (scheme + host + port, **no path**). Clients append `/api/v1/analyze` and `/api/v1/anonymize`. Container listens on **`8080`** by default (`PORT`). Example local compose mapping host `8081` → container `8080`: `http://localhost:8081`.
++
++**Health** — use **`GET /healthz`** or **`GET /health`** (both **HTTP 200**, JSON body includes `"status":"healthy"`).
++
++| Variable | Default | Purpose |
++|----------|---------|---------|
++| `HOST` | `0.0.0.0` | Bind address |
++| `PORT` | `8080` | Listen port inside the container |
++| `NER_MODEL_PATH` | *(unset)* / `/app/model/model.onnx` in full image | ONNX model path; full image enables NER when set |
++| `ORT_DYLIB_PATH` | *(unset)* / `/app/lib/libonnxruntime.so` in full image | ONNX Runtime `.so` for dynamic loading (`ort`) |
++| `ENABLE_TRACING` | `true` | Tower HTTP trace middleware |
++
+ The full image bakes in a pre-exported NER model (`dslim/bert-base-NER`) and sets `NER_MODEL_PATH=/app/model/model.onnx`, so NER is enabled at startup. To enable NER with the default image, mount a directory containing `model.onnx` and `tokenizer.json` and set:
+ 
+ ```bash
+@@ -245,6 +257,7 @@ fn main() -> anyhow::Result<()> {
+ ```bash
+ cargo run --release --bin redact-api
+ # Server listening on http://0.0.0.0:8080
++# GET /healthz or /health — readiness probe (HTTP 200, JSON)
+ ```
+ 
+ ### Analyze Endpoint
+diff --git a/artifacts/eng-67/STATUS.md b/artifacts/eng-67/STATUS.md
+new file mode 100644
+index 0000000..d968420
+--- /dev/null
++++ b/artifacts/eng-67/STATUS.md
+@@ -0,0 +1,21 @@
++# ENG-67 — redact-full container + `/healthz`
++
++Worktree-local evidence for Linear ENG-67 (platform redact HTTP boundary).
++
++## Acceptance
++
++| # | Criterion | Status |
++|---|-----------|--------|
++| 1 | `Dockerfile.ner` produces a runnable **redact-full** image with **`GET /healthz` → HTTP 200** | **PASS** — smoke used locally built `redact-full:eng-67-local` |
++| 2 | Run notes document required env vars, container port (`8080`), and **`PLATFORM_REDACT_API_URL`** usage | **PASS** — README “Full image” + REST quick note |
++| 3 | Smoke transcript: `docker run` + `curl /healthz` | **PASS** — `commands.log`, `healthz-curl.log` |
++
++## Alignment with seemath compose (profile `redact`)
++
++Reference commit `5ff9342` (`agent/eng-67-compose-redact-profile`): service **`redact-full`** maps **`8081:8080`**. Set **`PLATFORM_REDACT_API_URL=http://localhost:8081`** when exercising from the host (origin only — no path).
++
++## Evidence files
++
++- `commands.log` — Docker build + run/remove transcript tail
++- `healthz-curl.log` — verbose `curl` against `/healthz` (shows **HTTP/1.1 200**)
++- `diff.patch` — patch vs `main` at capture time
+diff --git a/artifacts/eng-67/commands.log b/artifacts/eng-67/commands.log
+new file mode 100644
+index 0000000..785e6ae
+--- /dev/null
++++ b/artifacts/eng-67/commands.log
+@@ -0,0 +1,569 @@
++#0 building with "orbstack" instance using docker driver
++
++#1 [internal] load build definition from Dockerfile.ner
++#1 transferring dockerfile: 4.97kB done
++#1 DONE 0.1s
++
++#2 [internal] load metadata for docker.io/library/rust:1.93-slim
++#2 ...
++
++#3 [internal] load metadata for gcr.io/distroless/cc-debian12:latest
++#3 DONE 0.5s
++
++#4 [internal] load metadata for ghcr.io/censgate/redact-ner-base:v2
++#4 ...
++
++#5 [auth] censgate/redact-ner-base:pull token for ghcr.io
++#5 DONE 0.0s
++
++#4 [internal] load metadata for ghcr.io/censgate/redact-ner-base:v2
++#4 ...
++
++#2 [internal] load metadata for docker.io/library/rust:1.93-slim
++#2 DONE 9.6s
++
++#4 [internal] load metadata for ghcr.io/censgate/redact-ner-base:v2
++#4 DONE 11.0s
++
++#6 [internal] load .dockerignore
++#6 transferring context:
++#6 transferring context: 2B done
++#6 DONE 0.6s
++
++#7 [builder 1/7] FROM docker.io/library/rust:1.93-slim@sha256:c0a38f5662afdb298898da1d70b909af4bda4e0acff2dc52aea6360a9b9c6956
++#7 DONE 0.0s
++
++#8 [stage-2 1/5] FROM gcr.io/distroless/cc-debian12:latest@sha256:847433844c7e04bcf07a3a0f0f5a8de554c6df6fa9e3e3ab14d3f6b73d780235
++#8 DONE 0.0s
++
++#9 [stage-2 2/5] WORKDIR /app
++#9 CACHED
++
++#10 [ner-base 1/1] FROM ghcr.io/censgate/redact-ner-base:v2@sha256:30c6081fcef34c3964114feb9b858e044fa1eaeb4470ba18823f036c83f9deeb
++#10 resolve ghcr.io/censgate/redact-ner-base:v2@sha256:30c6081fcef34c3964114feb9b858e044fa1eaeb4470ba18823f036c83f9deeb
++#10 ...
++
++#11 [internal] load build context
++#11 transferring context: 393.27kB 0.0s done
++#11 DONE 0.4s
++
++#10 [ner-base 1/1] FROM ghcr.io/censgate/redact-ner-base:v2@sha256:30c6081fcef34c3964114feb9b858e044fa1eaeb4470ba18823f036c83f9deeb
++#10 resolve ghcr.io/censgate/redact-ner-base:v2@sha256:30c6081fcef34c3964114feb9b858e044fa1eaeb4470ba18823f036c83f9deeb 0.3s done
++#10 ...
++
++#12 [builder 2/7] RUN apt-get update && apt-get install -y     pkg-config     libssl-dev     g++     cmake     && rm -rf /var/lib/apt/lists/*
++#12 CACHED
++
++#13 [builder 3/7] RUN if [ "arm64" = "arm64" ] && [ "linux/arm64" != "linux/arm64" ]; then         apt-get update && apt-get install -y             gcc-aarch64-linux-gnu             g++-aarch64-linux-gnu             libc6-dev-arm64-cross         && rm -rf /var/lib/apt/lists/*         && rustup target add aarch64-unknown-linux-gnu;     elif [ "arm64" = "amd64" ] && [ "linux/arm64" != "linux/amd64" ]; then         apt-get update && apt-get install -y             gcc-x86-64-linux-gnu             g++-x86-64-linux-gnu             libc6-dev-amd64-cross         && rm -rf /var/lib/apt/lists/*         && rustup target add x86_64-unknown-linux-gnu;     fi
++#13 CACHED
++
++#14 [builder 4/7] WORKDIR /app
++#14 CACHED
++
++#10 [ner-base 1/1] FROM ghcr.io/censgate/redact-ner-base:v2@sha256:30c6081fcef34c3964114feb9b858e044fa1eaeb4470ba18823f036c83f9deeb
++#10 sha256:c2a03fd11ac27ddfe49392b9224ffc35055930839eba0bb448c61dc2ecbca258 677B / 677B done
++#10 sha256:30c6081fcef34c3964114feb9b858e044fa1eaeb4470ba18823f036c83f9deeb 1.61kB / 1.61kB done
++#10 sha256:43aed29bd3b882c4d9f5b402f593233804cefbf0943e1cde6cf5140d41e24c97 674B / 674B done
++#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 0B / 399.78MB 0.1s
++#10 sha256:94ba357deed8ba5e3c4129407b302000435222f523e24a645f9630796a245221 0B / 7.28MB 0.1s
++#10 sha256:94ba357deed8ba5e3c4129407b302000435222f523e24a645f9630796a245221 4.19MB / 7.28MB 0.5s
++#10 extracting sha256:94ba357deed8ba5e3c4129407b302000435222f523e24a645f9630796a245221
++#10 sha256:94ba357deed8ba5e3c4129407b302000435222f523e24a645f9630796a245221 7.28MB / 7.28MB 0.5s done
++#10 extracting sha256:94ba357deed8ba5e3c4129407b302000435222f523e24a645f9630796a245221 0.2s done
++#10 ...
++
++#15 [builder 5/7] COPY Cargo.toml Cargo.lock ./
++#15 DONE 0.9s
++
++#10 [ner-base 1/1] FROM ghcr.io/censgate/redact-ner-base:v2@sha256:30c6081fcef34c3964114feb9b858e044fa1eaeb4470ba18823f036c83f9deeb
++#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 33.55MB / 399.78MB 1.1s
++#10 ...
++
++#16 [builder 6/7] COPY crates ./crates
++#16 DONE 0.5s
++
++#10 [ner-base 1/1] FROM ghcr.io/censgate/redact-ner-base:v2@sha256:30c6081fcef34c3964114feb9b858e044fa1eaeb4470ba18823f036c83f9deeb
++#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 65.01MB / 399.78MB 1.6s
++#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 91.23MB / 399.78MB 2.0s
++#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 119.54MB / 399.78MB 2.6s
++#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 144.70MB / 399.78MB 3.1s
++#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 170.92MB / 399.78MB 3.6s
++#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 196.08MB / 399.78MB 4.0s
++#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 219.15MB / 399.78MB 4.4s
++#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 248.51MB / 399.78MB 5.0s
++#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 270.53MB / 399.78MB 5.4s
++#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 291.50MB / 399.78MB 5.8s
++#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 319.82MB / 399.78MB 6.4s
++#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 343.93MB / 399.78MB 7.0s
++#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 374.34MB / 399.78MB 7.6s
++#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 395.31MB / 399.78MB 8.0s
++#10 sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 399.78MB / 399.78MB 9.2s done
++#10 extracting sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf
++#10 ...
++
++#17 [builder 7/7] RUN case "arm64" in         arm64)             if [ "linux/arm64" = "linux/arm64" ]; then                 RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api;             else                 RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc -C target-cpu=neoverse-n1"                 cargo build --release --package redact-api --target aarch64-unknown-linux-gnu                 && cp target/aarch64-unknown-linux-gnu/release/redact-api target/release/;             fi ;;         amd64)             if [ "linux/arm64" = "linux/amd64" ]; then                 RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api;             else                 RUSTFLAGS="-C linker=x86_64-linux-gnu-gcc -C target-cpu=x86-64-v3"                 cargo build --release --package redact-api --target x86_64-unknown-linux-gnu                 && cp target/x86_64-unknown-linux-gnu/release/redact-api target/release/;             fi ;;         *) cargo build --release --package redact-api ;;     esac
++#17 1.049     Updating crates.io index
++#17 7.720  Downloading crates ...
++#17 7.937   Downloaded castaway v0.2.4
++#17 7.942   Downloaded cfg-if v1.0.4
++#17 7.998   Downloaded arrayref v0.3.9
++#17 8.003   Downloaded atomic-waker v1.1.2
++#17 8.005   Downloaded block-buffer v0.12.0
++#17 8.009   Downloaded onig v6.5.1
++#17 8.024   Downloaded aead v0.5.2
++#17 8.025   Downloaded cpufeatures v0.2.17
++#17 8.028   Downloaded darling_macro v0.20.11
++#17 8.032   Downloaded opaque-debug v0.3.1
++#17 8.053   Downloaded pkg-config v0.3.32
++#17 8.056   Downloaded once_cell v1.21.4
++#17 8.058   Downloaded percent-encoding v2.3.2
++#17 8.059   Downloaded crypto-common v0.1.7
++#17 8.061   Downloaded crypto-common v0.2.1
++#17 8.063   Downloaded openssl-macros v0.1.1
++#17 8.065   Downloaded cpufeatures v0.3.0
++#17 8.066   Downloaded openssl-probe v0.2.1
++#17 8.068   Downloaded macro_rules_attribute-proc_macro v0.2.2
++#17 8.068   Downloaded foreign-types v0.3.2
++#17 8.069   Downloaded form_urlencoded v1.2.2
++#17 8.070   Downloaded inout v0.1.4
++#17 8.072   Downloaded sync_wrapper v1.0.2
++#17 8.073   Downloaded http-body v1.0.1
++#17 8.075   Downloaded futures-core v0.3.32
++#17 8.079   Downloaded futures-task v0.3.32
++#17 8.082   Downloaded fnv v1.0.7
++#17 8.084   Downloaded macro_rules_attribute v0.2.2
++#17 8.091   Downloaded tower-service v0.3.3
++#17 8.091   Downloaded tokio-macros v2.7.0
++#17 8.091   Downloaded strsim v0.11.1
++#17 8.093   Downloaded hmac-sha256 v1.1.14
++#17 8.100   Downloaded lazy_static v1.5.0
++#17 8.100   Downloaded itoa v1.0.18
++#17 8.105   Downloaded tracing-serde v0.2.0
++#17 8.106   Downloaded matchers v0.2.0
++#17 8.108   Downloaded ident_case v1.0.1
++#17 8.108   Downloaded httpdate v1.0.3
++#17 8.109   Downloaded scopeguard v1.2.0
++#17 8.110   Downloaded rayon-cond v0.4.0
++#17 8.116   Downloaded mime v0.3.17
++#17 8.121   Downloaded version_check v0.9.5
++#17 8.125   Downloaded universal-hash v0.5.1
++#17 8.127   Downloaded utf8-zero v0.8.1
++#17 8.130   Downloaded serde_urlencoded v0.7.1
++#17 8.139   Downloaded rawpointer v0.2.1
++#17 8.139   Downloaded autocfg v1.5.0
++#17 8.140   Downloaded monostate-impl v0.1.18
++#17 8.143   Downloaded arrayvec v0.7.6
++#17 8.145   Downloaded unit-prefix v0.5.2
++#17 8.147   Downloaded signal-hook-registry v1.4.8
++#17 8.147   Downloaded rand_core v0.9.5
++#17 8.148   Downloaded num-integer v0.1.46
++#17 8.154   Downloaded zeroize v1.8.2
++#17 8.160   Downloaded rand_chacha v0.9.0
++#17 8.160   Downloaded num-complex v0.4.6
++#17 8.160   Downloaded dary_heap v0.3.8
++#17 8.161   Downloaded cmov v0.5.3
++#17 8.167   Downloaded tracing-attributes v0.1.31
++#17 8.169   Downloaded ppv-lite86 v0.2.21
++#17 8.180   Downloaded parking_lot v0.12.5
++#17 8.187   Downloaded ureq-proto v0.6.0
++#17 8.195   Downloaded uuid v1.23.0
++#17 8.204   Downloaded serde_derive v1.0.228
++#17 8.220   Downloaded zerocopy-derive v0.8.48
++#17 8.248   Downloaded zmij v1.0.21
++#17 8.253   Downloaded tower-http v0.6.8
++#17 8.260   Downloaded serde_json v1.0.149
++#17 8.268   Downloaded webpki-root-certs v1.0.6
++#17 8.269   Downloaded tokenizers v0.22.2
++#17 8.280   Downloaded tracing-subscriber v0.3.23
++#17 8.286   Downloaded portable-atomic v1.13.1
++#17 8.294   Downloaded vcpkg v0.2.15
++#17 8.344   Downloaded matchit v0.8.4
++#17 8.348   Downloaded unicode-width v0.2.2
++#17 8.351   Downloaded zerocopy v0.8.48
++#17 8.375   Downloaded syn v2.0.117
++#17 8.390   Downloaded matrixmultiply v0.3.10
++#17 8.393   Downloaded minimal-lexical v0.2.1
++#17 8.398   Downloaded memchr v2.8.0
++#17 8.403   Downloaded regex-syntax v0.8.10
++#17 8.417   Downloaded mio v1.2.0
++#17 8.432   Downloaded aes v0.8.4
++#17 8.438   Downloaded hyper-util v0.1.20
++#17 8.446   Downloaded tracing v0.1.44
++#17 8.465   Downloaded itertools v0.14.0
++#17 8.471   Downloaded esaxx-rs v0.1.10
++#17 8.474   Downloaded lzma-rust2 v0.15.7
++#17 8.484   Downloaded chrono v0.4.44
++#17 8.492   Downloaded spm_precompiled v0.1.4
++#17 8.503   Downloaded ndarray v0.17.2
++#17 8.514   Downloaded blake3 v1.8.4
++#17 8.520   Downloaded regex-automata v0.4.14
++#17 8.535   Downloaded futures-util v0.3.32
++#17 8.548   Downloaded axum v0.8.8
++#17 8.556   Downloaded onig_sys v69.9.1
++#17 8.577   Downloaded aho-corasick v1.1.4
++#17 8.585   Downloaded aes-gcm v0.10.3
++#17 8.587   Downloaded hyper v1.9.0
++#17 8.591   Downloaded http v1.4.0
++#17 8.594   Downloaded der v0.8.0
++#17 8.600   Downloaded log v0.4.29
++#17 8.605   Downloaded compact_str v0.9.0
++#17 8.612   Downloaded cc v1.2.59
++#17 8.615   Downloaded bytes v1.11.1
++#17 8.622   Downloaded base64 v0.22.1
++#17 8.625   Downloaded indicatif v0.18.4
++#17 8.629   Downloaded tokio v1.51.0
++#17 8.657   Downloaded httparse v1.10.1
++#17 8.659   Downloaded openssl v0.10.79
++#17 8.667   Downloaded getrandom v0.3.4
++#17 8.672   Downloaded darling_core v0.20.11
++#17 8.676   Downloaded half v2.7.1
++#17 8.676   Downloaded console v0.16.3
++#17 8.678   Downloaded getrandom v0.4.2
++#17 8.680   Downloaded derive_builder v0.20.2
++#17 8.684   Downloaded const-oid v0.10.2
++#17 8.684   Downloaded base64 v0.13.1
++#17 8.689   Downloaded libloading v0.9.0
++#17 8.693   Downloaded iana-time-zone v0.1.65
++#17 8.696   Downloaded hybrid-array v0.4.10
++#17 8.698   Downloaded getrandom v0.2.17
++#17 8.700   Downloaded rayon v1.11.0
++#17 8.716   Downloaded libc v0.2.184
++#17 8.750   Downloaded ureq v3.3.0
++#17 8.754   Downloaded regex v1.12.3
++#17 8.760   Downloaded hmac v0.13.0
++#17 8.760   Downloaded futures-channel v0.3.32
++#17 8.760   Downloaded ort v2.0.0-rc.12
++#17 8.764   Downloaded ctr v0.9.2
++#17 8.767   Downloaded crossbeam-epoch v0.9.18
++#17 8.767   Downloaded derive_builder_core v0.20.2
++#17 8.769   Downloaded darling v0.20.11
++#17 8.778   Downloaded crossbeam-utils v0.8.21
++#17 8.780   Downloaded bitflags v2.11.0
++#17 8.782   Downloaded ahash v0.8.12
++#17 8.785   Downloaded unicode-segmentation v1.13.2
++#17 8.790   Downloaded unicode-normalization-alignments v0.1.12
++#17 8.795   Downloaded typenum v1.19.0
++#17 8.795   Downloaded tower v0.5.3
++#17 8.804   Downloaded rand v0.10.1
++#17 8.809   Downloaded rand v0.9.3
++#17 8.815   Downloaded pbkdf2 v0.13.0-rc.10
++#17 8.815   Downloaded nom v7.1.3
++#17 ...
++
++#10 [ner-base 1/1] FROM ghcr.io/censgate/redact-ner-base:v2@sha256:30c6081fcef34c3964114feb9b858e044fa1eaeb4470ba18823f036c83f9deeb
++#10 extracting sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 5.2s
++#10 ...
++
++#17 [builder 7/7] RUN case "arm64" in         arm64)             if [ "linux/arm64" = "linux/arm64" ]; then                 RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api;             else                 RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc -C target-cpu=neoverse-n1"                 cargo build --release --package redact-api --target aarch64-unknown-linux-gnu                 && cp target/aarch64-unknown-linux-gnu/release/redact-api target/release/;             fi ;;         amd64)             if [ "linux/arm64" = "linux/amd64" ]; then                 RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api;             else                 RUSTFLAGS="-C linker=x86_64-linux-gnu-gcc -C target-cpu=x86-64-v3"                 cargo build --release --package redact-api --target x86_64-unknown-linux-gnu                 && cp target/x86_64-unknown-linux-gnu/release/redact-api target/release/;             fi ;;         *) cargo build --release --package redact-api ;;     esac
++#17 8.823   Downloaded anyhow v1.0.102
++#17 8.828   Downloaded unicode_categories v0.1.1
++#17 8.829   Downloaded rayon-core v1.13.0
++#17 8.833   Downloaded openssl-sys v0.9.115
++#17 8.838   Downloaded http-body-util v0.1.3
++#17 8.839   Downloaded find-msvc-tools v0.1.9
++#17 8.842   Downloaded chacha20 v0.10.0
++#17 8.842   Downloaded serde_core v1.0.228
++#17 8.843   Downloaded serde v1.0.228
++#17 8.846   Downloaded ryu v1.0.23
++#17 8.847   Downloaded sharded-slab v0.1.7
++#17 8.853   Downloaded rustls-pki-types v1.14.0
++#17 8.857   Downloaded proc-macro2 v1.0.106
++#17 8.860   Downloaded ort-sys v2.0.0-rc.12
++#17 8.866   Downloaded num-traits v0.2.19
++#17 8.871   Downloaded lock_api v0.4.14
++#17 8.875   Downloaded digest v0.11.2
++#17 8.875   Downloaded derive_builder_macro v0.20.2
++#17 8.877   Downloaded unicode-ident v1.0.24
++#17 8.883   Downloaded tracing-core v0.1.36
++#17 8.883   Downloaded socket2 v0.6.3
++#17 8.883   Downloaded smallvec v1.15.1
++#17 8.883   Downloaded either v1.15.0
++#17 8.887   Downloaded ctutils v0.4.2
++#17 8.892   Downloaded cipher v0.4.4
++#17 8.897   Downloaded native-tls v0.2.18
++#17 8.898   Downloaded crossbeam-deque v0.8.6
++#17 8.901   Downloaded constant_time_eq v0.4.2
++#17 8.901   Downloaded slab v0.4.12
++#17 8.905   Downloaded sha2 v0.11.0
++#17 8.910   Downloaded pem-rfc7468 v1.0.0
++#17 8.911   Downloaded parking_lot_core v0.9.12
++#17 8.913   Downloaded byteorder v1.5.0
++#17 8.917   Downloaded tracing-log v0.2.0
++#17 8.918   Downloaded thread_local v1.1.9
++#17 8.919   Downloaded thiserror-impl v2.0.18
++#17 8.922   Downloaded static_assertions v1.1.0
++#17 8.924   Downloaded serde_path_to_error v0.1.20
++#17 8.929   Downloaded rustversion v1.0.22
++#17 8.931   Downloaded rand_core v0.6.4
++#17 8.934   Downloaded polyval v0.6.2
++#17 8.934   Downloaded nu-ansi-term v0.50.3
++#17 8.936   Downloaded tower-layer v0.3.3
++#17 8.936   Downloaded thiserror v2.0.18
++#17 8.952   Downloaded shlex v1.3.0
++#17 8.952   Downloaded rand_core v0.10.0
++#17 8.956   Downloaded quote v1.0.45
++#17 8.963   Downloaded paste v1.0.15
++#17 8.963   Downloaded base64ct v1.8.3
++#17 8.963   Downloaded axum-core v0.5.6
++#17 8.973   Downloaded subtle v2.6.1
++#17 8.973   Downloaded socks v0.3.4
++#17 8.976   Downloaded pin-project-lite v0.2.17
++#17 8.984   Downloaded monostate v0.1.18
++#17 8.984   Downloaded ghash v0.5.1
++#17 8.984   Downloaded foreign-types-shared v0.1.1
++#17 8.984   Downloaded errno v0.3.14
++#17 8.984   Downloaded generic-array v0.14.7
++#17 9.163    Compiling libc v0.2.184
++#17 9.166    Compiling proc-macro2 v1.0.106
++#17 9.171    Compiling quote v1.0.45
++#17 9.171    Compiling unicode-ident v1.0.24
++#17 9.172    Compiling cfg-if v1.0.4
++#17 9.182    Compiling shlex v1.3.0
++#17 9.182    Compiling find-msvc-tools v0.1.9
++#17 9.182    Compiling typenum v1.19.0
++#17 9.182    Compiling version_check v0.9.5
++#17 9.182    Compiling serde_core v1.0.228
++#17 9.528    Compiling pkg-config v0.3.32
++#17 9.916    Compiling cc v1.2.59
++#17 9.926    Compiling itoa v1.0.18
++#17 10.35    Compiling once_cell v1.21.4
++#17 10.46    Compiling serde v1.0.228
++#17 10.53    Compiling generic-array v0.14.7
++#17 10.83    Compiling pin-project-lite v0.2.17
++#17 10.85    Compiling autocfg v1.5.0
++#17 10.99    Compiling vcpkg v0.2.15
++#17 10.99    Compiling memchr v2.8.0
++#17 11.03    Compiling smallvec v1.15.1
++#17 11.09    Compiling tracing-core v0.1.36
++#17 11.64    Compiling log v0.4.29
++#17 12.25    Compiling zerocopy v0.8.48
++#17 12.40    Compiling bytes v1.11.1
++#17 13.02    Compiling getrandom v0.2.17
++#17 13.06    Compiling num-traits v0.2.19
++#17 13.17    Compiling zeroize v1.8.2
++#17 13.24    Compiling httparse v1.10.1
++#17 13.34    Compiling syn v2.0.117
++#17 13.35    Compiling rand_core v0.6.4
++#17 13.39    Compiling openssl v0.10.79
++#17 13.40    Compiling foreign-types-shared v0.1.1
++#17 13.55    Compiling crypto-common v0.1.7
++#17 13.56    Compiling crossbeam-utils v0.8.21
++#17 13.60    Compiling foreign-types v0.3.2
++#17 13.65    Compiling hybrid-array v0.4.10
++#17 13.65    Compiling native-tls v0.2.18
++#17 13.76    Compiling ident_case v1.0.1
++#17 13.81    Compiling zmij v1.0.21
++#17 13.82    Compiling fnv v1.0.7
++#17 13.87    Compiling base64ct v1.8.3
++#17 13.89    Compiling parking_lot_core v0.9.12
++#17 13.94    Compiling futures-core v0.3.32
++#17 13.99    Compiling getrandom v0.3.4
++#17 14.09    Compiling bitflags v2.11.0
++#17 14.13    Compiling strsim v0.11.1
++#17 14.44    Compiling openssl-sys v0.9.115
++#17 14.56    Compiling pem-rfc7468 v1.0.0
++#17 14.61    Compiling http v1.4.0
++#17 14.98    Compiling rustls-pki-types v1.14.0
++#17 15.02    Compiling aho-corasick v1.1.4
++#17 15.07    Compiling scopeguard v1.2.0
++#17 15.08    Compiling openssl-probe v0.2.1
++#17 15.16    Compiling base64 v0.22.1
++#17 15.34    Compiling serde_json v1.0.149
++#17 15.42    Compiling byteorder v1.5.0
++#17 15.58    Compiling cmov v0.5.3
++#17 15.73    Compiling regex-syntax v0.8.10
++#17 15.82    Compiling ctutils v0.4.2
++#17 15.87    Compiling socks v0.3.4
++#17 15.90    Compiling webpki-root-certs v1.0.6
++#17 16.06    Compiling ureq-proto v0.6.0
++#17 16.20    Compiling crossbeam-epoch v0.9.18
++#17 16.32    Compiling lock_api v0.4.14
++#17 16.60    Compiling der v0.8.0
++#17 16.88    Compiling http-body v1.0.1
++#17 17.15    Compiling block-buffer v0.12.0
++#17 17.25    Compiling crypto-common v0.2.1
++#17 17.83    Compiling regex-automata v0.4.14
++#17 18.03    Compiling inout v0.1.4
++#17 18.16    Compiling cpufeatures v0.2.17
++#17 18.20    Compiling errno v0.3.14
++#17 18.24    Compiling utf8-zero v0.8.1
++#17 18.29    Compiling const-oid v0.10.2
++#17 18.48    Compiling percent-encoding v2.3.2
++#17 18.52    Compiling rand_core v0.10.0
++#17 18.53    Compiling getrandom v0.4.2
++#17 18.74    Compiling rayon-core v1.13.0
++#17 18.81    Compiling subtle v2.6.1
++#17 18.85    Compiling rustversion v1.0.22
++#17 18.91    Compiling signal-hook-registry v1.4.8
++#17 19.02    Compiling cipher v0.4.4
++#17 19.14    Compiling digest v0.11.2
++#17 19.44    Compiling universal-hash v0.5.1
++#17 19.61    Compiling darling_core v0.20.11
++#17 19.64    Compiling parking_lot v0.12.5
++#17 19.71    Compiling crossbeam-deque v0.8.6
++#17 20.04    Compiling onig_sys v69.9.1
++#17 20.10    Compiling socket2 v0.6.3
++#17 20.53    Compiling mio v1.2.0
++#17 20.79    Compiling matrixmultiply v0.3.10
++#17 20.89    Compiling lzma-rust2 v0.15.7
++#17 21.18    Compiling either v1.15.0
++#17 21.29    Compiling paste v1.0.15
++#17 21.29    Compiling opaque-debug v0.3.1
++#17 21.53    Compiling thiserror v2.0.18
++#17 21.75    Compiling hmac-sha256 v1.1.14
++#17 21.75    Compiling tower-service v0.3.3
++#17 21.87    Compiling ryu v1.0.23
++#17 21.95    Compiling portable-atomic v1.13.1
++#17 22.34    Compiling polyval v0.6.2
++#17 23.12    Compiling rand_core v0.9.5
++#17 23.34    Compiling esaxx-rs v0.1.10
++#17 23.41    Compiling blake3 v1.8.4
++#17 23.66    Compiling cpufeatures v0.3.0
++#17 23.77    Compiling ahash v0.8.12
++#17 23.77    Compiling tower-layer v0.3.3
++#17 24.02    Compiling anyhow v1.0.102
++#17 24.07    Compiling minimal-lexical v0.2.1
++#17 24.18    Compiling rawpointer v0.2.1
++#17 24.31    Compiling lazy_static v1.5.0
++#17 24.44    Compiling unicode-width v0.2.2
++#17 24.47    Compiling nom v7.1.3
++#17 24.85    Compiling regex v1.12.3
++#17 24.86    Compiling console v0.16.3
++#17 25.00    Compiling rayon v1.11.0
++#17 25.00    Compiling serde_derive v1.0.228
++#17 25.35    Compiling tracing-attributes v0.1.31
++#17 25.70    Compiling zerocopy-derive v0.8.48
++#17 26.34    Compiling openssl-macros v0.1.1
++#17 ...
++
++#10 [ner-base 1/1] FROM ghcr.io/censgate/redact-ner-base:v2@sha256:30c6081fcef34c3964114feb9b858e044fa1eaeb4470ba18823f036c83f9deeb
++#10 extracting sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 18.5s
++#10 ...
++
++#17 [builder 7/7] RUN case "arm64" in         arm64)             if [ "linux/arm64" = "linux/arm64" ]; then                 RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api;             else                 RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc -C target-cpu=neoverse-n1"                 cargo build --release --package redact-api --target aarch64-unknown-linux-gnu                 && cp target/aarch64-unknown-linux-gnu/release/redact-api target/release/;             fi ;;         amd64)             if [ "linux/arm64" = "linux/amd64" ]; then                 RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api;             else                 RUSTFLAGS="-C linker=x86_64-linux-gnu-gcc -C target-cpu=x86-64-v3"                 cargo build --release --package redact-api --target x86_64-unknown-linux-gnu                 && cp target/x86_64-unknown-linux-gnu/release/redact-api target/release/;             fi ;;         *) cargo build --release --package redact-api ;;     esac
++#17 27.16    Compiling darling_macro v0.20.11
++#17 27.31    Compiling tokio-macros v2.7.0
++#17 27.87    Compiling thiserror-impl v2.0.18
++#17 28.01    Compiling darling v0.20.11
++#17 28.13    Compiling derive_builder_core v0.20.2
++#17 29.07    Compiling tokio v1.51.0
++#17 29.70    Compiling tracing v0.1.44
++#17 29.87    Compiling monostate-impl v0.1.18
++#17 30.86    Compiling derive_builder_macro v0.20.2
++#17 30.94    Compiling castaway v0.2.4
++#17 31.77    Compiling sha2 v0.11.0
++#17 33.28    Compiling ureq v3.3.0
++#17 ...
++
++#10 [ner-base 1/1] FROM ghcr.io/censgate/redact-ner-base:v2@sha256:30c6081fcef34c3964114feb9b858e044fa1eaeb4470ba18823f036c83f9deeb
++#10 extracting sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 26.0s
++#10 ...
++
++#17 [builder 7/7] RUN case "arm64" in         arm64)             if [ "linux/arm64" = "linux/arm64" ]; then                 RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api;             else                 RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc -C target-cpu=neoverse-n1"                 cargo build --release --package redact-api --target aarch64-unknown-linux-gnu                 && cp target/aarch64-unknown-linux-gnu/release/redact-api target/release/;             fi ;;         amd64)             if [ "linux/arm64" = "linux/amd64" ]; then                 RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api;             else                 RUSTFLAGS="-C linker=x86_64-linux-gnu-gcc -C target-cpu=x86-64-v3"                 cargo build --release --package redact-api --target x86_64-unknown-linux-gnu                 && cp target/x86_64-unknown-linux-gnu/release/redact-api target/release/;             fi ;;         *) cargo build --release --package redact-api ;;     esac
++#17 34.29    Compiling ghash v0.5.1
++#17 34.79    Compiling itertools v0.14.0
++#17 34.95    Compiling hmac v0.13.0
++#17 34.99    Compiling aes v0.8.4
++#17 35.01    Compiling ctr v0.9.2
++#17 35.13    Compiling chacha20 v0.10.0
++#17 35.34    Compiling num-integer v0.1.46
++#17 35.57    Compiling num-complex v0.4.6
++#17 35.70    Compiling futures-channel v0.3.32
++#17 35.87    Compiling aead v0.5.2
++#17 36.04    Compiling constant_time_eq v0.4.2
++#17 36.05    Compiling arrayvec v0.7.6
++#17 36.09    Compiling iana-time-zone v0.1.65
++#17 36.44    Compiling macro_rules_attribute-proc_macro v0.2.2
++#17 36.56    Compiling sync_wrapper v1.0.2
++#17 36.59    Compiling static_assertions v1.1.0
++#17 36.69    Compiling unit-prefix v0.5.2
++#17 36.71    Compiling atomic-waker v1.1.2
++#17 36.79    Compiling base64 v0.13.1
++#17 36.81    Compiling arrayref v0.3.9
++#17 36.86    Compiling unicode-segmentation v1.13.2
++#17 36.89    Compiling slab v0.4.12
++#17 37.05    Compiling futures-task v0.3.32
++#17 37.22    Compiling httpdate v1.0.3
++#17 37.42    Compiling macro_rules_attribute v0.2.2
++#17 37.57    Compiling ort-sys v2.0.0-rc.12
++#17 37.57    Compiling spm_precompiled v0.1.4
++#17 37.68    Compiling form_urlencoded v1.2.2
++#17 37.69    Compiling futures-util v0.3.32
++#17 37.84    Compiling ppv-lite86 v0.2.21
++#17 37.98    Compiling half v2.7.1
++#17 38.29    Compiling rand_chacha v0.9.0
++#17 38.37    Compiling rayon-cond v0.4.0
++#17 38.44    Compiling indicatif v0.18.4
++#17 38.58    Compiling rand v0.9.3
++#17 38.81    Compiling compact_str v0.9.0
++#17 39.87    Compiling ndarray v0.17.2
++#17 40.01    Compiling chrono v0.4.44
++#17 40.30    Compiling aes-gcm v0.10.3
++#17 40.58    Compiling hyper v1.9.0
++#17 40.87    Compiling rand v0.10.1
++#17 40.95    Compiling pbkdf2 v0.13.0-rc.10
++#17 41.11    Compiling dary_heap v0.3.8
++#17 41.42    Compiling derive_builder v0.20.2
++#17 41.57    Compiling monostate v0.1.18
++#17 41.89    Compiling uuid v1.23.0
++#17 42.07    Compiling http-body-util v0.1.3
++#17 42.10    Compiling unicode-normalization-alignments v0.1.12
++#17 42.20    Compiling libloading v0.9.0
++#17 ...
++
++#10 [ner-base 1/1] FROM ghcr.io/censgate/redact-ner-base:v2@sha256:30c6081fcef34c3964114feb9b858e044fa1eaeb4470ba18823f036c83f9deeb
++#10 extracting sha256:be3e42e6b99a5f0d3286fc45ec9f1594be6f8334149f0ebb3e6972bc99e609bf 32.0s done
++#10 DONE 44.1s
++
++#17 [builder 7/7] RUN case "arm64" in         arm64)             if [ "linux/arm64" = "linux/arm64" ]; then                 RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api;             else                 RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc -C target-cpu=neoverse-n1"                 cargo build --release --package redact-api --target aarch64-unknown-linux-gnu                 && cp target/aarch64-unknown-linux-gnu/release/redact-api target/release/;             fi ;;         amd64)             if [ "linux/arm64" = "linux/amd64" ]; then                 RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api;             else                 RUSTFLAGS="-C linker=x86_64-linux-gnu-gcc -C target-cpu=x86-64-v3"                 cargo build --release --package redact-api --target x86_64-unknown-linux-gnu                 && cp target/x86_64-unknown-linux-gnu/release/redact-api target/release/;             fi ;;         *) cargo build --release --package redact-api ;;     esac
++#17 42.30    Compiling unicode_categories v0.1.1
++#17 42.51    Compiling mime v0.3.17
++#17 42.57    Compiling tower v0.5.3
++#17 42.66    Compiling hyper-util v0.1.20
++#17 43.26    Compiling axum-core v0.5.6
++#17 43.35    Compiling redact-core v0.8.3 (/app/crates/redact-core)
++#17 43.35    Compiling serde_urlencoded v0.7.1
++#17 43.65    Compiling tracing-serde v0.2.0
++#17 43.77    Compiling matchers v0.2.0
++#17 44.04    Compiling sharded-slab v0.1.7
++#17 44.10    Compiling serde_path_to_error v0.1.20
++#17 44.27    Compiling tracing-log v0.2.0
++#17 44.54    Compiling thread_local v1.1.9
++#17 44.64    Compiling matchit v0.8.4
++#17 44.81    Compiling nu-ansi-term v0.50.3
++#17 45.35    Compiling tower-http v0.6.8
++#17 45.55    Compiling tracing-subscriber v0.3.23
++#17 46.06    Compiling axum v0.8.8
++#17 47.78    Compiling onig v6.5.1
++#17 48.18    Compiling tokenizers v0.22.2
++#17 ...
++
++#18 [stage-2 3/5] COPY --from=ner-base /app/lib/libonnxruntime.so /app/lib/libonnxruntime.so
++#18 DONE 1.7s
++
++#17 [builder 7/7] RUN case "arm64" in         arm64)             if [ "linux/arm64" = "linux/arm64" ]; then                 RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api;             else                 RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc -C target-cpu=neoverse-n1"                 cargo build --release --package redact-api --target aarch64-unknown-linux-gnu                 && cp target/aarch64-unknown-linux-gnu/release/redact-api target/release/;             fi ;;         amd64)             if [ "linux/arm64" = "linux/amd64" ]; then                 RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api;             else                 RUSTFLAGS="-C linker=x86_64-linux-gnu-gcc -C target-cpu=x86-64-v3"                 cargo build --release --package redact-api --target x86_64-unknown-linux-gnu                 && cp target/x86_64-unknown-linux-gnu/release/redact-api target/release/;             fi ;;         *) cargo build --release --package redact-api ;;     esac
++#17 51.41    Compiling ort v2.0.0-rc.12
++#17 ...
++
++#19 [stage-2 4/5] COPY --from=ner-base /app/model/ /app/model/
++#19 DONE 1.5s
++
++#17 [builder 7/7] RUN case "arm64" in         arm64)             if [ "linux/arm64" = "linux/arm64" ]; then                 RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api;             else                 RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc -C target-cpu=neoverse-n1"                 cargo build --release --package redact-api --target aarch64-unknown-linux-gnu                 && cp target/aarch64-unknown-linux-gnu/release/redact-api target/release/;             fi ;;         amd64)             if [ "linux/arm64" = "linux/amd64" ]; then                 RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api;             else                 RUSTFLAGS="-C linker=x86_64-linux-gnu-gcc -C target-cpu=x86-64-v3"                 cargo build --release --package redact-api --target x86_64-unknown-linux-gnu                 && cp target/x86_64-unknown-linux-gnu/release/redact-api target/release/;             fi ;;         *) cargo build --release --package redact-api ;;     esac
++#17 54.87    Compiling redact-ner v0.8.3 (/app/crates/redact-ner)
++#17 55.74    Compiling redact-api v0.8.3 (/app/crates/redact-api)
++#17 100.2     Finished `release` profile [optimized] target(s) in 1m 39s
++#17 DONE 100.7s
++
++#20 [stage-2 5/5] COPY --from=builder /app/target/release/redact-api /usr/local/bin/redact-api
++#20 DONE 1.4s
++
++#21 exporting to image
++#21 exporting layers
++#21 exporting layers 2.0s done
++#21 writing image sha256:a5fe0292152cb6b9eede98d078b19c2de3dfd96e59a437bc6698250604641f54 0.0s done
++#21 naming to docker.io/library/redact-full:eng-67-local 0.1s done
++#21 DONE 2.3s
++
++=== smoke: docker run ===
++424aecbebd4254b0d0e62c2b7494fcd9cd19ce72ca309b9d88605e39495905a9
++eng67-redact-smoke
+diff --git a/artifacts/eng-67/healthz-curl.log b/artifacts/eng-67/healthz-curl.log
+new file mode 100644
+index 0000000..2fe798d
+--- /dev/null
++++ b/artifacts/eng-67/healthz-curl.log
+@@ -0,0 +1,17 @@
++*   Trying 127.0.0.1:18081...
++* Connected to 127.0.0.1 (127.0.0.1) port 18081
++> GET /healthz HTTP/1.1
++> Host: 127.0.0.1:18081
++> User-Agent: curl/8.7.1
++> Accept: */*
++> 
++* Request completely sent off
++< HTTP/1.1 200 OK
++< content-type: application/json
++< content-length: 72
++< date: Sun, 17 May 2026 16:27:22 GMT
++< 
++{ [72 bytes data]
++* Connection #0 to host 127.0.0.1 left intact
++
++{"status":"healthy","version":"0.8.3","recognizers":2,"entity_types":39}
+\ No newline at end of file
+diff --git a/crates/redact-api/src/routes.rs b/crates/redact-api/src/routes.rs
+index 125d46a..7042303 100644
+--- a/crates/redact-api/src/routes.rs
++++ b/crates/redact-api/src/routes.rs
+@@ -12,6 +12,7 @@ use axum::{
+ pub fn create_router(state: AppState) -> Router {
+     Router::new()
+         .route("/health", get(health))
++        .route("/healthz", get(health))
+         .route("/api/v1/analyze", post(analyze_api))
+         .route("/api/v1/anonymize", post(anonymize_api))
+         .with_state(state)
+@@ -49,6 +50,26 @@ mod tests {
+         assert_eq!(response.status(), StatusCode::OK);
+     }
+ 
++    #[tokio::test]
++    async fn test_healthz_route() {
++        let state = AppState {
++            engine: Arc::new(AnalyzerEngine::new()),
++        };
++        let app = create_router(state);
++
++        let response = app
++            .oneshot(
++                Request::builder()
++                    .uri("/healthz")
++                    .body(Body::empty())
++                    .unwrap(),
++            )
++            .await
++            .unwrap();
++
++        assert_eq!(response.status(), StatusCode::OK);
++    }
++
+     #[tokio::test]
+     async fn test_analyze_route() {
+         let state = AppState {
+diff --git a/crates/redact-api/src/server.rs b/crates/redact-api/src/server.rs
+index 385e950..af2fc5b 100644
+--- a/crates/redact-api/src/server.rs
++++ b/crates/redact-api/src/server.rs
+@@ -89,6 +89,7 @@ impl ApiServer {
+         info!("Redact API server listening on {}", addr);
+         info!("Endpoints:");
+         info!("  GET  /health           - Health check");
++        info!("  GET  /healthz          - Health check (probe alias)");
+         info!("  POST /api/v1/analyze   - Analyze text for PII");
+         info!("  POST /api/v1/anonymize - Anonymize detected PII");
+ 

--- a/artifacts/eng-67/healthz-curl.log
+++ b/artifacts/eng-67/healthz-curl.log
@@ -1,0 +1,17 @@
+*   Trying 127.0.0.1:18081...
+* Connected to 127.0.0.1 (127.0.0.1) port 18081
+> GET /healthz HTTP/1.1
+> Host: 127.0.0.1:18081
+> User-Agent: curl/8.7.1
+> Accept: */*
+> 
+* Request completely sent off
+< HTTP/1.1 200 OK
+< content-type: application/json
+< content-length: 72
+< date: Sun, 17 May 2026 16:27:22 GMT
+< 
+{ [72 bytes data]
+* Connection #0 to host 127.0.0.1 left intact
+
+{"status":"healthy","version":"0.8.3","recognizers":2,"entity_types":39}

--- a/crates/redact-api/src/routes.rs
+++ b/crates/redact-api/src/routes.rs
@@ -12,6 +12,7 @@ use axum::{
 pub fn create_router(state: AppState) -> Router {
     Router::new()
         .route("/health", get(health))
+        .route("/healthz", get(health))
         .route("/api/v1/analyze", post(analyze_api))
         .route("/api/v1/anonymize", post(anonymize_api))
         .with_state(state)
@@ -40,6 +41,26 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_healthz_route() {
+        let state = AppState {
+            engine: Arc::new(AnalyzerEngine::new()),
+        };
+        let app = create_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/healthz")
                     .body(Body::empty())
                     .unwrap(),
             )

--- a/crates/redact-api/src/server.rs
+++ b/crates/redact-api/src/server.rs
@@ -89,6 +89,7 @@ impl ApiServer {
         info!("Redact API server listening on {}", addr);
         info!("Endpoints:");
         info!("  GET  /health           - Health check");
+        info!("  GET  /healthz          - Health check (probe alias)");
         info!("  POST /api/v1/analyze   - Analyze text for PII");
         info!("  POST /api/v1/anonymize - Anonymize detected PII");
 


### PR DESCRIPTION
## Summary

Adds a `GET /healthz` route alias to the same handler as `/health` so platform-side deploys that probe `/healthz` get a stable contract. README + Dockerfile header document the required env / port for `PLATFORM_REDACT_API_URL` consumption. Release CI smoke probes `/healthz`.

## Changes

- handler alias `/healthz` → existing `/health` handler
- README run notes for the `redact-full` image
- Dockerfile annotation

---

## Provenance (mandatory)

- **Linear:** ENG-67
- **Repo:** `censgate/redact`
- **Branch:** `agent/eng-67-redact-full-deploy`
- **Worktree:** `redact.worktrees/agent-eng-67-redact-full-deploy`
- **BOM digest:** `57394145f01a9168a4fafb3d557d06c8c03f6dbb930baf8959d2e8d931705a5b`
- **Wave:** `2026-05-17-mvp-wave0`

## Evidence

- `cargo check --workspace` green on integration branch
- image built locally: `redact-full:eng-67-local` (used in seemath integrated-stack run; healthz 200 confirmed)

## Dependencies / sequencing

- companion to **censgate/platform#ENG-67** (resilient client) and **censgate/seemath#ENG-67** (compose profile)

## How to verify locally

```
cargo build --workspace
docker build -t redact-full:local .
docker run --rm -p 8080:8080 redact-full:local &
curl -sf http://127.0.0.1:8080/healthz
```

## Out of scope

- redact-lite variant (separate image; not in scope)

---

Authored by **Composer subagent** (composer-2-fast) under premium-orchestrator coordination from `censgate/seemath`. See seemath `docs/program/merge-train-playbook.md` for the canonical wave-0 dispatch sequence and `docs/program/dependency-change-ledger.md` for the worktree ↔ branch ledger.
