### PR TITLE
feat: add CLI exit codes, multi-file input, and WASM pattern-only bindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,29 @@ jobs:
       - name: Run doc tests
         run: cargo test --workspace --doc
 
+  wasm:
+    name: WASM (pattern-only)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      # Phase 1 WASM scope: the pattern engine from redact-core compiles to
+      # wasm32-unknown-unknown. NER (redact-ner / ONNX) is intentionally not
+      # part of this build — see the README "WebAssembly" section.
+      - name: Check redact-wasm compiles for wasm32
+        run: cargo check --target wasm32-unknown-unknown -p redact-wasm
+
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,16 +67,36 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      # Pin wasm-pack; taiki-e/install-action is widely used and keeps tools
+      # version-pinned without relying on Node 16-era third-party actions.
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@0.13.1
+
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          key: wasm
 
       # Phase 1 WASM scope: the pattern engine from redact-core compiles to
       # wasm32-unknown-unknown. NER (redact-ner / ONNX) is intentionally not
       # part of this build — see the README "WebAssembly" section.
+      # Supported entry point is `redact-wasm` only (not standalone redact-core).
       - name: Check redact-wasm compiles for wasm32
         run: cargo check --target wasm32-unknown-unknown -p redact-wasm
+
+      # Execute bindings under Node (wasm-bindgen-test). Proves constructor,
+      # analyze (Timer/Instant path), anonymize, supported_entities, and the
+      # salted-hash error/success contract actually run on wasm32-unknown-unknown.
+      - name: Run WASM runtime tests (Node)
+        run: wasm-pack test --node crates/redact-wasm
 
   coverage:
     name: Code Coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- CLI: `redact analyze --fail-on-detect` opt-in flag exits with code 1 when PII is
+  detected, for CI gates and pre-commit hooks. Default behavior (exit 0 on success)
+  is unchanged (#95).
+- CLI: `redact analyze -i`/`--file` now accepts multiple paths (`-i f1 f2` or repeated
+  `-i f1 -i f2`). Text output prints a `--- <path> ---` header per file; JSON output
+  for multiple files is a single array of `{ "file", "result" }` objects. Single-file
+  and inline-text output are unchanged (#94).
+- WASM: `redact-wasm` now exposes a real `RedactEngine` backed by `redact-core`'s
+  pattern engine (36 entity types) via `wasm-bindgen`, with `analyze`, `anonymize`,
+  and `supported_entities` bindings. Compiles for `wasm32-unknown-unknown`; covered
+  by a new CI job.
+
+### Changed
+
+- `redact-core`: `Instant::now()` (which panics on `wasm32-unknown-unknown`) is now
+  gated behind a `Timer` helper so the engine is WASM-safe; native timing behavior is
+  unchanged.
+- `chrono` workspace dependency now disables default `clock` feature (only the
+  `DateTime<Utc>` type and `serde` are used); no behavior change for native builds.
+- WASM scope: NER (`PERSON`, `ORGANIZATION`, `LOCATION` in prose) is not available in
+  the WASM build because the ONNX model + runtime do not fit browser/Cloudflare Workers
+  limits. See the README "WebAssembly" section for the hybrid alternative.
+
 ### Security
 
 - Bump `openssl` to 0.10.80 to fix CVE-2026-45784 (GHSA-phqj-4mhp-q6mq, out-of-bounds write in AES-KW-PAD cipher path)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for multiple files is a single array of `{ "file", "result" }` objects. Single-file
   and inline-text output are unchanged (#94).
 - WASM: `redact-wasm` now exposes a real `RedactEngine` backed by `redact-core`'s
-  pattern engine (36 entity types) via `wasm-bindgen`, with `analyze`, `anonymize`,
-  and `supported_entities` bindings. Compiles for `wasm32-unknown-unknown`; covered
-  by a new CI job.
+  pattern engine (36 entity types) via `wasm-bindgen`, with `analyze`,
+  `anonymize` (replace/mask), `anonymize_with_hash` (required non-empty salt),
+  and `supported_entities` bindings. Compiles for `wasm32-unknown-unknown`; CI
+  runs `cargo check` plus Node `wasm-pack test` runtime coverage. `redact-wasm`
+  is the only supported WASM entry point (standalone `redact-core` wasm32 builds
+  are not supported).
 
 ### Changed
 
@@ -34,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- WASM: `anonymize(..., "hash")` is rejected; unsalted hashing of low-entropy PII
+  is enumerable. Callers must use `anonymize_with_hash(text, salt)` with
+  non-empty caller-provided salt for deterministic pseudonymization (no random
+  salt is generated).
 - Bump `openssl` to 0.10.80 to fix CVE-2026-45784 (GHSA-phqj-4mhp-q6mq, out-of-bounds write in AES-KW-PAD cipher path)
 - Bump `rand` to 0.9.3 to fix GHSA-cq8v-f236-94qc (unsoundness UB when custom logger accesses ThreadRng during reseeding)
   - Updated transitive dependencies in `quinn-proto` and `tokenizers` that also depended on `rand 0.9.2`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,15 +70,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,12 +382,8 @@ version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
- "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
- "windows-link",
 ]
 
 [[package]]
@@ -1006,11 +993,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1204,30 +1193,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -2305,10 +2270,14 @@ dependencies = [
 name = "redact-wasm"
 version = "0.8.3"
 dependencies = [
+ "getrandom 0.2.17",
+ "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
  "redact-core",
  "serde",
  "serde_json",
+ "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -3461,41 +3430,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "windows-link"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2035,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,7 +465,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -702,7 +713,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -713,7 +724,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -753,7 +764,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -763,7 +774,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -792,7 +803,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1431,7 +1442,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1483,6 +1494,12 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1577,6 +1594,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1612,7 +1639,7 @@ checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1697,6 +1724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1767,7 +1795,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2001,7 +2029,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2280,6 +2308,7 @@ dependencies = [
  "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-bindgen-test",
  "web-sys",
 ]
 
@@ -2561,7 +2590,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2717,6 +2746,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2733,7 +2773,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2802,7 +2842,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2813,7 +2853,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2919,7 +2959,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3012,7 +3052,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3324,7 +3364,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3336,6 +3376,45 @@ checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941c102b3f0c15b6d72a53205e09e6646aafcf2991e18412cc331dbac1806bc0"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26bd6570f39bb1440fd8f01b63461faaf2a3f6078a508e4e54efa99363108d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c29582b14d5bf030b02fa232b9b57faf2afc322d2c61964dd80bad02bf76207"
 
 [[package]]
 name = "wasm-encoder"
@@ -3718,7 +3797,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3734,7 +3813,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3801,7 +3880,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3822,7 +3901,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3842,7 +3921,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3882,7 +3961,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ pbkdf2 = { version = "0.13.0-rc.10", features = ["hmac", "sha2"] }
 rand = "0.10"
 
 # Time handling
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde", "std"] }
 
 # UUID generation
 uuid = { version = "1.23", features = ["v4", "serde"] }

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A production-ready, Rust-based solution designed as a drop-in replacement for Mi
 - **High Performance** — 10-100x faster than Python-based solutions with sub-millisecond inference
 - **Memory Safe** — Rust's borrow checker eliminates entire classes of security vulnerabilities
 - **Production Ready** — 36 pattern-based entity types with validation, plus transformer-based NER
-- **Multi-Platform** — Native server and CLI support
+- **Multi-Platform** — Native server, CLI, and WebAssembly (pattern-only) support
 - **ML-Powered** — Full ONNX Runtime integration for transformer models (BERT, RoBERTa, DistilBERT)
 - **Lightweight** — ~20-50MB memory footprint vs ~300MB for Presidio
 - **Extensible** — Plugin architecture for custom recognizers and anonymization strategies
@@ -74,11 +74,37 @@ redact anonymize --strategy hash "Card: 4532-1234-5678-9010"
 # Analyze a file
 redact analyze -i sensitive_data.txt
 
+# Analyze multiple files at once (`-i` accepts several paths)
+redact analyze -i logs/a.txt logs/b.txt logs/c.txt
+
 # Pipe from stdin
 cat document.txt | redact anonymize --strategy mask
 
 # Output as JSON
 redact analyze --format json "test@example.com" > results.json
+
+# Multiple files as a single JSON array (one document, machine-parseable)
+redact analyze --format json -i logs/a.txt logs/b.txt > results.json
+```
+
+When multiple files are analyzed, text output prints a `--- <path> ---` header before
+each file's results, and JSON output is emitted as a single array of
+`{ "file": "<path>", "result": <AnalysisResult> }` objects. Single-file and inline-text
+output remain unchanged for backward compatibility.
+
+### CI Gates and Pre-commit Hooks
+
+Use `--fail-on-detect` to exit with code 1 when PII is detected, so `redact analyze`
+can gate CI pipelines or git pre-commit hooks. Output is printed normally before the
+non-zero exit. The flag is opt-in — without it, `analyze` exits 0 on success regardless
+of detections, preserving existing behavior.
+
+```bash
+# Fail the build if a file contains PII
+redact analyze --fail-on-detect -i secrets-check.txt
+
+# Pre-commit hook example
+redact analyze --fail-on-detect -i "$(git diff --cached --name-only)" || exit 1
 ```
 
 ### Filter by Entity Type
@@ -88,6 +114,53 @@ redact analyze --entities EmailAddress --entities UsSsn \
   "Email: test@example.com, SSN: 123-45-6789, Phone: (555) 123-4567"
 # Only detects EmailAddress and UsSsn, ignores PhoneNumber
 ```
+
+## WebAssembly
+
+The `redact-wasm` crate compiles `redact-core`'s **pattern engine** to
+`wasm32-unknown-unknown` for use in browsers and edge runtimes such as
+Cloudflare Workers. It exposes a `RedactEngine` with `analyze`, `anonymize`, and
+`supported_entities` via `wasm-bindgen`.
+
+```bash
+# Build (requires wasm-pack and the wasm32-unknown-unknown target)
+rustup target add wasm32-unknown-unknown
+cargo install wasm-pack
+wasm-pack build --target web crates/redact-wasm
+```
+
+### What is available
+
+All **36 pattern-based entity types** (email, phone, SSN, credit cards, IBAN, UK
+identifiers, crypto addresses, hashes, GUIDs, URLs, IP, dates, ...) and the
+replace/mask/hash anonymization strategies. Typical bundle size is ~1-3 MB.
+
+### What is NOT available in WASM
+
+Contextual named-entity recognition — `PERSON`, `ORGANIZATION`, `LOCATION` in
+prose like "John met Acme in Boston" — requires an ONNX transformer model
+(~250-420 MB) plus the ONNX Runtime. That stack does not fit Cloudflare Workers
+(128 MB isolate, 64 MiB bundle, ~50 ms CPU) and is impractical to inline in a
+browser module. For name-based detection, use a **hybrid architecture**:
+
+```mermaid
+sequenceDiagram
+  participant Client
+  participant Worker as CF Worker (pattern WASM)
+  participant API as redact-api :full or Workers AI
+
+  Client->>Worker: text
+  Worker->>Worker: pattern PII scan locally
+  alt names / orgs / locations needed
+    Worker->>API: NER subset request
+    API-->>Worker: PERSON / ORG / LOC spans
+  end
+  Worker-->>Client: merged redaction result
+```
+
+This tiered approach keeps fast structured-PII detection at the edge and
+delegates contextual NER to a service boundary (`redact-api` `:full` image or
+Cloudflare Workers AI). Inline WASM NER remains a deferred roadmap item.
 
 ## Installation
 
@@ -544,9 +617,12 @@ See [TEST_COVERAGE.md](/censgate/redact/blob/main/TEST_COVERAGE.md) for detailed
 #### v0.9.0 (Planned)
 
 - [x] Publish crates to crates.io
-- [ ] WebAssembly (WASM) browser support
+- [x] WebAssembly bindings — pattern engine (browser + Cloudflare Workers)
 - [ ] Streaming API for large texts
 - [ ] Enhanced documentation
+- [ ] WebAssembly + inline NER — deferred; ONNX model + runtime do not fit
+      Cloudflare Workers limits. Use the hybrid architecture in the
+      [WebAssembly](#webassembly) section for name-based detection.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ of detections, preserving existing behavior.
 # Fail the build if a file contains PII
 redact analyze --fail-on-detect -i secrets-check.txt
 
-# Pre-commit hook example
-redact analyze --fail-on-detect -i "$(git diff --cached --name-only)" || exit 1
+# Pre-commit hook example (one path per -i argument)
+git diff --cached --name-only -z --diff-filter=ACMRT | xargs -0 redact analyze --fail-on-detect -i || exit 1
 ```
 
 ### Filter by Entity Type

--- a/README.md
+++ b/README.md
@@ -103,8 +103,10 @@ of detections, preserving existing behavior.
 # Fail the build if a file contains PII
 redact analyze --fail-on-detect -i secrets-check.txt
 
-# Pre-commit hook example (one path per -i argument)
-git diff --cached --name-only -z --diff-filter=ACMRT | xargs -0 redact analyze --fail-on-detect -i || exit 1
+# Pre-commit hook example (NUL-safe paths; skip when nothing is staged)
+if [ "$(git diff --cached --name-only -z --diff-filter=ACMRT | wc -c)" -gt 0 ]; then
+  git diff --cached --name-only -z --diff-filter=ACMRT | xargs -0 redact analyze --fail-on-detect -i || exit 1
+fi
 ```
 
 ### Filter by Entity Type
@@ -117,23 +119,42 @@ redact analyze --entities EmailAddress --entities UsSsn \
 
 ## WebAssembly
 
-The `redact-wasm` crate compiles `redact-core`'s **pattern engine** to
-`wasm32-unknown-unknown` for use in browsers and edge runtimes such as
-Cloudflare Workers. It exposes a `RedactEngine` with `analyze`, `anonymize`, and
+The **`redact-wasm`** crate is the supported WASM entry point. It compiles
+`redact-core`'s **pattern engine** to `wasm32-unknown-unknown` for browsers and
+edge runtimes such as Cloudflare Workers, and wires the JS RNG backends
+(`getrandom` / `uuid`) required on that target. Compiling `redact-core` alone
+for `wasm32-unknown-unknown` is **not** supported.
+
+It exposes a `RedactEngine` with `analyze`, `anonymize` (replace/mask),
+`anonymize_with_hash` (requires a non-empty caller-provided salt), and
 `supported_entities` via `wasm-bindgen`.
 
 ```bash
 # Build (requires wasm-pack and the wasm32-unknown-unknown target)
 rustup target add wasm32-unknown-unknown
-cargo install wasm-pack
+cargo install wasm-pack --version 0.13.1
 wasm-pack build --target web crates/redact-wasm
+
+# Runtime tests under Node (wasm-bindgen-test)
+wasm-pack test --node crates/redact-wasm
+```
+
+```js
+import init, { RedactEngine } from "./pkg/redact_wasm.js";
+await init();
+const engine = new RedactEngine();
+engine.analyze("Contact john@example.com");
+engine.anonymize("Email: john@example.com", "replace");
+// Hash requires caller-provided salt (never generated randomly):
+engine.anonymize_with_hash("SSN 123-45-6789", "app-secret-salt");
 ```
 
 ### What is available
 
 All **36 pattern-based entity types** (email, phone, SSN, credit cards, IBAN, UK
 identifiers, crypto addresses, hashes, GUIDs, URLs, IP, dates, ...) and the
-replace/mask/hash anonymization strategies. Typical bundle size is ~1-3 MB.
+replace/mask anonymization strategies, plus salted hash via
+`anonymize_with_hash`. Typical bundle size is ~1-3 MB.
 
 ### What is NOT available in WASM
 

--- a/crates/redact-cli/src/main.rs
+++ b/crates/redact-cli/src/main.rs
@@ -9,9 +9,8 @@ use anyhow::Result;
 use clap::{Parser, Subcommand, ValueEnum};
 use redact_core::{
     anonymizers::{AnonymizationStrategy, AnonymizerConfig},
-    AnalyzerEngine, EntityType,
+    AnalysisResult, AnalyzerEngine, EntityType,
 };
-use serde_json;
 use std::io::{self, Read};
 use std::path::PathBuf;
 
@@ -39,22 +38,31 @@ enum Commands {
         /// Text to analyze (reads from stdin if not provided)
         text: Option<String>,
 
-        /// Read from file instead
-        #[arg(short = 'i', long)]
-        file: Option<PathBuf>,
+        /// Read from file(s) instead. Accepts multiple paths: `-i f1 f2` or repeated `-i f1 -i f2`.
+        #[arg(short = 'i', long, num_args = 1..)]
+        files: Vec<PathBuf>,
 
         /// Entity types to detect (all if not specified)
         #[arg(short, long)]
         entities: Vec<String>,
+
+        /// Exit with code 1 when PII entities are detected.
+        ///
+        /// Useful for CI gates and pre-commit hooks. Output is printed
+        /// normally before exiting. Default (off) preserves existing
+        /// behavior of exiting 0 on successful analysis regardless of
+        /// detections.
+        #[arg(long, alias = "fail-on-detection", visible_alias = "fail-on-find")]
+        fail_on_detect: bool,
     },
     /// Anonymize detected PII
     Anonymize {
         /// Text to anonymize (reads from stdin if not provided)
         text: Option<String>,
 
-        /// Read from file instead
-        #[arg(short = 'i', long)]
-        file: Option<PathBuf>,
+        /// Read from file(s) instead. Accepts multiple paths: `-i f1 f2` or repeated `-i f1 -i f2`.
+        #[arg(short = 'i', long, num_args = 1..)]
+        files: Vec<PathBuf>,
 
         /// Anonymization strategy
         #[arg(short, long, value_enum, default_value = "replace")]
@@ -104,26 +112,30 @@ fn run() -> Result<()> {
     match cli.command {
         Commands::Analyze {
             text,
-            file,
+            files,
             entities,
+            fail_on_detect,
         } => {
-            let input = get_input(text, file)?;
+            let inputs = collect_inputs(text, &files)?;
             let entity_types = parse_entity_types(&entities)?;
-            analyze(&input, &cli.language, entity_types, cli.format)?;
+            let detected = analyze(&inputs, &cli.language, &entity_types, cli.format)?;
+            if fail_on_detect && detected > 0 {
+                std::process::exit(1);
+            }
         }
         Commands::Anonymize {
             text,
-            file,
+            files,
             strategy,
             entities,
         } => {
-            let input = get_input(text, file)?;
+            let inputs = collect_inputs(text, &files)?;
             let entity_types = parse_entity_types(&entities)?;
             anonymize(
-                &input,
+                &inputs,
                 &cli.language,
                 strategy.into(),
-                entity_types,
+                &entity_types,
                 cli.format,
             )?;
         }
@@ -132,17 +144,26 @@ fn run() -> Result<()> {
     Ok(())
 }
 
-fn get_input(text: Option<String>, file: Option<PathBuf>) -> Result<String> {
+fn collect_inputs(
+    text: Option<String>,
+    files: &[PathBuf],
+) -> Result<Vec<(Option<String>, String)>> {
     if let Some(text) = text {
-        Ok(text)
-    } else if let Some(file_path) = file {
-        Ok(std::fs::read_to_string(file_path)?)
-    } else {
-        // Read from stdin
-        let mut buffer = String::new();
-        io::stdin().read_to_string(&mut buffer)?;
-        Ok(buffer)
+        return Ok(vec![(None, text)]);
     }
+    if !files.is_empty() {
+        let mut inputs = Vec::with_capacity(files.len());
+        for f in files {
+            let content = std::fs::read_to_string(f)
+                .map_err(|e| anyhow::anyhow!("Failed to read {}: {}", f.display(), e))?;
+            inputs.push((Some(f.display().to_string()), content));
+        }
+        return Ok(inputs);
+    }
+    // Read from stdin
+    let mut buffer = String::new();
+    io::stdin().read_to_string(&mut buffer)?;
+    Ok(vec![(None, buffer)])
 }
 
 fn parse_entity_types(entities: &[String]) -> Result<Option<Vec<EntityType>>> {
@@ -206,86 +227,123 @@ fn parse_entity_types(entities: &[String]) -> Result<Option<Vec<EntityType>>> {
 }
 
 fn analyze(
-    text: &str,
+    inputs: &[(Option<String>, String)],
     language: &str,
-    entity_types: Option<Vec<EntityType>>,
+    entity_types: &Option<Vec<EntityType>>,
     format: OutputFormat,
-) -> Result<()> {
+) -> Result<usize> {
     let engine = AnalyzerEngine::new();
+    let multi = inputs.len() > 1;
+    let is_json = matches!(format, OutputFormat::Json);
+    let mut total = 0;
+    let mut json_entries: Vec<serde_json::Value> = Vec::new();
 
-    let result = if let Some(types) = entity_types {
-        engine.analyze_with_entities(text, &types, Some(language))?
-    } else {
-        engine.analyze(text, Some(language))?
-    };
+    for (label, content) in inputs {
+        let result = if let Some(types) = entity_types {
+            engine.analyze_with_entities(content, types, Some(language))?
+        } else {
+            engine.analyze(content, Some(language))?
+        };
+        total += result.detected_entities.len();
 
-    match format {
-        OutputFormat::Json => {
-            println!("{}", serde_json::to_string_pretty(&result)?);
-        }
-        OutputFormat::Text => {
-            if result.detected_entities.is_empty() {
-                println!("No PII entities detected.");
+        if is_json {
+            if multi {
+                let entry = serde_json::json!({
+                    "file": label,
+                    "result": serde_json::to_value(&result)?,
+                });
+                json_entries.push(entry);
             } else {
-                println!(
-                    "Detected {} PII entities:\n",
-                    result.detected_entities.len()
-                );
-                for entity in &result.detected_entities {
-                    let text_preview = entity.text.as_deref().unwrap_or("");
-                    println!(
-                        "  {:?} at {}..{} (score: {:.2}): {}",
-                        entity.entity_type, entity.start, entity.end, entity.score, text_preview
-                    );
-                }
-                println!(
-                    "\nProcessing time: {}ms",
-                    result.metadata.processing_time_ms
-                );
+                println!("{}", serde_json::to_string_pretty(&result)?);
             }
+        } else {
+            if multi {
+                println!("--- {} ---", label.as_deref().unwrap_or("stdin"));
+            }
+            print_analysis_text(&result);
         }
     }
 
-    Ok(())
+    if is_json && multi {
+        println!("{}", serde_json::to_string_pretty(&json_entries)?);
+    }
+
+    Ok(total)
+}
+
+fn print_analysis_text(result: &AnalysisResult) {
+    if result.detected_entities.is_empty() {
+        println!("No PII entities detected.");
+    } else {
+        println!(
+            "Detected {} PII entities:\n",
+            result.detected_entities.len()
+        );
+        for entity in &result.detected_entities {
+            let text_preview = entity.text.as_deref().unwrap_or("");
+            println!(
+                "  {:?} at {}..{} (score: {:.2}): {}",
+                entity.entity_type, entity.start, entity.end, entity.score, text_preview
+            );
+        }
+        println!(
+            "\nProcessing time: {}ms",
+            result.metadata.processing_time_ms
+        );
+    }
 }
 
 fn anonymize(
-    text: &str,
+    inputs: &[(Option<String>, String)],
     language: &str,
     strategy: AnonymizationStrategy,
-    entity_types: Option<Vec<EntityType>>,
+    entity_types: &Option<Vec<EntityType>>,
     format: OutputFormat,
 ) -> Result<()> {
     let engine = AnalyzerEngine::new();
-
-    // First analyze with entity type filtering if specified
-    let analysis = if let Some(ref types) = entity_types {
-        engine.analyze_with_entities(text, types, Some(language))?
-    } else {
-        engine.analyze(text, Some(language))?
-    };
-
     let config = AnonymizerConfig {
         strategy,
         ..Default::default()
     };
+    let multi = inputs.len() > 1;
+    let is_json = matches!(format, OutputFormat::Json);
+    let mut json_entries: Vec<serde_json::Value> = Vec::new();
 
-    // Then anonymize the detected entities
-    let anonymized = engine.anonymizer_registry().anonymize(
-        text,
-        analysis.detected_entities.clone(),
-        &config,
-    )?;
+    for (label, content) in inputs {
+        let analysis = if let Some(ref types) = entity_types {
+            engine.analyze_with_entities(content, types, Some(language))?
+        } else {
+            engine.analyze(content, Some(language))?
+        };
 
-    match format {
-        OutputFormat::Json => {
+        let anonymized = engine.anonymizer_registry().anonymize(
+            content,
+            analysis.detected_entities.clone(),
+            &config,
+        )?;
+
+        if is_json {
             let mut result = analysis;
             result.anonymized = Some(anonymized);
-            println!("{}", serde_json::to_string_pretty(&result)?);
-        }
-        OutputFormat::Text => {
+            if multi {
+                let entry = serde_json::json!({
+                    "file": label,
+                    "result": serde_json::to_value(&result)?,
+                });
+                json_entries.push(entry);
+            } else {
+                println!("{}", serde_json::to_string_pretty(&result)?);
+            }
+        } else {
+            if multi {
+                println!("--- {} ---", label.as_deref().unwrap_or("stdin"));
+            }
             println!("{}", anonymized.text);
         }
+    }
+
+    if is_json && multi {
+        println!("{}", serde_json::to_string_pretty(&json_entries)?);
     }
 
     Ok(())

--- a/crates/redact-cli/src/main.rs
+++ b/crates/redact-cli/src/main.rs
@@ -39,7 +39,7 @@ enum Commands {
         text: Option<String>,
 
         /// Read from file(s) instead. Accepts multiple paths: `-i f1 f2` or repeated `-i f1 -i f2`.
-        #[arg(short = 'i', long, num_args = 1..)]
+        #[arg(short = 'i', long = "file", alias = "files", num_args = 1..)]
         files: Vec<PathBuf>,
 
         /// Entity types to detect (all if not specified)
@@ -61,7 +61,7 @@ enum Commands {
         text: Option<String>,
 
         /// Read from file(s) instead. Accepts multiple paths: `-i f1 f2` or repeated `-i f1 -i f2`.
-        #[arg(short = 'i', long, num_args = 1..)]
+        #[arg(short = 'i', long = "file", alias = "files", num_args = 1..)]
         files: Vec<PathBuf>,
 
         /// Anonymization strategy

--- a/crates/redact-cli/tests/cli_integration.rs
+++ b/crates/redact-cli/tests/cli_integration.rs
@@ -390,3 +390,234 @@ fn test_multiple_entity_filters() {
         .stdout(predicate::str::contains("UsSsn"))
         .stdout(predicate::str::contains("PhoneNumber").not());
 }
+
+#[test]
+fn test_fail_on_detect_clean_text_exits_zero() {
+    cli()
+        .arg("analyze")
+        .arg("--fail-on-detect")
+        .arg("This text has no PII")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No PII entities detected"));
+}
+
+#[test]
+fn test_fail_on_detect_with_pii_exits_nonzero() {
+    cli()
+        .arg("analyze")
+        .arg("--fail-on-detect")
+        .arg("Contact me at john@example.com")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("EmailAddress"))
+        .stdout(predicate::str::contains("john@example.com"));
+}
+
+#[test]
+fn test_fail_on_detect_json_output_with_pii_exits_nonzero() {
+    cli()
+        .arg("--format")
+        .arg("json")
+        .arg("analyze")
+        .arg("--fail-on-detect")
+        .arg("Email: john@example.com")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("detected_entities"))
+        .stdout(predicate::str::contains("EMAIL_ADDRESS"));
+}
+
+#[test]
+fn test_fail_on_detect_flag_off_by_default() {
+    // Without the flag, PII detection must still exit 0 (backwards compatible).
+    cli()
+        .arg("analyze")
+        .arg("Contact me at john@example.com")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("EmailAddress"));
+}
+
+#[test]
+fn test_fail_on_detect_from_file_exits_nonzero() {
+    let mut temp_file = NamedTempFile::new().unwrap();
+    writeln!(temp_file, "Contact: john@example.com").unwrap();
+    temp_file.flush().unwrap();
+
+    cli()
+        .arg("analyze")
+        .arg("--fail-on-detect")
+        .arg("-i")
+        .arg(temp_file.path())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("EmailAddress"));
+}
+
+#[test]
+fn test_analyze_multiple_files_text() {
+    let mut file_a = NamedTempFile::new().unwrap();
+    writeln!(file_a, "Email: alice@example.com").unwrap();
+    file_a.flush().unwrap();
+
+    let mut file_b = NamedTempFile::new().unwrap();
+    writeln!(file_b, "SSN: 123-45-6789").unwrap();
+    file_b.flush().unwrap();
+
+    cli()
+        .arg("analyze")
+        .arg("-i")
+        .arg(file_a.path())
+        .arg(file_b.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("---"))
+        .stdout(predicate::str::contains("EmailAddress"))
+        .stdout(predicate::str::contains("UsSsn"));
+}
+
+#[test]
+fn test_analyze_multiple_files_json_array() {
+    let mut file_a = NamedTempFile::new().unwrap();
+    writeln!(file_a, "Email: alice@example.com").unwrap();
+    file_a.flush().unwrap();
+
+    let mut file_b = NamedTempFile::new().unwrap();
+    writeln!(file_b, "SSN: 123-45-6789").unwrap();
+    file_b.flush().unwrap();
+
+    let output = cli()
+        .arg("--format")
+        .arg("json")
+        .arg("analyze")
+        .arg("-i")
+        .arg(file_a.path())
+        .arg(file_b.path())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let parsed: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert!(parsed.is_array(), "multi-file JSON output must be an array");
+    let arr = parsed.as_array().unwrap();
+    assert_eq!(arr.len(), 2);
+    assert!(arr[0].get("file").is_some());
+    assert!(arr[0].get("result").is_some());
+    assert!(arr[1].get("file").is_some());
+    assert!(arr[1].get("result").is_some());
+}
+
+#[test]
+fn test_analyze_multiple_files_fail_on_detect_any() {
+    // One clean file, one with PII -> exit 1 because at least one file has detections.
+    let mut file_clean = NamedTempFile::new().unwrap();
+    writeln!(file_clean, "nothing here").unwrap();
+    file_clean.flush().unwrap();
+
+    let mut file_pii = NamedTempFile::new().unwrap();
+    writeln!(file_pii, "Email: alice@example.com").unwrap();
+    file_pii.flush().unwrap();
+
+    cli()
+        .arg("analyze")
+        .arg("--fail-on-detect")
+        .arg("-i")
+        .arg(file_clean.path())
+        .arg(file_pii.path())
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("EmailAddress"));
+}
+
+#[test]
+fn test_analyze_multiple_files_all_clean_exits_zero() {
+    let mut file_a = NamedTempFile::new().unwrap();
+    writeln!(file_a, "nothing here").unwrap();
+    file_a.flush().unwrap();
+
+    let mut file_b = NamedTempFile::new().unwrap();
+    writeln!(file_b, "also clean").unwrap();
+    file_b.flush().unwrap();
+
+    cli()
+        .arg("analyze")
+        .arg("--fail-on-detect")
+        .arg("-i")
+        .arg(file_a.path())
+        .arg(file_b.path())
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_analyze_multiple_files_repeated_flag() {
+    // Backward-compatible repeated -i flags also work.
+    let mut file_a = NamedTempFile::new().unwrap();
+    writeln!(file_a, "Email: alice@example.com").unwrap();
+    file_a.flush().unwrap();
+
+    let mut file_b = NamedTempFile::new().unwrap();
+    writeln!(file_b, "SSN: 123-45-6789").unwrap();
+    file_b.flush().unwrap();
+
+    cli()
+        .arg("analyze")
+        .arg("-i")
+        .arg(file_a.path())
+        .arg("-i")
+        .arg(file_b.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("EmailAddress"))
+        .stdout(predicate::str::contains("UsSsn"));
+}
+
+#[test]
+fn test_anonymize_multiple_files_text() {
+    let mut file_a = NamedTempFile::new().unwrap();
+    writeln!(file_a, "Email: alice@example.com").unwrap();
+    file_a.flush().unwrap();
+
+    let mut file_b = NamedTempFile::new().unwrap();
+    writeln!(file_b, "SSN: 123-45-6789").unwrap();
+    file_b.flush().unwrap();
+
+    cli()
+        .arg("anonymize")
+        .arg("-i")
+        .arg(file_a.path())
+        .arg(file_b.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("---"))
+        .stdout(predicate::str::contains("[EMAIL_ADDRESS]"))
+        .stdout(predicate::str::contains("[US_SSN]"));
+}
+
+#[test]
+fn test_analyze_single_file_json_no_array_wrapper() {
+    // Single-file JSON must remain a bare object (backward compatible), not an array.
+    let mut temp_file = NamedTempFile::new().unwrap();
+    writeln!(temp_file, "Email: john@example.com").unwrap();
+    temp_file.flush().unwrap();
+
+    let output = cli()
+        .arg("--format")
+        .arg("json")
+        .arg("analyze")
+        .arg("-i")
+        .arg(temp_file.path())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let parsed: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert!(parsed.is_object(), "single-file JSON must be an object");
+    assert!(!parsed.is_array());
+    assert!(parsed.get("detected_entities").is_some());
+}

--- a/crates/redact-cli/tests/cli_integration.rs
+++ b/crates/redact-cli/tests/cli_integration.rs
@@ -553,6 +553,21 @@ fn test_analyze_multiple_files_all_clean_exits_zero() {
 }
 
 #[test]
+fn test_analyze_long_file_flag() {
+    let mut file = NamedTempFile::new().unwrap();
+    writeln!(file, "Email: alice@example.com").unwrap();
+    file.flush().unwrap();
+
+    cli()
+        .arg("analyze")
+        .arg("--file")
+        .arg(file.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("EmailAddress"));
+}
+
+#[test]
 fn test_analyze_multiple_files_repeated_flag() {
     // Backward-compatible repeated -i flags also work.
     let mut file_a = NamedTempFile::new().unwrap();

--- a/crates/redact-core/benches/analyzer_benchmarks.rs
+++ b/crates/redact-core/benches/analyzer_benchmarks.rs
@@ -4,11 +4,11 @@
 //! Run specific benchmark: cargo bench --package redact-core --bench analyzer_benchmarks
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use std::hint::black_box;
 use redact_core::{
     anonymizers::{AnonymizationStrategy, AnonymizerConfig},
     AnalyzerEngine, EntityType,
 };
+use std::hint::black_box;
 
 /// Benchmark simple email detection
 fn bench_analyze_email(c: &mut Criterion) {

--- a/crates/redact-core/benches/analyzer_benchmarks.rs
+++ b/crates/redact-core/benches/analyzer_benchmarks.rs
@@ -3,7 +3,8 @@
 //! Run with: cargo bench --package redact-core
 //! Run specific benchmark: cargo bench --package redact-core --bench analyzer_benchmarks
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use std::hint::black_box;
 use redact_core::{
     anonymizers::{AnonymizationStrategy, AnonymizerConfig},
     AnalyzerEngine, EntityType,

--- a/crates/redact-core/src/engine/mod.rs
+++ b/crates/redact-core/src/engine/mod.rs
@@ -9,6 +9,32 @@ use anyhow::Result;
 use std::sync::Arc;
 use std::time::Instant;
 
+/// Monotonic timer for `processing_time_ms`.
+///
+/// `std::time::Instant::now()` is not implemented on `wasm32-unknown-unknown`
+/// (it panics at runtime). On WASM we record no elapsed time; on every other
+/// target we use a real `Instant`, preserving native behavior exactly.
+struct Timer {
+    start: Option<Instant>,
+}
+
+impl Timer {
+    fn new() -> Self {
+        Self {
+            #[cfg(not(target_arch = "wasm32"))]
+            start: Some(Instant::now()),
+            #[cfg(target_arch = "wasm32")]
+            start: None,
+        }
+    }
+
+    fn elapsed_ms(&self) -> u64 {
+        self.start
+            .map(|s| s.elapsed().as_millis() as u64)
+            .unwrap_or(0)
+    }
+}
+
 /// Main analyzer engine that coordinates recognition and anonymization
 #[derive(Debug, Clone)]
 pub struct AnalyzerEngine {
@@ -74,12 +100,12 @@ impl AnalyzerEngine {
 
     /// Analyze text and detect PII entities
     pub fn analyze(&self, text: &str, language: Option<&str>) -> Result<AnalysisResult> {
-        let start = Instant::now();
+        let start = Timer::new();
         let lang = language.unwrap_or(&self.default_language);
 
         let detected_entities = self.recognizer_registry.analyze(text, lang)?;
 
-        let processing_time_ms = start.elapsed().as_millis() as u64;
+        let processing_time_ms = start.elapsed_ms();
 
         Ok(AnalysisResult {
             original_text: None,
@@ -101,14 +127,14 @@ impl AnalyzerEngine {
         entity_types: &[EntityType],
         language: Option<&str>,
     ) -> Result<AnalysisResult> {
-        let start = Instant::now();
+        let start = Timer::new();
         let lang = language.unwrap_or(&self.default_language);
 
         let detected_entities =
             self.recognizer_registry
                 .analyze_with_entities(text, lang, entity_types)?;
 
-        let processing_time_ms = start.elapsed().as_millis() as u64;
+        let processing_time_ms = start.elapsed_ms();
 
         Ok(AnalysisResult {
             original_text: None,
@@ -147,7 +173,7 @@ impl AnalyzerEngine {
         language: Option<&str>,
         config: &AnonymizerConfig,
     ) -> Result<AnalysisResult> {
-        let start = Instant::now();
+        let start = Timer::new();
         let lang = language.unwrap_or(&self.default_language);
 
         // Analyze
@@ -159,7 +185,7 @@ impl AnalyzerEngine {
                 .anonymize(text, result.detected_entities.clone(), config)?;
 
         result.anonymized = Some(anonymized);
-        result.metadata.processing_time_ms = start.elapsed().as_millis() as u64;
+        result.metadata.processing_time_ms = start.elapsed_ms();
 
         Ok(result)
     }

--- a/crates/redact-core/src/lib.rs
+++ b/crates/redact-core/src/lib.rs
@@ -13,8 +13,14 @@
 //! - **NER Support**: Named Entity Recognition using ONNX Runtime (via redact-ner)
 //! - **Multiple Anonymization Strategies**: Replace, mask, hash, encrypt
 //! - **Policy-Aware**: Configurable rules and thresholds
-//! - **Multi-platform**: Server, WASM, mobile support
+//! - **Multi-platform**: Server, CLI, and (via `redact-wasm`) WebAssembly
 //! - **High Performance**: Zero-copy where possible, efficient overlap resolution
+//!
+//! # WebAssembly
+//!
+//! For `wasm32-unknown-unknown`, use the **`redact-wasm`** crate as the supported
+//! entry point. It enables the JS RNG backends (`getrandom` / `uuid`) required by
+//! this crate on WASM. Building `redact-core` alone for wasm32 is not supported.
 //!
 //! # Example
 //!

--- a/crates/redact-wasm/Cargo.toml
+++ b/crates/redact-wasm/Cargo.toml
@@ -22,3 +22,13 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 js-sys = { workspace = true }
 web-sys = { workspace = true, features = ["console"] }
+
+# WASM-only: enable the JavaScript backend for `getrandom` so that `rand`/`uuid`
+# (used by redact-core's anonymizers) compile on wasm32-unknown-unknown.
+# Multiple `getrandom` major versions appear in the dependency graph; each needs
+# its own wasm feature enabled (js for 0.2, wasm_js for 0.3+).
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
+getrandom03 = { package = "getrandom", version = "0.3", default-features = false, features = ["wasm_js"] }
+getrandom04 = { package = "getrandom", version = "0.4", default-features = false, features = ["wasm_js"] }
+uuid = { workspace = true, features = ["js"] }

--- a/crates/redact-wasm/Cargo.toml
+++ b/crates/redact-wasm/Cargo.toml
@@ -32,3 +32,6 @@ getrandom = { version = "0.2", features = ["js"] }
 getrandom03 = { package = "getrandom", version = "0.3", default-features = false, features = ["wasm_js"] }
 getrandom04 = { package = "getrandom", version = "0.4", default-features = false, features = ["wasm_js"] }
 uuid = { workspace = true, features = ["js"] }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"

--- a/crates/redact-wasm/src/lib.rs
+++ b/crates/redact-wasm/src/lib.rs
@@ -2,24 +2,231 @@
 // Licensed under the Apache License, Version 2.0. See the LICENSE file
 // in the project root for license information.
 
-//! WASM bindings for Redact PII engine
-//! Placeholder - will provide browser/mobile bindings
+//! WebAssembly bindings for the Redact PII engine.
+//!
+//! ## Scope
+//!
+//! These bindings expose the **pattern-based** detection and anonymization from
+//! [`redact_core`]: the 36 regex entity types (email, phone, SSN, credit cards,
+//! IBAN, UK identifiers, crypto addresses, hashes, GUIDs, URLs, IP, dates, ...).
+//! No ML model is loaded, so the module stays small (~1-3 MB) and fits browser
+//! and Cloudflare Workers limits.
+//!
+//! ## What is NOT available in WASM
+//!
+//! Contextual named-entity recognition — `PERSON`, `ORGANIZATION`, `LOCATION` in
+//! prose like "John met Acme in Boston" — requires an ONNX transformer model
+//! (~250-420 MB) plus the ONNX Runtime. That stack does not fit Cloudflare
+//! Workers (128 MB isolate, 64 MiB bundle, ~50 ms CPU) and is impractical to
+//! inline in a browser WASM module. For name-based detection, call the
+//! `redact-api` `:full` service or Cloudflare Workers AI from a Worker and merge
+//! the results. See the repository README "WebAssembly" section.
+//!
+//! ## Example (JavaScript)
+//!
+//! ```no_run
+//! use redact_wasm::RedactEngine;
+//! let engine = RedactEngine::new();
+//! let analysis = engine.analyze("Contact john@example.com");
+//! let redacted = engine.anonymize("Email: john@example.com", "replace");
+//! ```
+//!
+//! Both `analyze` and `anonymize` return a JSON string.
 
+use redact_core::{
+    anonymizers::{AnonymizationStrategy, AnonymizerConfig},
+    AnalyzerEngine,
+};
 use wasm_bindgen::prelude::*;
 
+/// PII detection and anonymization engine (pattern-based, 36 entity types).
 #[wasm_bindgen]
 pub struct RedactEngine {
-    // Placeholder
+    engine: AnalyzerEngine,
 }
 
 #[wasm_bindgen]
 impl RedactEngine {
+    /// Create a new engine with the default pattern recognizer.
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
-        Self {}
+        Self {
+            engine: AnalyzerEngine::new(),
+        }
     }
 
+    /// Analyze `text` and return a JSON `AnalysisResult` string.
+    ///
+    /// Returns `{"error": "..."}` if analysis or serialization fails.
     pub fn analyze(&self, text: &str) -> String {
-        format!("Analysis placeholder for: {}", text)
+        match self.engine.analyze(text, Some("en")) {
+            Ok(result) => serde_json::to_string(&result).unwrap_or_else(|_| {
+                r#"{"error":"failed to serialize analysis result"}"#.to_string()
+            }),
+            Err(e) => serde_json::json!({ "error": e.to_string() }).to_string(),
+        }
+    }
+
+    /// Anonymize `text` with the given strategy and return a JSON `AnalysisResult`
+    /// string (with `anonymized` populated).
+    ///
+    /// `strategy` is one of `replace`, `mask`, `hash`, or `encrypt` (case-insensitive).
+    /// `encrypt` requires key material that this default binding does not provide;
+    /// it will return an `{"error": "..."}` object. Use `replace`, `mask`, or `hash`
+    /// from the browser/Worker.
+    pub fn anonymize(&self, text: &str, strategy: &str) -> String {
+        let strat = match parse_strategy(strategy) {
+            Ok(s) => s,
+            Err(msg) => return serde_json::json!({ "error": msg }).to_string(),
+        };
+        let config = AnonymizerConfig {
+            strategy: strat,
+            ..Default::default()
+        };
+        match self.engine.analyze_and_anonymize(text, Some("en"), &config) {
+            Ok(result) => serde_json::to_string(&result).unwrap_or_else(|_| {
+                r#"{"error":"failed to serialize anonymized result"}"#.to_string()
+            }),
+            Err(e) => serde_json::json!({ "error": e.to_string() }).to_string(),
+        }
+    }
+
+    /// Return a JSON array of the entity type strings the pattern recognizer detects.
+    ///
+    /// Useful for callers to know which entities are available in the WASM build
+    /// (versus NER-only types like `PERSON`/`ORGANIZATION`/`LOCATION`).
+    pub fn supported_entities(&self) -> String {
+        serde_json::to_string(SUPPORTED_ENTITY_TYPES).unwrap_or_else(|_| "[]".to_string())
+    }
+}
+
+fn parse_strategy(s: &str) -> Result<AnonymizationStrategy, String> {
+    match s.to_ascii_lowercase().as_str() {
+        "replace" => Ok(AnonymizationStrategy::Replace),
+        "mask" => Ok(AnonymizationStrategy::Mask),
+        "hash" => Ok(AnonymizationStrategy::Hash),
+        "encrypt" => Ok(AnonymizationStrategy::Encrypt),
+        other => Err(format!(
+            "Unknown strategy '{}': expected one of replace, mask, hash, encrypt",
+            other
+        )),
+    }
+}
+
+impl Default for RedactEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Entity types available in the WASM (pattern-only) build.
+///
+/// NER-only types (`PERSON`, `ORGANIZATION`, `LOCATION`) are intentionally absent;
+/// see the crate-level docs for the rationale and the hybrid alternative.
+static SUPPORTED_ENTITY_TYPES: &[&str] = &[
+    "EMAIL_ADDRESS",
+    "PHONE_NUMBER",
+    "IP_ADDRESS",
+    "URL",
+    "DOMAIN_NAME",
+    "CREDIT_CARD",
+    "IBAN_CODE",
+    "US_BANK_NUMBER",
+    "US_SSN",
+    "US_DRIVER_LICENSE",
+    "US_PASSPORT",
+    "US_ZIP_CODE",
+    "UK_NHS",
+    "UK_NINO",
+    "UK_POSTCODE",
+    "UK_DRIVER_LICENSE",
+    "UK_PASSPORT_NUMBER",
+    "UK_PHONE_NUMBER",
+    "UK_MOBILE_NUMBER",
+    "UK_SORT_CODE",
+    "UK_COMPANY_NUMBER",
+    "MEDICAL_LICENSE",
+    "MEDICAL_RECORD_NUMBER",
+    "PASSPORT_NUMBER",
+    "AGE",
+    "ISBN",
+    "PO_BOX",
+    "CRYPTO_WALLET",
+    "BTC_ADDRESS",
+    "ETH_ADDRESS",
+    "GUID",
+    "MAC_ADDRESS",
+    "MD5_HASH",
+    "SHA1_HASH",
+    "SHA256_HASH",
+    "DATE_TIME",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_engine_constructs() {
+        let _ = RedactEngine::new();
+    }
+
+    #[test]
+    fn analyze_detects_email() {
+        let engine = RedactEngine::new();
+        let json = engine.analyze("Contact john@example.com");
+        assert!(json.contains("EMAIL_ADDRESS"));
+        assert!(json.contains("detected_entities"));
+    }
+
+    #[test]
+    fn analyze_clean_text_has_empty_entities() {
+        let engine = RedactEngine::new();
+        let json = engine.analyze("nothing to see here");
+        assert!(json.contains("\"detected_entities\":[]"));
+    }
+
+    #[test]
+    fn anonymize_replace_redacts_email() {
+        let engine = RedactEngine::new();
+        let json = engine.anonymize("Email: john@example.com", "replace");
+        assert!(json.contains("[EMAIL_ADDRESS]"));
+    }
+
+    #[test]
+    fn anonymize_mask_works() {
+        let engine = RedactEngine::new();
+        let json = engine.anonymize("Email: john@example.com", "mask");
+        assert!(json.contains("anonymized"));
+    }
+
+    #[test]
+    fn anonymize_unknown_strategy_returns_error_json() {
+        let engine = RedactEngine::new();
+        let json = engine.anonymize("Email: john@example.com", "bogus");
+        assert!(json.contains("\"error\""));
+        assert!(json.contains("Unknown strategy"));
+    }
+
+    #[test]
+    fn supported_entities_lists_36_types_and_excludes_ner_types() {
+        let engine = RedactEngine::new();
+        let json = engine.supported_entities();
+        let parsed: Vec<String> = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.len(), 36);
+        assert!(parsed.contains(&"EMAIL_ADDRESS".to_string()));
+        assert!(parsed.contains(&"US_SSN".to_string()));
+        assert!(!parsed.contains(&"PERSON".to_string()));
+        assert!(!parsed.contains(&"ORGANIZATION".to_string()));
+        assert!(!parsed.contains(&"LOCATION".to_string()));
+    }
+
+    #[test]
+    fn parse_strategy_is_case_insensitive() {
+        assert!(matches!(
+            parse_strategy("REPLACE"),
+            Ok(AnonymizationStrategy::Replace)
+        ));
+        assert!(parse_strategy("nope").is_err());
     }
 }

--- a/crates/redact-wasm/src/lib.rs
+++ b/crates/redact-wasm/src/lib.rs
@@ -29,9 +29,16 @@
 //! let engine = RedactEngine::new();
 //! let analysis = engine.analyze("Contact john@example.com");
 //! let redacted = engine.anonymize("Email: john@example.com", "replace");
+//! let hashed = engine.anonymize_with_hash("Email: john@example.com", "app-secret-salt");
 //! ```
 //!
-//! Both `analyze` and `anonymize` return a JSON string.
+//! `analyze`, `anonymize`, and `anonymize_with_hash` return a JSON string.
+//!
+//! ## Supported WASM entry point
+//!
+//! Compile and consume **`redact-wasm`** for `wasm32-unknown-unknown`. Standalone
+//! `redact-core` is not a supported WASM target: its RNG backends (`getrandom` /
+//! `uuid` JS features) are wired only through this crate.
 
 use redact_core::{
     anonymizers::{AnonymizationStrategy, AnonymizerConfig},
@@ -70,25 +77,65 @@ impl RedactEngine {
     /// Anonymize `text` with the given strategy and return a JSON `AnalysisResult`
     /// string (with `anonymized` populated).
     ///
-    /// `strategy` is one of `replace`, `mask`, `hash`, or `encrypt` (case-insensitive).
-    /// `encrypt` requires key material that this default binding does not provide;
-    /// it will return an `{"error": "..."}` object. Use `replace`, `mask`, or `hash`
-    /// from the browser/Worker.
+    /// `strategy` is one of `replace` or `mask` (case-insensitive).
+    ///
+    /// `hash` is rejected here: unsalted hashes of low-entropy PII are enumerable.
+    /// Call [`Self::anonymize_with_hash`] with a non-empty caller-provided salt instead.
+    /// `encrypt` is also rejected (no key material in this two-argument binding).
     pub fn anonymize(&self, text: &str, strategy: &str) -> String {
         let strat = match parse_strategy(strategy) {
             Ok(s) => s,
             Err(msg) => return serde_json::json!({ "error": msg }).to_string(),
         };
+        match strat {
+            AnonymizationStrategy::Hash => {
+                return serde_json::json!({
+                    "error": "strategy 'hash' requires a non-empty salt; use anonymize_with_hash(text, salt)"
+                })
+                .to_string();
+            }
+            AnonymizationStrategy::Encrypt => {
+                return serde_json::json!({
+                    "error": "strategy 'encrypt' is not supported in the WASM binding (no key material)"
+                })
+                .to_string();
+            }
+            AnonymizationStrategy::Replace | AnonymizationStrategy::Mask => {}
+            other => {
+                return serde_json::json!({
+                    "error": format!(
+                        "strategy '{:?}' is not supported in the WASM binding; use replace or mask",
+                        other
+                    )
+                })
+                .to_string();
+            }
+        }
         let config = AnonymizerConfig {
             strategy: strat,
             ..Default::default()
         };
-        match self.engine.analyze_and_anonymize(text, Some("en"), &config) {
-            Ok(result) => serde_json::to_string(&result).unwrap_or_else(|_| {
-                r#"{"error":"failed to serialize anonymized result"}"#.to_string()
-            }),
-            Err(e) => serde_json::json!({ "error": e.to_string() }).to_string(),
+        self.run_anonymize(text, &config)
+    }
+
+    /// Anonymize `text` with the hash strategy using a required non-empty `salt`.
+    ///
+    /// The salt is caller-provided key material for deterministic pseudonymization.
+    /// Empty salt is rejected; a random salt is never generated (that would break
+    /// stable pseudonyms across runs).
+    pub fn anonymize_with_hash(&self, text: &str, salt: &str) -> String {
+        if salt.is_empty() {
+            return serde_json::json!({
+                "error": "hash salt must be a non-empty string (caller-provided key material)"
+            })
+            .to_string();
         }
+        let config = AnonymizerConfig {
+            strategy: AnonymizationStrategy::Hash,
+            hash_salt: Some(salt.to_string()),
+            ..Default::default()
+        };
+        self.run_anonymize(text, &config)
     }
 
     /// Return a JSON array of the entity type strings the pattern recognizer detects.
@@ -97,6 +144,17 @@ impl RedactEngine {
     /// (versus NER-only types like `PERSON`/`ORGANIZATION`/`LOCATION`).
     pub fn supported_entities(&self) -> String {
         serde_json::to_string(SUPPORTED_ENTITY_TYPES).unwrap_or_else(|_| "[]".to_string())
+    }
+}
+
+impl RedactEngine {
+    fn run_anonymize(&self, text: &str, config: &AnonymizerConfig) -> String {
+        match self.engine.analyze_and_anonymize(text, Some("en"), config) {
+            Ok(result) => serde_json::to_string(&result).unwrap_or_else(|_| {
+                r#"{"error":"failed to serialize anonymized result"}"#.to_string()
+            }),
+            Err(e) => serde_json::json!({ "error": e.to_string() }).to_string(),
+        }
     }
 }
 
@@ -206,6 +264,95 @@ mod tests {
         let json = engine.anonymize("Email: john@example.com", "bogus");
         assert!(json.contains("\"error\""));
         assert!(json.contains("Unknown strategy"));
+    }
+
+    #[test]
+    fn anonymize_rejects_hash_without_salt() {
+        let engine = RedactEngine::new();
+        let json = engine.anonymize("Email: john@example.com", "hash");
+        assert!(
+            json.contains("\"error\""),
+            "expected error JSON, got: {json}"
+        );
+        assert!(
+            json.contains("anonymize_with_hash"),
+            "error should point callers at anonymize_with_hash: {json}"
+        );
+        assert!(
+            !json.contains("anonymized"),
+            "hash must not run unsalted via anonymize: {json}"
+        );
+    }
+
+    #[test]
+    fn anonymize_rejects_encrypt() {
+        let engine = RedactEngine::new();
+        let json = engine.anonymize("Email: john@example.com", "encrypt");
+        assert!(
+            json.contains("\"error\""),
+            "expected error JSON, got: {json}"
+        );
+        assert!(
+            !json.contains("anonymized"),
+            "encrypt must not run without key material: {json}"
+        );
+    }
+
+    #[test]
+    fn anonymize_with_hash_requires_non_empty_salt() {
+        let engine = RedactEngine::new();
+        let json = engine.anonymize_with_hash("Email: john@example.com", "");
+        assert!(
+            json.contains("\"error\""),
+            "expected error JSON, got: {json}"
+        );
+        assert!(
+            json.to_ascii_lowercase().contains("salt"),
+            "error should mention salt: {json}"
+        );
+        assert!(
+            !json.contains("anonymized"),
+            "empty salt must not hash: {json}"
+        );
+    }
+
+    #[test]
+    fn anonymize_with_hash_redacts_with_salt() {
+        let engine = RedactEngine::new();
+        let json = engine.anonymize_with_hash("Email: john@example.com", "app-secret-salt");
+        assert!(
+            !json.contains("\"error\""),
+            "salted hash should succeed: {json}"
+        );
+        let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+        let anonymized = v["anonymized"]["text"].as_str().expect("anonymized.text");
+        assert!(
+            !anonymized.contains("john@example.com"),
+            "original email must be redacted: {anonymized}"
+        );
+        assert!(
+            anonymized.contains("EMAIL_ADDRESS_"),
+            "hash strategy uses EMAIL_ADDRESS_<digest> placeholders: {anonymized}"
+        );
+    }
+
+    #[test]
+    fn anonymize_with_hash_is_deterministic_for_same_salt() {
+        let engine = RedactEngine::new();
+        let a = engine.anonymize_with_hash("SSN 123-45-6789", "tenant-key");
+        let b = engine.anonymize_with_hash("SSN 123-45-6789", "tenant-key");
+        let va: serde_json::Value = serde_json::from_str(&a).unwrap();
+        let vb: serde_json::Value = serde_json::from_str(&b).unwrap();
+        assert_eq!(
+            va["anonymized"]["text"], vb["anonymized"]["text"],
+            "same salt must yield identical pseudonyms"
+        );
+        let c = engine.anonymize_with_hash("SSN 123-45-6789", "other-tenant-key");
+        let vc: serde_json::Value = serde_json::from_str(&c).unwrap();
+        assert_ne!(
+            va["anonymized"]["text"], vc["anonymized"]["text"],
+            "different salts must change the digest"
+        );
     }
 
     #[test]

--- a/crates/redact-wasm/tests/wasm_runtime.rs
+++ b/crates/redact-wasm/tests/wasm_runtime.rs
@@ -1,0 +1,77 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! JavaScript-runtime smoke tests for the WASM bindings.
+//!
+//! Run with: `wasm-pack test --node crates/redact-wasm`
+//!
+//! These execute under `wasm32-unknown-unknown` via the wasm-bindgen Node
+//! runner, covering the Timer path that must not call `Instant::now()`.
+
+#[cfg(target_arch = "wasm32")]
+mod wasm32 {
+    use redact_wasm::RedactEngine;
+    use wasm_bindgen_test::*;
+
+    #[wasm_bindgen_test]
+    fn constructor_and_analyze_run_without_instant_panic() {
+        let engine = RedactEngine::new();
+        let json = engine.analyze("Contact john@example.com");
+        assert!(
+            json.contains("EMAIL_ADDRESS"),
+            "analyze must detect email under wasm32: {json}"
+        );
+        assert!(
+            json.contains("processing_time_ms"),
+            "Timer path must populate metadata (0 ms on wasm32): {json}"
+        );
+        // On wasm32, Timer skips Instant::now(); elapsed is always 0.
+        assert!(
+            json.contains("\"processing_time_ms\":0"),
+            "wasm Timer must record 0 ms (proves Instant::now was not called): {json}"
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn anonymize_replace_and_mask() {
+        let engine = RedactEngine::new();
+        let replaced = engine.anonymize("Email: john@example.com", "replace");
+        assert!(replaced.contains("[EMAIL_ADDRESS]"), "{replaced}");
+        let masked = engine.anonymize("Email: john@example.com", "mask");
+        assert!(masked.contains("anonymized"), "{masked}");
+        assert!(!masked.contains("\"error\""), "{masked}");
+    }
+
+    #[wasm_bindgen_test]
+    fn anonymize_hash_requires_salt_contract() {
+        let engine = RedactEngine::new();
+        let rejected = engine.anonymize("Email: john@example.com", "hash");
+        assert!(rejected.contains("\"error\""), "{rejected}");
+        assert!(rejected.contains("anonymize_with_hash"), "{rejected}");
+
+        let empty = engine.anonymize_with_hash("Email: john@example.com", "");
+        assert!(empty.contains("\"error\""), "{empty}");
+        assert!(empty.to_ascii_lowercase().contains("salt"), "{empty}");
+
+        let hashed = engine.anonymize_with_hash("Email: john@example.com", "runtime-salt");
+        assert!(!hashed.contains("\"error\""), "{hashed}");
+        assert!(hashed.contains("EMAIL_ADDRESS_"), "{hashed}");
+    }
+
+    #[wasm_bindgen_test]
+    fn supported_entities_lists_pattern_types() {
+        let engine = RedactEngine::new();
+        let json = engine.supported_entities();
+        assert!(json.contains("EMAIL_ADDRESS"), "{json}");
+        assert!(json.contains("US_SSN"), "{json}");
+        assert!(!json.contains("PERSON"), "{json}");
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn wasm_runtime_suite_is_exercised_by_wasm_pack() {
+    // Native `cargo test` does not execute the wasm32 module above.
+    // CI runs: `wasm-pack test --node crates/redact-wasm`
+}


### PR DESCRIPTION
## Summary
- **CLI #95**: `redact analyze --fail-on-detect` exits 1 when PII is detected (opt-in; default behavior unchanged) for CI gates and pre-commit hooks.
- **CLI #94**: `-i/--file` accepts multiple paths. Text output prints a `--- <path> ---` header per file; JSON output for multiple files is a single array of `{"file", "result"}` objects. Single-file/inline output unchanged.
- **WASM**: replace the `redact-wasm` placeholder with real `AnalyzerEngine` bindings (`analyze`, `anonymize`, `supported_entities`) — pattern-only, 36 entity types. Inline NER (PERSON/ORG/LOCATION) is intentionally out of scope; documented with a Cloudflare hybrid architecture.
- **redact-core**: `Timer` gates `Instant::now()` (panics on wasm32); `chrono` drops the `clock` default feature (only the `DateTime<Utc>` type is used).
- **CI**: `wasm32-unknown-unknown` check job for `redact-wasm`.
- **Docs**: README WebAssembly section + roadmap split (pattern-only done, inline NER deferred); CHANGELOG entries.

Closes #94. Closes #95.

## Test plan
- [x] `cargo test --package redact-cli` — 44 integration tests (12 new: exit codes + multi-file, incl. JSON-array contract and single-file backward compat)
- [x] `cargo test --package redact-core --package redact-wasm` — core suite green; 8 new WASM unit tests
- [x] `cargo check --target wasm32-unknown-unknown -p redact-wasm` — passes
- [x] `cargo fmt --all -- --check` — clean
- [x] Scoped clippy (`--lib --bins --tests`) clean for cli/core/wasm
- [ ] Reviewer: spot-check `redact analyze --fail-on-detect -i <file>` exit codes and `redact analyze --format json -i f1 f2` array output

## Notes
- `cargo clippy --all-targets -- -D warnings` fails on a **pre-existing** `criterion::black_box` deprecation in `crates/redact-core/benches/analyzer_benchmarks.rs` (unrelated to this PR). Happy to fix it in a separate commit if desired.
- npm `wasm-pack` publish is not included; that's a release action.