### PR TITLE
docs(agents): Cursor Cloud run notes for redact

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,3 +200,13 @@ Before committing:
 - **Rust**: 1.93.0 (see `.tool-versions`)
 - **MSRV**: 1.88
 - **Python**: 3.8+ (for NER model export only)
+
+## Cursor Cloud specific instructions
+
+Rust is pinned via **mise** (`.tool-versions`), but `cargo`/`rustc` are the system rustup proxies at `/usr/local/cargo/bin` — non-interactive shells need that on `PATH` (and `~/.local/bin/mise` for mise). Build/test with `mise exec -- cargo ...` from the repo root.
+
+Non-obvious notes:
+
+- The **CLI binary is named `redact`** (crate `redact-cli`), not `redact-cli`: run `mise exec -- cargo run --bin redact -- analyze "test@example.com"` (or `target/debug/redact`). The API binary is `redact-api` (health at `/healthz`, endpoints `POST /api/v1/analyze` and `/api/v1/anonymize`); it honors `HOST`/`PORT`.
+- Building `redact-ner` / the `tokenizers` (`esaxx-rs`) C++ code needs a **GCC** C++ toolchain. The image's default `c++` alias is clang, which fails to find libstdc++ headers (`'cstdint' file not found`); the working setup repoints `c++`/`cc` to `g++`/`gcc`.
+- `redact-core` builds/tests need no ML model; NER e2e (`cargo test -p redact-ner --test ner_e2e -- --ignored`) requires an exported ONNX model.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with non-obvious build/run notes discovered while setting up redact in a fresh Cursor Cloud VM. No functional code changes.

- Rust is pinned via **mise**, but `cargo`/`rustc` are the system rustup proxies at `/usr/local/cargo/bin` (must be on `PATH` for non-interactive shells).
- The **CLI binary is `redact`** (crate `redact-cli`), not `redact-cli`.
- Building `redact-ner` / `tokenizers` (`esaxx-rs`) requires a **GCC** C++ toolchain — the image's default `c++` alias is clang and fails with `'cstdint' file not found`.

## Verification

Ran in the cloud VM: `cargo build -p redact-cli -p redact-api`, `cargo test -p redact-core` (37 pass), CLI `analyze`/`anonymize` on sample PII, and the API on :8081 (`/healthz`, `POST /api/v1/analyze`, `POST /api/v1/anonymize`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e59dbc6d-3b6c-45e3-ba6b-32611169eba7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e59dbc6d-3b6c-45e3-ba6b-32611169eba7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

