### PR TITLE
feat(core): pattern-v1 quality harness and precision-first gates

### DIFF
--- a/crates/redact-core/src/recognizers/pattern.rs
+++ b/crates/redact-core/src/recognizers/pattern.rs
@@ -2,7 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See the LICENSE file
 // in the project root for license information.
 
-use super::{validation::validate_entity, Recognizer, RecognizerResult};
+use super::{
+    validation::{precision_gate, validate_entity},
+    Recognizer, RecognizerResult,
+};
 use crate::types::EntityType;
 use anyhow::Result;
 use lazy_static::lazy_static;
@@ -643,6 +646,9 @@ impl Recognizer for PatternRecognizer {
                         // This can reduce or zero out the score for invalid matches
                         let validation_factor = validate_entity(entity_type, matched_text);
                         score *= validation_factor;
+
+                        // Surrounding-text precision gate (order IDs, commit SHA1, junk domains)
+                        score *= precision_gate(entity_type, text, start, end, matched_text);
 
                         if score >= self.min_score {
                             results.push(

--- a/crates/redact-core/src/recognizers/validation.rs
+++ b/crates/redact-core/src/recognizers/validation.rs
@@ -9,6 +9,7 @@
 //! pass the Luhn checksum, and IBANs have country-specific formats.
 
 use crate::types::EntityType;
+use chrono::NaiveDate;
 
 /// Validate a detected entity value based on its type.
 ///
@@ -25,8 +26,164 @@ pub fn validate_entity(entity_type: &EntityType, value: &str) -> f32 {
         EntityType::UkNhs => validate_uk_nhs(value),
         EntityType::Isbn => validate_isbn(value),
         EntityType::IpAddress => validate_ip_address(value),
+        EntityType::DateTime => validate_date_time(value),
+        EntityType::MacAddress => validate_mac_address(value),
         _ => 1.0, // No validation available
     }
+}
+
+/// Validate calendar date (and optional time) for `DATE_TIME` matches.
+///
+/// Accepts `YYYY-MM-DD` with optional `T`/` ` time (`HH:MM` or `HH:MM:SS`).
+/// Impossible calendar dates (e.g. month 99, Feb 31) return `0.0`.
+pub fn validate_date_time(value: &str) -> f32 {
+    let value = value.trim();
+    let date_part = value.split(['T', ' ']).next().unwrap_or(value);
+
+    if NaiveDate::parse_from_str(date_part, "%Y-%m-%d").is_err() {
+        return 0.0;
+    }
+
+    if let Some(rest) = value
+        .strip_prefix(date_part)
+        .map(str::trim_start)
+        .filter(|s| !s.is_empty())
+    {
+        let time = rest.trim_start_matches(['T', ' ']);
+        let ok = matches!(time.len(), 5 | 8)
+            && time.as_bytes().get(2) == Some(&b':')
+            && (time.len() == 5 || time.as_bytes().get(5) == Some(&b':'))
+            && time.chars().all(|c| c.is_ascii_digit() || c == ':');
+        if !ok {
+            return 0.0;
+        }
+        let hh: u32 = time.get(0..2).and_then(|s| s.parse().ok()).unwrap_or(99);
+        let mm: u32 = time.get(3..5).and_then(|s| s.parse().ok()).unwrap_or(99);
+        if hh > 23 || mm > 59 {
+            return 0.0;
+        }
+        if time.len() == 8 {
+            let ss: u32 = time.get(6..8).and_then(|s| s.parse().ok()).unwrap_or(99);
+            if ss > 59 {
+                return 0.0;
+            }
+        }
+    }
+
+    1.0
+}
+
+/// Validate MAC addresses, rejecting null and broadcast forms.
+pub fn validate_mac_address(value: &str) -> f32 {
+    let cleaned: String = value
+        .chars()
+        .filter(|c| c.is_ascii_hexdigit())
+        .flat_map(|c| c.to_lowercase())
+        .collect();
+    if cleaned.len() != 12 {
+        return 0.0;
+    }
+    if cleaned.chars().all(|c| c == '0') || cleaned.chars().all(|c| c == 'f') {
+        return 0.0;
+    }
+    1.0
+}
+
+/// Surrounding-text precision gate applied after value validation.
+///
+/// Returns a multiplicative factor (`0.0` rejects, `1.0` keeps).
+pub fn precision_gate(
+    entity_type: &EntityType,
+    text: &str,
+    start: usize,
+    end: usize,
+    value: &str,
+) -> f32 {
+    let left = left_context(text, start, 50);
+    let left_lower = left.to_ascii_lowercase();
+
+    match entity_type {
+        EntityType::PhoneNumber | EntityType::CreditCard => {
+            if order_like_context(&left_lower) && !phone_or_card_cue(&left_lower) {
+                0.0
+            } else {
+                1.0
+            }
+        }
+        EntityType::Sha1Hash => {
+            if left_lower.contains("commit") {
+                0.0
+            } else {
+                1.0
+            }
+        }
+        EntityType::DomainName => {
+            if junk_domain_fragment(text, start, value) {
+                0.0
+            } else {
+                1.0
+            }
+        }
+        _ => {
+            let _ = end;
+            1.0
+        }
+    }
+}
+
+fn left_context(text: &str, start: usize, window: usize) -> &str {
+    let ctx_start = start.saturating_sub(window);
+    // Align to char boundary
+    let mut idx = ctx_start;
+    while idx < start && !text.is_char_boundary(idx) {
+        idx += 1;
+    }
+    &text[idx..start]
+}
+
+fn order_like_context(left_lower: &str) -> bool {
+    left_lower.contains("order_id")
+        || left_lower.contains("orderid")
+        || left_lower
+            .split(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+            .any(|tok| tok == "order")
+}
+
+fn phone_or_card_cue(left_lower: &str) -> bool {
+    const CUES: &[&str] = &[
+        "phone",
+        "tel",
+        "mobile",
+        "cell",
+        "call",
+        "card",
+        "visa",
+        "mastercard",
+        "amex",
+        "payment",
+        "credit",
+    ];
+    CUES.iter().any(|c| left_lower.contains(c))
+}
+
+fn junk_domain_fragment(text: &str, start: usize, value: &str) -> bool {
+    if let Some(prev) = text[..start].chars().next_back() {
+        if matches!(prev, '%' | '\\' | '@') {
+            return true;
+        }
+    }
+    let lower = value.to_ascii_lowercase();
+    // Percent-decoded / unicode-escape debris: `40example.com`, `u0040example.com`
+    if lower.starts_with(|c: char| c.is_ascii_digit()) {
+        return true;
+    }
+    if lower.starts_with("u00") && lower.len() > 6 {
+        let hex = &lower[3..5];
+        if hex.chars().all(|c| c.is_ascii_hexdigit()) {
+            return true;
+        }
+    }
+    false
 }
 
 /// Validate credit card number using Luhn algorithm.
@@ -414,5 +571,64 @@ mod tests {
     fn test_invalid_ip() {
         assert_eq!(validate_ip_address("256.1.1.1"), 0.0);
         assert_eq!(validate_ip_address("1.1.1"), 0.0);
+    }
+
+    #[test]
+    fn test_date_time_calendar() {
+        assert_eq!(validate_date_time("2026-07-13"), 1.0);
+        assert_eq!(validate_date_time("2026-07-13T08:15:30"), 1.0);
+        assert_eq!(validate_date_time("2026-99-13"), 0.0);
+        assert_eq!(validate_date_time("2026-02-31"), 0.0);
+    }
+
+    #[test]
+    fn test_mac_null_broadcast_rejected() {
+        assert_eq!(validate_mac_address("00:00:00:00:00:00"), 0.0);
+        assert_eq!(validate_mac_address("ff:ff:ff:ff:ff:ff"), 0.0);
+        assert_eq!(validate_mac_address("02:42:ac:11:00:02"), 1.0);
+    }
+
+    #[test]
+    fn test_precision_gate_order_and_commit() {
+        let phone = "order 202-555-0142";
+        assert_eq!(
+            precision_gate(&EntityType::PhoneNumber, phone, 6, 18, "202-555-0142"),
+            0.0
+        );
+        let call = "Call (202) 555-0142";
+        assert_eq!(
+            precision_gate(&EntityType::PhoneNumber, call, 5, 19, "(202) 555-0142"),
+            1.0
+        );
+        let card = "order_id=4111111111111111";
+        assert_eq!(
+            precision_gate(&EntityType::CreditCard, card, 9, 25, "4111111111111111"),
+            0.0
+        );
+        let commit = "commit=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        assert_eq!(
+            precision_gate(
+                &EntityType::Sha1Hash,
+                commit,
+                7,
+                47,
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            ),
+            0.0
+        );
+    }
+
+    #[test]
+    fn test_precision_gate_junk_domain() {
+        let text = "contact=ada%40example.com";
+        assert_eq!(
+            precision_gate(&EntityType::DomainName, text, 12, 25, "40example.com"),
+            0.0
+        );
+        let ok = "visit example.com today";
+        assert_eq!(
+            precision_gate(&EntityType::DomainName, ok, 6, 17, "example.com"),
+            1.0
+        );
     }
 }

--- a/crates/redact-core/tests/quality_pattern_v1.rs
+++ b/crates/redact-core/tests/quality_pattern_v1.rs
@@ -1,0 +1,219 @@
+//! Pattern-v1 quality corpus: exact-span scoring + baseline ratchet.
+//!
+//! Config: AnalyzerEngine defaults, language `en`, min score 0.5, no NER.
+
+use redact_core::AnalyzerEngine;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Debug, Deserialize)]
+struct Corpus {
+    version: String,
+    config: CorpusConfig,
+    cases: Vec<Case>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CorpusConfig {
+    language: String,
+    entity_types_in_scope: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Case {
+    id: String,
+    input: String,
+    expected: Vec<ExpectedSpan>,
+    tier: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct ExpectedSpan {
+    entity_type: String,
+    start: usize,
+    end: usize,
+    raw: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct Baseline {
+    corpus_sha256: String,
+    max_fp_overall: u32,
+    max_fp_negative_tier: u32,
+    min_precision_ppm: u32,
+    require_contract_exact: bool,
+}
+
+#[derive(Debug, Default)]
+struct Counts {
+    tp: u32,
+    fp: u32,
+    fn_: u32,
+}
+
+fn quality_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../testdata/quality")
+}
+
+fn load_corpus() -> (Corpus, Vec<u8>) {
+    let path = quality_dir().join("pattern-v1.json");
+    let bytes = fs::read(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let corpus: Corpus =
+        serde_json::from_slice(&bytes).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()));
+    assert_eq!(corpus.version, "pattern-v1");
+    (corpus, bytes)
+}
+
+fn load_baseline() -> Baseline {
+    let path = quality_dir().join("pattern-v1-baseline.json");
+    let bytes = fs::read(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    serde_json::from_slice(&bytes).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
+
+fn score_case(
+    engine: &AnalyzerEngine,
+    case: &Case,
+    in_scope: &HashSet<String>,
+    language: &str,
+) -> Counts {
+    for exp in &case.expected {
+        let slice = case
+            .input
+            .get(exp.start..exp.end)
+            .unwrap_or_else(|| panic!("{}: span {}..{} out of range", case.id, exp.start, exp.end));
+        assert_eq!(
+            slice, exp.raw,
+            "{}: raw mismatch for {}..{}",
+            case.id, exp.start, exp.end
+        );
+    }
+
+    let analysis = engine
+        .analyze(&case.input, Some(language))
+        .unwrap_or_else(|e| panic!("{}: analyze failed: {e}", case.id));
+
+    let mut preds: Vec<(String, usize, usize)> = analysis
+        .detected_entities
+        .iter()
+        .map(|e| (e.entity_type.as_str().to_string(), e.start, e.end))
+        .filter(|(t, _, _)| in_scope.contains(t))
+        .collect();
+    preds.sort();
+
+    let mut expected: Vec<(String, usize, usize)> = case
+        .expected
+        .iter()
+        .map(|e| (e.entity_type.clone(), e.start, e.end))
+        .collect();
+    expected.sort();
+
+    let mut counts = Counts::default();
+    let mut used_pred = vec![false; preds.len()];
+
+    for exp in &expected {
+        if let Some((idx, _)) = preds
+            .iter()
+            .enumerate()
+            .find(|(i, p)| !used_pred[*i] && *p == exp)
+        {
+            used_pred[idx] = true;
+            counts.tp += 1;
+        } else {
+            counts.fn_ += 1;
+        }
+    }
+    for (i, _) in preds.iter().enumerate() {
+        if !used_pred[i] {
+            counts.fp += 1;
+        }
+    }
+    counts
+}
+
+#[test]
+fn pattern_v1_quality_baseline() {
+    let (corpus, corpus_bytes) = load_corpus();
+    let baseline = load_baseline();
+
+    let digest = sha256_hex(&corpus_bytes);
+    assert_eq!(
+        digest, baseline.corpus_sha256,
+        "pattern-v1.json hash mismatch; update baseline corpus_sha256 when changing the corpus"
+    );
+
+    assert_eq!(corpus.config.language, "en");
+    let in_scope: HashSet<String> = corpus.config.entity_types_in_scope.into_iter().collect();
+
+    let engine = AnalyzerEngine::new();
+    let mut overall = Counts::default();
+    let mut negative_fp = 0u32;
+    let mut per_case: HashMap<String, Counts> = HashMap::new();
+
+    for case in &corpus.cases {
+        let c = score_case(&engine, case, &in_scope, &corpus.config.language);
+        if case.tier == "negative" {
+            negative_fp += c.fp;
+        }
+        if baseline.require_contract_exact && case.tier == "contract" {
+            assert_eq!(c.fn_, 0, "contract case {} has FN={}", case.id, c.fn_);
+            assert_eq!(
+                c.fp, 0,
+                "contract case {} has FP={} (preds may include in-scope extras)",
+                case.id, c.fp
+            );
+        }
+        overall.tp += c.tp;
+        overall.fp += c.fp;
+        overall.fn_ += c.fn_;
+        per_case.insert(case.id.clone(), c);
+    }
+
+    let denom = overall.tp + overall.fp;
+    let precision_ppm = if denom == 0 {
+        1_000_000
+    } else {
+        (u64::from(overall.tp) * 1_000_000 / u64::from(denom)) as u32
+    };
+
+    eprintln!(
+        "pattern-v1 overall tp={} fp={} fn={} precision_ppm={} negative_fp={}",
+        overall.tp, overall.fp, overall.fn_, precision_ppm, negative_fp
+    );
+    for (id, c) in &per_case {
+        if c.fp > 0 || c.fn_ > 0 {
+            eprintln!("  {id}: tp={} fp={} fn={}", c.tp, c.fp, c.fn_);
+        }
+    }
+
+    assert!(
+        overall.fp <= baseline.max_fp_overall,
+        "overall FP {} exceeds max_fp_overall {}",
+        overall.fp,
+        baseline.max_fp_overall
+    );
+    assert!(
+        negative_fp <= baseline.max_fp_negative_tier,
+        "negative-tier FP {} exceeds max_fp_negative_tier {}",
+        negative_fp,
+        baseline.max_fp_negative_tier
+    );
+    assert!(
+        precision_ppm >= baseline.min_precision_ppm,
+        "precision_ppm {} below min_precision_ppm {}",
+        precision_ppm,
+        baseline.min_precision_ppm
+    );
+}

--- a/docs/superpowers/plans/2026-07-27-pattern-precision-quality.md
+++ b/docs/superpowers/plans/2026-07-27-pattern-precision-quality.md
@@ -1,0 +1,138 @@
+# Pattern-Default Precision & Quality Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (or subagent-driven-development) to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship an owned `pattern-v1` quality corpus + CI ratchet and wave-1 precision fixes so negative-tier FPs drop to zero without regressing compact contract positives.
+
+**Architecture:** Add `testdata/quality/` fixtures and a `redact-core` integration test that scores exact spans. Extend `validation.rs` / `pattern.rs` analyze path with value validators and surrounding-text precision gates. Ratchet baseline after fixes.
+
+**Tech Stack:** Rust, serde_json corpus, `AnalyzerEngine` / `PatternRecognizer`, cargo test in existing CI.
+
+## Global Constraints
+
+- Pattern-default only: `AnalyzerEngine::new()`, language `en`, min score `0.5`, no NER.
+- Exact UTF-8 byte span + entity type matching; no post-filter of predictions in the scorer.
+- Precision first; wave-2 recall is out of scope for this plan.
+- Apache-2.0 compatible provenance for adapted cases; do not vendor anon-pii runner.
+- Conventional commits; keep public APIs documented.
+
+## File map
+
+| Path | Responsibility |
+|------|----------------|
+| `testdata/quality/README.md` | How to run, config contract, provenance |
+| `testdata/quality/pattern-v1.json` | Cases |
+| `testdata/quality/pattern-v1-baseline.json` | Ratchets + corpus sha256 |
+| `crates/redact-core/tests/quality_pattern_v1.rs` | Load, score, assert baseline |
+| `crates/redact-core/src/recognizers/validation.rs` | `validate_date_time`, `validate_mac_address`, `precision_gate` |
+| `crates/redact-core/src/recognizers/pattern.rs` | Call validators/gates in `analyze`; unit tests |
+
+---
+
+### Task 1: Quality corpus + runner (documents current debt)
+
+**Files:**
+- Create: `testdata/quality/README.md`
+- Create: `testdata/quality/pattern-v1.json`
+- Create: `testdata/quality/pattern-v1-baseline.json`
+- Create: `crates/redact-core/tests/quality_pattern_v1.rs`
+
+**Interfaces:**
+- Produces: corpus schema `{ version, cases: [{ id, input, expected: [{ entity_type, start, end, raw }], tier, provenance? }] }`
+- Produces: baseline `{ corpus_sha256, max_fp_overall, max_fp_negative_tier, min_precision_ppm, require_contract_exact: true }`
+- Scorer uses `AnalyzerEngine::analyze(input, Some("en"))` and maps `EntityType::as_str()` to expected `entity_type`.
+
+- [ ] **Step 1:** Add README with config contract and provenance note (anon-pii commit `1a22680e43b29c80e141a39b0a66eb3dcafb7522`, adapted case ids).
+
+- [ ] **Step 2:** Add `pattern-v1.json` with at least:
+  - **Negatives:** `negative-date-month`, `negative-impossible-calendar-date`, `negative-mac-null`, `negative-mac-broadcast`, `negative-phone-like-order`, `negative-card-like-order`, `negative-commit-hash`, `negative-card-luhn`
+  - **Contracts (compact TPs):** `email-basic`, `card-visa-compact`, `iban-gb-compact`, `uuid-request-id`, `mac-locally-administered`, `url-basic`, `ipv4-documentation`
+  - Use exact byte spans; set `raw` == slice.
+
+- [ ] **Step 3:** Implement `quality_pattern_v1.rs` that:
+  - Loads corpus/baseline from `CARGO_MANIFEST_DIR/../../testdata/quality/`
+  - Verifies corpus sha256 matches baseline
+  - Scores TP/FP/FN (exact start/end + entity_type string)
+  - Asserts contract cases have zero FN/FP each
+  - Asserts overall FP ≤ `max_fp_overall`, negative-tier FP ≤ `max_fp_negative_tier`, precision ≥ floor
+  - Initially set baseline to **current** measured debt (allow FPs) so the test is green before fixes
+
+- [ ] **Step 4:** Run `cargo test -p redact-core --test quality_pattern_v1` — expect PASS with debt baseline.
+
+- [ ] **Step 5:** Commit `test(core): add pattern-v1 quality corpus and ratchet harness`
+
+---
+
+### Task 2: DateTime + MAC validators
+
+**Files:**
+- Modify: `crates/redact-core/src/recognizers/validation.rs`
+- Modify: `crates/redact-core/src/recognizers/pattern.rs` (unit tests; `validate_entity` match arms)
+
+**Interfaces:**
+- `pub fn validate_date_time(value: &str) -> f32` — `1.0` valid calendar date (and optional time), `0.0` otherwise
+- `pub fn validate_mac_address(value: &str) -> f32` — `0.0` for null/broadcast, else `1.0`
+- Wire both into `validate_entity`
+
+- [ ] **Step 1:** Write failing unit tests in `validation.rs` or `pattern.rs` tests for invalid dates and null/broadcast MAC.
+
+- [ ] **Step 2:** Implement validators; run unit tests — PASS.
+
+- [ ] **Step 3:** Run quality test; tighten negative-tier allowance if those FPs are gone.
+
+- [ ] **Step 4:** Commit `fix(core): reject invalid DATE_TIME and null/broadcast MAC`
+
+---
+
+### Task 3: Surrounding-text precision gate (order/commit/domain)
+
+**Files:**
+- Modify: `crates/redact-core/src/recognizers/validation.rs`
+- Modify: `crates/redact-core/src/recognizers/pattern.rs` `analyze`
+
+**Interfaces:**
+- `pub fn precision_gate(entity_type: &EntityType, text: &str, start: usize, end: usize, value: &str) -> f32`
+  - Phone/CreditCard: if left context (50 chars) matches order-like labels (`order_id`, `order`) and lacks phone/card cues → `0.0`
+  - Sha1Hash: if left context has `commit` → `0.0`
+  - DomainName: if previous char is `%`/`\`/`@`, or value looks like email-decode fragment (`^\d+example\.`, `^u00[0-9a-f]{2}`) → `0.0`
+  - Else `1.0`
+- In `analyze`, after `validate_entity`: `score *= precision_gate(...)`
+
+- [ ] **Step 1:** Failing unit tests for order phone/card, commit SHA1, junk domains.
+
+- [ ] **Step 2:** Implement gate + wire into analyze.
+
+- [ ] **Step 3:** Run unit + quality tests.
+
+- [ ] **Step 4:** Commit `fix(core): precision-gate order IDs, commit SHA1, junk domains`
+
+---
+
+### Task 4: Ratchet baseline to wave-1 success
+
+**Files:**
+- Modify: `testdata/quality/pattern-v1-baseline.json`
+- Modify: `testdata/quality/README.md` if needed
+
+- [ ] **Step 1:** Run quality test, set `max_fp_negative_tier: 0`, `max_fp_overall` to measured, raise `min_precision_ppm` accordingly, update `corpus_sha256` if corpus unchanged still same.
+
+- [ ] **Step 2:** `cargo test -p redact-core --test quality_pattern_v1` PASS; `cargo test -p redact-core` PASS; `cargo fmt`; clippy on touched crates if feasible.
+
+- [ ] **Step 3:** Commit `test(core): ratchet pattern-v1 baseline after precision fixes`
+
+- [ ] **Step 4:** Push branch and open PR against `main`.
+
+---
+
+## Spec coverage check
+
+| Spec item | Task |
+|-----------|------|
+| Owned corpus + baseline + sha256 | 1, 4 |
+| Exact-span scorer, pattern-only config | 1 |
+| Provenance README | 1 |
+| Invalid dates / MAC negatives | 2 |
+| Order phone/card, commit SHA1, domain junk | 3 |
+| Ratchet to 0 negative FP | 4 |
+| CI via cargo test | 1 (existing workspace job) |
+| No NER / no recall wave | Global constraints |

--- a/docs/superpowers/specs/2026-07-27-pattern-precision-quality-design.md
+++ b/docs/superpowers/specs/2026-07-27-pattern-precision-quality-design.md
@@ -1,0 +1,161 @@
+# Pattern-Default Precision & Quality Harness
+
+**Date:** 2026-07-27  
+**Status:** Draft for review  
+**Owner:** Censgate / redact-core  
+**Related:** anon-pii comparison (`tcheuD/anon-pii` shared-family diagnostic); Approach 1 (validator hardening first)
+
+## Goal
+
+Improve **pattern-default** detection **precision** for `censgate/redact` with a durable, owned quality corpus and CI ratchet—without mixing optional NER into the score, and without a recall-first push until the precision floor holds.
+
+## Non-goals (wave 1)
+
+- Formatted-value recall (spaced/hyphenated cards, Cisco MAC, intl E.164, fullwidth email, etc.)
+- NER / `:full` accuracy work, or merging NER into the pattern score
+- Latency/throughput optimization
+- Gateway or OpenClaw changes
+- Public “we beat X” marketing claims against third-party scoreboards
+
+## Decisions (locked)
+
+| Decision | Choice |
+|----------|--------|
+| Priority mix | Pattern accuracy + measurement harness primary; NER packaging secondary later |
+| Precision vs recall | **Precision first** |
+| Success bar | **C:** adapt comparable cases as fixtures **and** own long-term corpus/CI |
+| Approach | **1:** validator/context hardening behind an owned harness, then careful recall |
+
+## Context
+
+A pinned comparison in `tcheuD/anon-pii` (`docs/comparison-redact.md`) scored pattern-default `redact-cli` poorly on a shared-family exact-span protocol. Arithmetic matched their artifact, but:
+
+- The corpus is project-owned by anon-pii (home-field).
+- Exact byte-span matching double-counts partial detections as FP+FN.
+- NER would not fix most misses (no PERSON/ORG/LOC labels in that slice).
+- Several FPs are real precision debt: impossible dates, null/broadcast MAC, order-like phone/card, commit-shaped SHA1, junk `DOMAIN_NAME` after email misses.
+
+We respond by **owning measurement** and fixing **precision** first.
+
+## Architecture
+
+```
+testdata/quality/
+  README.md                 # provenance, how to run, config contract
+  pattern-v1.json           # cases + expected exact spans
+  pattern-v1-baseline.json  # ratchets (FP/precision floors)
+
+crates/redact-core/
+  tests/quality_pattern_v1.rs   # loads corpus, scores, asserts baseline
+  src/recognizers/
+    validation.rs               # calendar/MAC/card/… validators
+    pattern.rs                  # patterns, context, scoring
+```
+
+**Fixed evaluation config (pattern-v1):**
+
+- `AnalyzerEngine` default pattern registry only
+- Language: `en`
+- Minimum score: `0.5`
+- **No NER** registered
+- No entity-type filter
+- Matching: exact UTF-8 byte span + entity type/family
+- No post-hoc prediction filtering in the scorer
+
+A future `ner-v1` corpus/config is allowed but **must never** be merged into the pattern-v1 score.
+
+## Corpus design
+
+### Case schema
+
+Each case in `pattern-v1.json`:
+
+- `id` (stable string)
+- `input` (UTF-8 string)
+- `expected`: list of `{ entity_type, start, end, raw }` (exact span; `raw` must equal `input[start:end]`)
+- `tier`: `contract` | `challenge` | `negative`
+- Optional `notes`, `provenance` (source case id if adapted)
+
+### Tiers
+
+| Tier | Meaning |
+|------|---------|
+| `negative` | `expected` empty; any prediction is FP |
+| `contract` | Must stay exact; regressions fail CI |
+| `challenge` | Tracked; may have reviewed exceptions in baseline |
+
+### Family scope (v1)
+
+Shared families aligned with the comparison slice: email, URL, IP, phone, payment card, IBAN, UUID, MAC, date/time—plus negatives that stress those detectors (and SHA1 where it pollutes negatives).
+
+### Provenance
+
+- Cases adapted from `tcheuD/anon-pii` list source repo, commit, and case ids in `testdata/quality/README.md` (and/or per-case `provenance`).
+- Fixtures are rewritten as needed so Redact **owns** them; do not vendor their runner or republish their aggregate as ours.
+- Attribution must remain Apache-2.0 compatible.
+
+### Integrity
+
+- Baseline (or test) records SHA-256 of `pattern-v1.json`.
+- Changing labels/corpus without updating the hash/baseline is a hard fail.
+
+## Wave 1 — precision fixes
+
+Ordered work in `redact-core`:
+
+1. **Impossible / invalid dates** — Reject non-calendar `DATE_TIME` values (e.g. `2026-99-13`, `2026-02-31`). Prefer full ISO-8601 spans when matching timestamps.
+2. **MAC negatives** — Suppress null (`00:…:00`) and broadcast (`ff:…:ff`) unless strong device context; keep ordinary MACs.
+3. **Order-like phone/card** — Require context (or stronger cues) when values sit under `order` / `order_id`-style labels; keep explicit phone/card contexts working.
+4. **Commit-shaped SHA1** — Lower or suppress bare 40-hex under `commit=` / VCS-ish labels so negatives do not fire as `SHA1_HASH`.
+5. **Domain fallback cleanup** — Do not emit junk `DOMAIN_NAME` from failed email parses (e.g. `40example.com`, `u0040example.com`); prefer email or no detection.
+6. **Fixtures + ratchet** — Land adapted negatives/shared-family cases; tighten baseline as FPs fall.
+
+**Success for wave 1:**
+
+- Quality test green in CI
+- **0 FP on the negative tier** (or a documented tiny allowance only if unavoidable)
+- All `contract` compact positives still pass
+- Precision baseline ratcheted upward vs the initial “debt” baseline
+
+## CI & rollout
+
+1. Land corpus + runner + **current** baseline (documents today’s FP debt).
+2. Land wave-1 validator/context PRs; tighten `pattern-v1-baseline.json` as FPs drop (loosening requires explicit PR rationale).
+3. Optional short `docs/` note on how to run/report scores—not a competitive claim.
+4. **Wave 2 (recall)** only after negative-tier FP target is met: spaced/hyphenated cards, spaced/lowercase IBAN, Cisco MAC, intl phones, fullwidth/encoded email, span completeness (DATE_TIME, IPv4-mapped IPv6)—each change must preserve the precision floor.
+
+Hook: existing workspace CI via `cargo test -p redact-core --test quality_pattern_v1` (name may vary slightly; no network/ONNX).
+
+## Testing strategy
+
+- Unit tests beside validator/pattern changes for each FP class.
+- Corpus integration test for aggregate TP/FP/FN and baseline.
+- Existing `pattern_coverage.rs` remains; quality corpus is the regression gate for precision policy, not a replacement for per-entity smoke coverage.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Context gates hurt real recall | Contract positives for compact forms; challenge tier can lag |
+| Corpus gaming / silent relabeling | Content hash + reviewed baseline diffs |
+| Scope creep into NER or gateway | Explicit non-goals; separate future corpus |
+| Over-claiming vs anon-pii | Own scores only; provenance without scoreboard marketing |
+
+## Implementation sketch (post-approval)
+
+Not part of this approval gate beyond orientation:
+
+1. Add `testdata/quality/` + README + initial corpus/baseline.
+2. Add `quality_pattern_v1` test runner.
+3. Implement wave-1 fixes with unit tests; ratchet baseline.
+4. Open wave-2 recall plan only after wave-1 success criteria.
+
+## Approval
+
+Design sections reviewed in conversation:
+
+- §1 Corpus & measurement — approved
+- §2 Wave-1 precision fixes & out of scope — approved
+- §3 CI, attribution, rollout — approved
+
+**Next step after human review of this file:** write the implementation plan (`writing-plans`), then implement.

--- a/docs/superpowers/specs/2026-07-27-pattern-precision-quality-design.md
+++ b/docs/superpowers/specs/2026-07-27-pattern-precision-quality-design.md
@@ -1,7 +1,7 @@
 # Pattern-Default Precision & Quality Harness
 
 **Date:** 2026-07-27  
-**Status:** Draft for review  
+**Status:** Approved — wave 1 implemented on `coder-pattern-precision-quality-spec-5276`  
 **Owner:** Censgate / redact-core  
 **Related:** anon-pii comparison (`tcheuD/anon-pii` shared-family diagnostic); Approach 1 (validator hardening first)
 

--- a/testdata/quality/README.md
+++ b/testdata/quality/README.md
@@ -1,0 +1,39 @@
+# Pattern quality corpus (v1)
+
+Owned regression fixtures for **pattern-default** precision (and later recall).
+
+## Config contract
+
+| Setting | Value |
+|---------|-------|
+| Engine | `AnalyzerEngine::new()` (default pattern registry) |
+| Language | `en` |
+| Min score | `0.5` |
+| NER | off |
+| Matching | Exact UTF-8 byte span + `entity_type` string |
+| In-scope types | Listed in `pattern-v1.json` → `config.entity_types_in_scope` |
+
+Predictions whose `entity_type` is **outside** that allowlist are ignored for scoring (shared-family diagnostic). In-scope extras are false positives.
+
+## Run
+
+```bash
+cargo test -p redact-core --test quality_pattern_v1
+```
+
+## Baseline
+
+`pattern-v1-baseline.json` records:
+
+- `corpus_sha256` of `pattern-v1.json` (bytes on disk)
+- `max_fp_overall`, `max_fp_negative_tier`
+- `min_precision_ppm` (parts per million; `1000000` = 100%)
+- `require_contract_exact`: every `contract` case must have 0 FN and 0 FP
+
+Tightening the baseline in the same PR as a precision fix is encouraged. Loosening requires an explicit rationale.
+
+## Provenance
+
+Some cases are adapted from [`tcheuD/anon-pii`](https://github.com/tcheuD/anon-pii) at commit `1a22680e43b29c80e141a39b0a66eb3dcafb7522` (Apache-2.0). Per-case `provenance` fields list source case ids. Fixtures are owned by this repository; do not treat third-party aggregate scores as ours.
+
+See `docs/superpowers/specs/2026-07-27-pattern-precision-quality-design.md`.

--- a/testdata/quality/pattern-v1-baseline.json
+++ b/testdata/quality/pattern-v1-baseline.json
@@ -1,0 +1,7 @@
+{
+  "corpus_sha256": "aa154b701af5b1008053082c4388db99a9e043278e955e56503a67112c5649bf",
+  "max_fp_overall": 0,
+  "max_fp_negative_tier": 0,
+  "min_precision_ppm": 1000000,
+  "require_contract_exact": true
+}

--- a/testdata/quality/pattern-v1.json
+++ b/testdata/quality/pattern-v1.json
@@ -1,0 +1,248 @@
+{
+  "version": "pattern-v1",
+  "config": {
+    "language": "en",
+    "min_score": 0.5,
+    "ner": false,
+    "entity_types_in_scope": [
+      "EMAIL_ADDRESS",
+      "PHONE_NUMBER",
+      "CREDIT_CARD",
+      "IBAN_CODE",
+      "IP_ADDRESS",
+      "URL",
+      "GUID",
+      "MAC_ADDRESS",
+      "DATE_TIME",
+      "SHA1_HASH",
+      "DOMAIN_NAME"
+    ]
+  },
+  "cases": [
+    {
+      "id": "negative-date-month",
+      "input": "created_at=2026-99-13",
+      "expected": [],
+      "tier": "negative",
+      "provenance": {
+        "adapted_from": "tcheuD/anon-pii",
+        "commit": "1a22680e43b29c80e141a39b0a66eb3dcafb7522",
+        "case_id": "negative-date-month"
+      }
+    },
+    {
+      "id": "negative-impossible-calendar-date",
+      "input": "created_at=2026-02-31",
+      "expected": [],
+      "tier": "negative",
+      "provenance": {
+        "adapted_from": "tcheuD/anon-pii",
+        "commit": "1a22680e43b29c80e141a39b0a66eb3dcafb7522",
+        "case_id": "negative-impossible-calendar-date"
+      }
+    },
+    {
+      "id": "negative-mac-null",
+      "input": "device=00:00:00:00:00:00",
+      "expected": [],
+      "tier": "negative",
+      "provenance": {
+        "adapted_from": "tcheuD/anon-pii",
+        "commit": "1a22680e43b29c80e141a39b0a66eb3dcafb7522",
+        "case_id": "negative-mac-null"
+      }
+    },
+    {
+      "id": "negative-mac-broadcast",
+      "input": "device=ff:ff:ff:ff:ff:ff",
+      "expected": [],
+      "tier": "negative",
+      "provenance": {
+        "adapted_from": "tcheuD/anon-pii",
+        "commit": "1a22680e43b29c80e141a39b0a66eb3dcafb7522",
+        "case_id": "negative-mac-broadcast"
+      }
+    },
+    {
+      "id": "negative-phone-like-order",
+      "input": "order 202-555-0142",
+      "expected": [],
+      "tier": "negative",
+      "provenance": {
+        "adapted_from": "tcheuD/anon-pii",
+        "commit": "1a22680e43b29c80e141a39b0a66eb3dcafb7522",
+        "case_id": "negative-phone-like-order"
+      }
+    },
+    {
+      "id": "negative-card-like-order",
+      "input": "order_id=4111111111111111",
+      "expected": [],
+      "tier": "negative",
+      "provenance": {
+        "adapted_from": "tcheuD/anon-pii",
+        "commit": "1a22680e43b29c80e141a39b0a66eb3dcafb7522",
+        "case_id": "negative-card-like-order"
+      }
+    },
+    {
+      "id": "negative-commit-hash",
+      "input": "commit=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "expected": [],
+      "tier": "negative",
+      "provenance": {
+        "adapted_from": "tcheuD/anon-pii",
+        "commit": "1a22680e43b29c80e141a39b0a66eb3dcafb7522",
+        "case_id": "negative-commit-hash"
+      }
+    },
+    {
+      "id": "negative-card-luhn",
+      "input": "Card: 4111111111111112",
+      "expected": [],
+      "tier": "negative",
+      "provenance": {
+        "adapted_from": "tcheuD/anon-pii",
+        "commit": "1a22680e43b29c80e141a39b0a66eb3dcafb7522",
+        "case_id": "negative-card-luhn"
+      }
+    },
+    {
+      "id": "email-basic",
+      "input": "Email ada@example.com",
+      "expected": [
+        {
+          "entity_type": "EMAIL_ADDRESS",
+          "start": 6,
+          "end": 21,
+          "raw": "ada@example.com"
+        }
+      ],
+      "tier": "contract",
+      "provenance": {
+        "adapted_from": "tcheuD/anon-pii",
+        "commit": "1a22680e43b29c80e141a39b0a66eb3dcafb7522",
+        "case_id": "email-basic"
+      }
+    },
+    {
+      "id": "card-visa-compact",
+      "input": "Payment card 4111111111111111",
+      "expected": [
+        {
+          "entity_type": "CREDIT_CARD",
+          "start": 13,
+          "end": 29,
+          "raw": "4111111111111111"
+        }
+      ],
+      "tier": "contract",
+      "provenance": {
+        "adapted_from": "tcheuD/anon-pii",
+        "commit": "1a22680e43b29c80e141a39b0a66eb3dcafb7522",
+        "case_id": "card-visa-compact"
+      }
+    },
+    {
+      "id": "iban-gb-compact",
+      "input": "IBAN GB82WEST12345698765432",
+      "expected": [
+        {
+          "entity_type": "IBAN_CODE",
+          "start": 5,
+          "end": 27,
+          "raw": "GB82WEST12345698765432"
+        }
+      ],
+      "tier": "contract",
+      "provenance": {
+        "adapted_from": "tcheuD/anon-pii",
+        "commit": "1a22680e43b29c80e141a39b0a66eb3dcafb7522",
+        "case_id": "iban-gb-compact"
+      }
+    },
+    {
+      "id": "uuid-request-id",
+      "input": "request_id=550e8400-e29b-41d4-a716-446655440000",
+      "expected": [
+        {
+          "entity_type": "GUID",
+          "start": 11,
+          "end": 47,
+          "raw": "550e8400-e29b-41d4-a716-446655440000"
+        }
+      ],
+      "tier": "contract"
+    },
+    {
+      "id": "mac-locally-administered",
+      "input": "MAC: 02:42:ac:11:00:02",
+      "expected": [
+        {
+          "entity_type": "MAC_ADDRESS",
+          "start": 5,
+          "end": 22,
+          "raw": "02:42:ac:11:00:02"
+        }
+      ],
+      "tier": "contract",
+      "provenance": {
+        "adapted_from": "tcheuD/anon-pii",
+        "commit": "1a22680e43b29c80e141a39b0a66eb3dcafb7522",
+        "case_id": "mac-locally-administered"
+      }
+    },
+    {
+      "id": "url-basic",
+      "input": "See https://example.com/path",
+      "expected": [
+        {
+          "entity_type": "URL",
+          "start": 4,
+          "end": 28,
+          "raw": "https://example.com/path"
+        }
+      ],
+      "tier": "contract"
+    },
+    {
+      "id": "ipv4-documentation",
+      "input": "peer=192.0.2.44",
+      "expected": [
+        {
+          "entity_type": "IP_ADDRESS",
+          "start": 5,
+          "end": 15,
+          "raw": "192.0.2.44"
+        }
+      ],
+      "tier": "contract"
+    },
+    {
+      "id": "phone-us-context",
+      "input": "Call (202) 555-0142",
+      "expected": [
+        {
+          "entity_type": "PHONE_NUMBER",
+          "start": 5,
+          "end": 19,
+          "raw": "(202) 555-0142"
+        }
+      ],
+      "tier": "contract"
+    },
+    {
+      "id": "date-iso-date-only",
+      "input": "created_at=2026-07-13",
+      "expected": [
+        {
+          "entity_type": "DATE_TIME",
+          "start": 11,
+          "end": 21,
+          "raw": "2026-07-13"
+        }
+      ],
+      "tier": "contract"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the approved precision-first design ([spec](docs/superpowers/specs/2026-07-27-pattern-precision-quality-design.md), [plan](docs/superpowers/plans/2026-07-27-pattern-precision-quality.md)):

- Owned `testdata/quality/pattern-v1` corpus + baseline ratchet
- `cargo test -p redact-core --test quality_pattern_v1` exact-span scorer (pattern-default, no NER)
- Wave-1 precision fixes:
  - Reject impossible `DATE_TIME` calendar values
  - Reject null/broadcast `MAC_ADDRESS`
  - Surrounding-text precision gate for order-like phone/card, commit-shaped SHA1, junk `DOMAIN_NAME` fragments

## Results on pattern-v1

| Metric | Before | After |
|--------|--------|-------|
| Negative-tier FP | 7 | **0** |
| Overall FP | 7 | **0** |
| Precision | 56.25% | **100%** |
| Contract cases | exact | exact (no regression) |

## Test plan

- [x] `cargo test -p redact-core --test quality_pattern_v1`
- [x] `cargo test -p redact-core`
- [x] `cargo clippy -p redact-core --all-targets -- -D warnings`
- [x] `cargo fmt --all`

## Out of scope (wave 2)

Formatted-value recall (spaced cards, Cisco MAC, intl phones, etc.), NER scoring, performance work.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2409d804-1b9d-4fa2-852b-476713765276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2409d804-1b9d-4fa2-852b-476713765276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

