### PR TITLE
Wave 7: key-once DEK tokenization in redact-core

### DIFF
--- a/crates/redact-api/src/routes.rs
+++ b/crates/redact-api/src/routes.rs
@@ -195,4 +195,87 @@ mod tests {
         assert!(json["text"].as_str().unwrap().contains("[EMAIL_ADDRESS]"));
         assert_eq!(json["results"][0]["text"], "john@example.com");
     }
+
+    fn ner_model_fixture_dir() -> std::path::PathBuf {
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../redact-ner/tests/fixtures/models/bert-base-ner")
+    }
+
+    fn ner_model_available(model_dir: &std::path::Path) -> bool {
+        model_dir.join("model.onnx").exists() && model_dir.join("tokenizer.json").exists()
+    }
+
+    /// `/api/v1/analyze` returns NER entity spans when an ONNX model is loaded.
+    #[tokio::test]
+    #[ignore = "requires redact-ner/tests/fixtures/models/bert-base-ner (see ner_e2e.rs setup)"]
+    async fn test_analyze_route_returns_ner_person_spans() {
+        use redact_core::recognizers::RecognizerRegistry;
+        use redact_ner::{NerConfig, NerRecognizer};
+
+        let model_dir = ner_model_fixture_dir();
+        if !ner_model_available(&model_dir) {
+            eprintln!(
+                "Skipping NER analyze route test: model fixture missing at {}",
+                model_dir.display()
+            );
+            return;
+        }
+
+        let config = NerConfig {
+            model_path: model_dir.join("model.onnx").to_string_lossy().into_owned(),
+            tokenizer_path: Some(
+                model_dir
+                    .join("tokenizer.json")
+                    .to_string_lossy()
+                    .into_owned(),
+            ),
+            min_confidence: 0.7,
+            ..Default::default()
+        };
+
+        let ner = NerRecognizer::from_config(config).expect("load NER model");
+        let mut registry = RecognizerRegistry::new();
+        registry.add_recognizer(Arc::new(ner));
+
+        let state = AppState {
+            engine: Arc::new(
+                AnalyzerEngine::builder()
+                    .with_recognizer_registry(registry)
+                    .build(),
+            ),
+        };
+        let app = create_router(state);
+
+        let body = r#"{"text":"Contact John Doe at john@example.com","language":"en"}"#;
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/analyze")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: Value = serde_json::from_slice(&body).unwrap();
+
+        let person_spans: Vec<_> = json["results"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|r| r["entity_type"] == "PERSON")
+            .collect();
+
+        assert!(
+            !person_spans.is_empty(),
+            "expected PERSON spans from NER-enabled analyze response"
+        );
+        assert!(person_spans[0]["start"].is_number());
+        assert!(person_spans[0]["end"].is_number());
+        assert!(person_spans[0]["score"].as_f64().unwrap() > 0.0);
+    }
 }

--- a/crates/redact-core/src/anonymizers/encrypt.rs
+++ b/crates/redact-core/src/anonymizers/encrypt.rs
@@ -14,22 +14,57 @@ use rand::RngExt;
 use sha2::Sha256;
 use uuid::Uuid;
 
+/// Version byte for key-once DEK envelopes (`0x01 || nonce(12) || ciphertext+tag`).
+const DEK_ENVELOPE_VERSION: u8 = 0x01;
+
+/// Minimum byte length for a DEK envelope after base64 decode (version + nonce).
+const DEK_ENVELOPE_MIN_LEN: usize = 1 + 12;
+
 /// Encrypt anonymizer for reversible anonymization
 #[derive(Debug, Clone)]
 pub struct EncryptAnonymizer {
     key_derivation_iterations: u32,
+    dek: Option<[u8; 32]>,
 }
 
 impl EncryptAnonymizer {
     pub fn new() -> Self {
         Self {
             key_derivation_iterations: 100_000,
+            dek: None,
+        }
+    }
+
+    /// Create an encrypt anonymizer that seals values with a pre-derived 32-byte DEK.
+    ///
+    /// Uses AES-256-GCM directly (no PBKDF2, no per-value salt). Each seal generates a
+    /// fresh random 12-byte nonce. Output is base64-encoded:
+    /// `0x01 || nonce(12) || ciphertext_with_tag`.
+    pub fn with_dek(dek: [u8; 32]) -> Self {
+        Self {
+            key_derivation_iterations: 100_000,
+            dek: Some(dek),
         }
     }
 
     pub fn with_iterations(mut self, iterations: u32) -> Self {
         self.key_derivation_iterations = iterations;
         self
+    }
+
+    /// Seal a value using the configured DEK (key-once mode).
+    pub fn seal_with_dek(&self, value: &str) -> Result<String> {
+        let dek = self
+            .dek
+            .as_ref()
+            .ok_or_else(|| anyhow!("DEK not configured; use EncryptAnonymizer::with_dek"))?;
+        Self::seal_value_with_dek(dek, value)
+    }
+
+    /// Decrypt a key-once envelope produced by [`Self::seal_with_dek`] or [`Self::with_dek`].
+    pub fn decrypt_with_dek(dek: &[u8; 32], envelope_b64: &str) -> Result<String> {
+        let envelope = base64_decode(envelope_b64)?;
+        Self::decrypt_envelope_with_dek(dek, &envelope)
     }
 
     /// Derive encryption key from password
@@ -75,6 +110,50 @@ impl EncryptAnonymizer {
         Ok((encoded, encrypted))
     }
 
+    fn seal_value_with_dek(dek: &[u8; 32], value: &str) -> Result<String> {
+        let mut rng = rand::rng();
+        let nonce_bytes: [u8; 12] = rng.random();
+        let cipher = Aes256Gcm::new(dek.into());
+        let nonce = Nonce::from_slice(&nonce_bytes);
+
+        let ciphertext = cipher
+            .encrypt(nonce, value.as_bytes())
+            .map_err(|e| anyhow!("Encryption failed: {}", e))?;
+
+        let mut envelope = Vec::with_capacity(DEK_ENVELOPE_MIN_LEN + ciphertext.len());
+        envelope.push(DEK_ENVELOPE_VERSION);
+        envelope.extend_from_slice(&nonce_bytes);
+        envelope.extend_from_slice(&ciphertext);
+
+        Ok(base64_encode(&envelope))
+    }
+
+    fn decrypt_envelope_with_dek(dek: &[u8; 32], envelope: &[u8]) -> Result<String> {
+        if envelope.len() < DEK_ENVELOPE_MIN_LEN {
+            return Err(anyhow!("Invalid encrypted data"));
+        }
+
+        if envelope[0] != DEK_ENVELOPE_VERSION {
+            return Err(anyhow!(
+                "Unsupported envelope version: expected 0x{:02x}, got 0x{:02x}",
+                DEK_ENVELOPE_VERSION,
+                envelope[0]
+            ));
+        }
+
+        let nonce_bytes = &envelope[1..13];
+        let ciphertext = &envelope[13..];
+
+        let cipher = Aes256Gcm::new(dek.into());
+        let nonce = Nonce::from_slice(nonce_bytes);
+
+        let plaintext = cipher
+            .decrypt(nonce, ciphertext)
+            .map_err(|e| anyhow!("Decryption failed: {}", e))?;
+
+        String::from_utf8(plaintext).map_err(|e| anyhow!("Invalid UTF-8: {}", e))
+    }
+
     /// Decrypt a value
     pub fn decrypt_value(&self, encrypted: &[u8], password: &str) -> Result<String> {
         if encrypted.len() < 28 {
@@ -118,10 +197,9 @@ impl Anonymizer for EncryptAnonymizer {
         entities: Vec<RecognizerResult>,
         config: &AnonymizerConfig,
     ) -> Result<AnonymizedResult> {
-        let password = config
-            .encryption_key
-            .as_ref()
-            .ok_or_else(|| anyhow!("Encryption key not provided"))?;
+        if self.dek.is_none() && config.encryption_key.is_none() {
+            return Err(anyhow!("Encryption key not provided"));
+        }
 
         // Pre-encrypt all values and build tokens
         let mut tokens = Vec::new();
@@ -132,14 +210,20 @@ impl Anonymizer for EncryptAnonymizer {
                 let original = &text[entity.start..entity.end];
 
                 // Encrypt the original value
-                let encrypted = self
-                    .encrypt_value(original, password)
-                    .unwrap_or_else(|_| (base64_encode(original.as_bytes()), vec![]));
+                let encrypted = if let Some(dek) = &self.dek {
+                    Self::seal_value_with_dek(dek, original)
+                        .unwrap_or_else(|_| base64_encode(original.as_bytes()))
+                } else {
+                    let password = config.encryption_key.as_ref().unwrap();
+                    self.encrypt_value(original, password)
+                        .map(|(encoded, _)| encoded)
+                        .unwrap_or_else(|_| base64_encode(original.as_bytes()))
+                };
 
                 // Create token
                 tokens.push(Token {
                     token_id: token_id.clone(),
-                    original_value: encrypted.0,
+                    original_value: encrypted,
                     entity_type: entity.entity_type.clone(),
                     start: entity.start,
                     end: entity.end,
@@ -194,6 +278,67 @@ fn base64_encode(bytes: &[u8]) -> String {
     }
 
     result
+}
+
+fn base64_decode(input: &str) -> Result<Vec<u8>> {
+    const DECODE: [u8; 128] = {
+        let mut table = [255u8; 128];
+        let chars = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        let mut i = 0;
+        while i < 64 {
+            table[chars[i] as usize] = i as u8;
+            i += 1;
+        }
+        table
+    };
+
+    let input = input.trim_end_matches('=');
+    if input.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut output = Vec::with_capacity(input.len() * 3 / 4);
+    let bytes = input.as_bytes();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        let remaining = bytes.len() - i;
+        if remaining >= 4 {
+            let b1 = DECODE[bytes[i] as usize];
+            let b2 = DECODE[bytes[i + 1] as usize];
+            let b3 = DECODE[bytes[i + 2] as usize];
+            let b4 = DECODE[bytes[i + 3] as usize];
+            if b1 == 255 || b2 == 255 || b3 == 255 || b4 == 255 {
+                return Err(anyhow!("Invalid base64 input"));
+            }
+            output.push((b1 << 2) | (b2 >> 4));
+            output.push((b2 << 4) | (b3 >> 2));
+            output.push((b3 << 6) | b4);
+            i += 4;
+        } else if remaining == 3 {
+            let b1 = DECODE[bytes[i] as usize];
+            let b2 = DECODE[bytes[i + 1] as usize];
+            let b3 = DECODE[bytes[i + 2] as usize];
+            if b1 == 255 || b2 == 255 || b3 == 255 {
+                return Err(anyhow!("Invalid base64 input"));
+            }
+            output.push((b1 << 2) | (b2 >> 4));
+            output.push((b2 << 4) | (b3 >> 2));
+            break;
+        } else if remaining == 2 {
+            let b1 = DECODE[bytes[i] as usize];
+            let b2 = DECODE[bytes[i + 1] as usize];
+            if b1 == 255 || b2 == 255 {
+                return Err(anyhow!("Invalid base64 input"));
+            }
+            output.push((b1 << 2) | (b2 >> 4));
+            break;
+        } else {
+            return Err(anyhow!("Invalid base64 input"));
+        }
+    }
+
+    Ok(output)
 }
 
 #[cfg(test)]
@@ -256,5 +401,90 @@ mod tests {
 
         let result = anonymizer.anonymize(text, entities, &config);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_dek_round_trip() {
+        let dek = [0x42u8; 32];
+        let anonymizer = EncryptAnonymizer::with_dek(dek);
+        let original = "sensitive_pii_value";
+
+        let envelope = anonymizer.seal_with_dek(original).unwrap();
+        let decrypted = EncryptAnonymizer::decrypt_with_dek(&dek, &envelope).unwrap();
+
+        assert_eq!(decrypted, original);
+    }
+
+    #[test]
+    fn test_dek_different_nonces_produce_different_ciphertext() {
+        let dek = [0x11u8; 32];
+        let anonymizer = EncryptAnonymizer::with_dek(dek);
+        let plaintext = "same_plaintext";
+
+        let envelope_a = anonymizer.seal_with_dek(plaintext).unwrap();
+        let envelope_b = anonymizer.seal_with_dek(plaintext).unwrap();
+
+        assert_ne!(envelope_a, envelope_b);
+        assert_eq!(
+            EncryptAnonymizer::decrypt_with_dek(&dek, &envelope_a).unwrap(),
+            plaintext
+        );
+        assert_eq!(
+            EncryptAnonymizer::decrypt_with_dek(&dek, &envelope_b).unwrap(),
+            plaintext
+        );
+    }
+
+    #[test]
+    fn test_dek_wrong_key_fails_to_decrypt() {
+        let dek = [0x01u8; 32];
+        let wrong_dek = [0x02u8; 32];
+        let anonymizer = EncryptAnonymizer::with_dek(dek);
+
+        let envelope = anonymizer.seal_with_dek("secret").unwrap();
+        let result = EncryptAnonymizer::decrypt_with_dek(&wrong_dek, &envelope);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_dek_version_byte_mismatch_errors() {
+        let dek = [0x99u8; 32];
+        let anonymizer = EncryptAnonymizer::with_dek(dek);
+        let envelope = anonymizer.seal_with_dek("secret").unwrap();
+        let mut bytes = base64_decode(&envelope).unwrap();
+        bytes[0] = 0x02;
+        let bad_envelope = base64_encode(&bytes);
+
+        let result = EncryptAnonymizer::decrypt_with_dek(&dek, &bad_envelope);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Unsupported envelope version"));
+    }
+
+    #[test]
+    fn test_dek_anonymize_without_password() {
+        let dek = [0x55u8; 32];
+        let anonymizer = EncryptAnonymizer::with_dek(dek);
+        let text = "Email: john@example.com";
+        let entities = vec![RecognizerResult::new(
+            EntityType::EmailAddress,
+            7,
+            23,
+            0.9,
+            "test",
+        )];
+        let config = AnonymizerConfig::default();
+
+        let result = anonymizer.anonymize(text, entities, &config).unwrap();
+        let token = result.tokens.as_ref().unwrap().first().unwrap();
+
+        assert!(result.text.contains("<TOKEN_"));
+        assert_eq!(
+            EncryptAnonymizer::decrypt_with_dek(&dek, &token.original_value).unwrap(),
+            "john@example.com"
+        );
     }
 }


### PR DESCRIPTION
## Summary
Adds `EncryptAnonymizer::with_dek` / `decrypt_with_dek` (HKDF-derived DEK + AES-256-GCM v1 envelope, no PBKDF2 per entity). Legacy password path unchanged. Ignored NER analyze route test.

## Linear
Rolls up to [ENG-76](https://linear.app/censgate/issue/ENG-76) — Wave 7 production stabilization.

## BOM
Library-only for Wave 7 prod: platform/docent seal locally. Merge for completeness + tests.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p redact-core test_dek` (5 DEK tests green)

## Test plan
- [ ] CI green on PR

Made with [Cursor](https://cursor.com)