### PR TITLE
chore: release v0.9.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Concise guidance for AI agents working with the Redact codebase.
 - Pattern-based detection (54 entity types via regex, including secrets/credentials)
 - ML-powered NER using ONNX Runtime (BERT, RoBERTa, DistilBERT)
 - Multiple anonymization strategies (replace, mask, hash, encrypt)
-- Multi-platform: REST API, CLI, WebAssembly
+- Multi-platform: REST API, CLI, WebAssembly, privacy gateway (`redact-gateway`)
 
 ## Crate Architecture
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-27
+
 ### Added
 
 - `redact-gateway`: policy profiles with per-entity actions (`allow`, `block`,
@@ -117,6 +119,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `rand` to 0.9.3 to fix GHSA-cq8v-f236-94qc (unsoundness UB when custom logger accesses ThreadRng during reseeding)
   - Updated transitive dependencies in `quinn-proto` and `tokenizers` that also depended on `rand 0.9.2`
 
+## [0.8.3] - 2026-04-19
+
+### Changed
+
+- Docs: crates.io metadata, benchmarks, and release documentation updates (#54).
+
 ## [0.8.2] - 2026-04-17
 
 ### Fixed
@@ -181,4 +189,4 @@ See [README.md](README.md) for usage examples.
 ## Previous Releases (Go Implementation)
 
 For historical reference, versions v0.1.0 through v0.4.1 were the Go implementation.
-Those versions are no longer maintained. Please upgrade to v0.8.2 or later.
+Those versions are no longer maintained. Please upgrade to v0.9.0 or later.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,16 +193,24 @@ This project follows [Semantic Versioning](https://semver.org/):
 
 ## Release Process
 
-1. Update version in `Cargo.toml` (workspace and relevant crates)
-2. Update `CHANGELOG.md` with release notes
-3. Create a git tag: `git tag -a v1.2.3 -m "Release v1.2.3"`
-4. Push tag: `git push origin v1.2.3`
-5. GitHub Actions will automatically:
-   - Run CI tests
-   - Build binaries for all platforms
-   - Publish crates to crates.io
-   - Create GitHub release
-   - Build and push Docker images: default (`Dockerfile`) as `:latest`, `:X.Y.Z`, etc.; full image (`Dockerfile.ner`, pattern + ONNX NER) as `:full`, `:X.Y.Z-full`, etc.
+Preferred path (GitHub Actions):
+
+1. Update `CHANGELOG.md` and docs on a `release/vX.Y.Z` branch (or merge docs to `main` first)
+2. Bump versions in the workspace `Cargo.toml` and inter-crate dependency pins (`redact-ner`, `redact-api`, `redact-cli`, `redact-gateway`), or dispatch **Prepare Release** with the target version
+3. Open a PR from `release/vX.Y.Z` → `main` and wait for **CI** to pass
+4. Merge the PR — **Create Release Tag** creates `vX.Y.Z` and dispatches **Release**
+5. The **Release** workflow will:
+   - Build binaries for all platforms (`redact` and `redact-gateway`)
+   - Publish crates to crates.io (`redact-core`, `redact-ner`, `redact-api`, `redact-cli`)
+   - Create a GitHub release
+   - Build and push Docker images:
+     - default (`Dockerfile`) as `:latest`, `:X.Y.Z`, etc.
+     - full image (`Dockerfile.ner`, pattern + ONNX NER) as `:full`, `:X.Y.Z-full`, etc.
+     - gateway (`Dockerfile.gateway`) as `ghcr.io/<org>/redact-gateway:latest`, `:X.Y.Z`, etc.
+
+The NER base layer (`ghcr.io/<org>/redact-ner-base`) is built separately via the **NER Base Image** workflow and is not republished on every release.
+
+Manual fallback: bump versions, update the changelog, then `git tag -a vX.Y.Z -m "Release vX.Y.Z"` and `git push origin vX.Y.Z`.
 
 ## Project Structure
 
@@ -213,10 +221,14 @@ redact/
 │   ├── redact-ner/          # NER with ONNX Runtime
 │   ├── redact-api/          # REST API server
 │   ├── redact-cli/          # CLI tool
-│   └── redact-wasm/         # WASM bindings
+│   ├── redact-wasm/         # WASM bindings
+│   └── redact-gateway/      # OpenAI-compatible privacy gateway
+├── deploy/                  # Gateway Collector config and Kubernetes manifests
 ├── scripts/                 # Utility scripts
 ├── examples/                # Usage examples
-├── docs/                    # Documentation
+├── docs/
+│   ├── gateway/             # Gateway operator documentation
+│   └── benchmarks/          # Benchmark methodology and results
 └── .github/workflows/       # CI/CD pipelines
 ```
 
@@ -232,7 +244,7 @@ redact/
 
 ### Medium Priority
 
-- [ ] WASM implementation completion
+- [ ] WASM + inline NER (deferred; see README hybrid architecture)
 - [ ] Mobile FFI bindings
 - [ ] Additional anonymization strategies
 - [ ] Multi-language pattern support

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2554,7 +2554,7 @@ dependencies = [
 
 [[package]]
 name = "redact-api"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2571,7 +2571,7 @@ dependencies = [
 
 [[package]]
 name = "redact-cli"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "redact-core"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "redact-examples"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "redact-api",
@@ -2621,7 +2621,7 @@ dependencies = [
 
 [[package]]
 name = "redact-gateway"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "redact-ner"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "ndarray",
@@ -2681,7 +2681,7 @@ dependencies = [
 
 [[package]]
 name = "redact-wasm"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "getrandom 0.2.17",
  "getrandom 0.3.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.3"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.88"
 authors = ["Censgate LLC <support@censgate.com>"]

--- a/Dockerfile.ner
+++ b/Dockerfile.ner
@@ -1,4 +1,4 @@
-# Docker image with all entities enabled: pattern-based (36 types) + ONNX NER (PERSON, ORG, LOCATION).
+# Docker image with all entities enabled: pattern-based (54 types) + ONNX NER (PERSON, ORG, LOCATION).
 #
 # Build:
 #   docker build -f Dockerfile.ner -t ghcr.io/censgate/redact:full .

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 [![Tests](https://github.com/censgate/redact/workflows/CI/badge.svg)](https://github.com/censgate/redact/actions)
 [![Crates.io](https://img.shields.io/crates/v/redact-core.svg)](https://crates.io/crates/redact-core)
 
-**High-performance PII detection and anonymization engine**
+**High-performance PII detection, anonymization, and AI privacy gateway**
 
-A production-ready, Rust-based solution designed as a drop-in replacement for Microsoft Presidio.
+A production-ready Rust engine — drop-in Presidio replacement for detection and anonymization, plus an OpenAI-compatible gateway that redacts prompts and model answers in flight. Pattern detection covers 54 entity types (including secrets and credentials); WebAssembly ships the same pattern engine for browsers and edge runtimes.
 
-[Quick Start](#quick-start) · [Documentation](#documentation) · [Examples](#examples) · [Contributing](#contributing)
+[Quick Start](#quick-start) · [Privacy Gateway](#privacy-gateway) · [Documentation](#documentation) · [Examples](#examples) · [Contributing](#contributing)
 
 </div>
 
@@ -20,9 +20,9 @@ A production-ready, Rust-based solution designed as a drop-in replacement for Mi
 
 - **High Performance** — 10-100x faster than Python-based solutions with sub-millisecond inference
 - **Memory Safe** — Rust's borrow checker eliminates entire classes of security vulnerabilities
-- **Production Ready** — 54 pattern-based entity types with validation, plus transformer-based NER
-- **Multi-Platform** — Native server, CLI, and WebAssembly (pattern-only) support
-- **AI Privacy Gateway** — OpenAI-compatible proxy that redacts prompts and model answers in flight, with policy profiles, reversible tokenization, and OpenTelemetry
+- **Production Ready** — 54 pattern-based entity types with validation (including secrets/credentials), plus transformer-based NER
+- **AI Privacy Gateway** — OpenAI-compatible proxy (`redact-gateway`) with policy profiles, reversible tokenization, API key/OIDC auth, OpenTelemetry, and buffered/incremental streaming redaction
+- **Multi-Platform** — REST API, CLI, WebAssembly (pattern-only), and privacy gateway
 - **ML-Powered** — Full ONNX Runtime integration for transformer models (BERT, RoBERTa, DistilBERT)
 - **Lightweight** — ~20-50MB memory footprint vs ~300MB for Presidio
 - **Extensible** — Plugin architecture for custom recognizers and anonymization strategies
@@ -35,6 +35,22 @@ A production-ready, Rust-based solution designed as a drop-in replacement for Mi
 cargo install redact-cli
 redact --version
 ```
+
+### Privacy Gateway (OpenAI-compatible proxy)
+
+`redact-gateway` embeds `redact-core` and sits between your app and a model provider. Start with local redaction (no provider), then point an OpenAI SDK at the gateway.
+
+```bash
+# Local redaction without a model provider
+export OTEL_SDK_DISABLED=true
+cargo run -p redact-gateway -- --host 127.0.0.1
+
+curl -s http://127.0.0.1:8080/v1/redact \
+  -H 'content-type: application/json' \
+  -d '{"text":"Email me at alice@example.com"}'
+```
+
+Full walkthrough (Ollama chat, OpenAI SDK, policy profiles): [`docs/gateway/getting-started.md`](docs/gateway/getting-started.md). Docker image: `ghcr.io/censgate/redact-gateway:latest`.
 
 ### Analyze Text for PII
 
@@ -278,8 +294,8 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-redact-core = "0.8.2"
-redact-ner = "0.8.2"  # Optional: for ML-based NER
+redact-core = "0.9.0"
+redact-ner = "0.9.0"  # Optional: for ML-based NER
 ```
 
 ### Basic Pattern Detection
@@ -687,7 +703,7 @@ See [TEST_COVERAGE.md](/censgate/redact/blob/main/TEST_COVERAGE.md) for detailed
 #### v0.8.2
 
 - [x] Complete Rust rewrite (replacing Go v0.1.0-v0.4.1)
-- [x] 36 pattern-based entity types with checksum validation
+- [x] Pattern-based entity types with checksum validation
 - [x] Full ONNX NER integration (PERSON, ORGANIZATION, LOCATION)
 - [x] 4 anonymization strategies (replace, mask, hash, encrypt)
 - [x] REST API service
@@ -696,17 +712,16 @@ See [TEST_COVERAGE.md](/censgate/redact/blob/main/TEST_COVERAGE.md) for detailed
 - [x] Full Docker image with embedded NER model (`ghcr.io/censgate/redact:full`)
 - [x] Comprehensive test suite (~75% coverage)
 - [x] Entity overlap resolution with specificity scoring
+- [x] Publish crates to crates.io
 
-#### Unreleased
+#### v0.9.0
 
 - [x] 18 secret/credential entity types (54 pattern-based total) — Phase 1 of #101
 - [x] `redact-gateway`: policy profiles, reversible tokenization, OIDC and API key auth,
-      OpenTelemetry traces/metrics/logs, runtime pattern packs, container and Kubernetes assets
-
-#### v0.9.0 (Planned)
-
-- [x] Publish crates to crates.io
-- [x] WebAssembly bindings — pattern engine (browser + Cloudflare Workers)
+      OpenTelemetry traces/metrics/logs, runtime pattern packs, streaming redaction,
+      container and Kubernetes assets (`ghcr.io/censgate/redact-gateway`)
+- [x] CLI: `--fail-on-detect` and multi-file `-i` / `--file` analyze
+- [x] WebAssembly bindings — real pattern engine (browser + Cloudflare Workers)
 - [ ] Streaming API for large texts
 - [ ] Enhanced documentation
 - [ ] WebAssembly + inline NER — deferred; ONNX model + runtime do not fit

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,8 @@ We aim to respond within 48 hours and will work with you to understand and resol
 
 | Version | Supported | Notes |
 |---------|-----------|-------|
-| 0.8.x   | ✅ Yes | Current release (Rust rewrite) |
+| 0.9.x   | ✅ Yes | Current release |
+| 0.8.x   | ✅ Yes | Prior minor (security fixes) |
 | 0.1.x - 0.4.x | ❌ No | Legacy Go implementation (deprecated) |
 
 As new versions are released, this table will be updated. We generally support the current minor version and one prior.

--- a/crates/redact-api/Cargo.toml
+++ b/crates/redact-api/Cargo.toml
@@ -12,8 +12,8 @@ documentation = "https://docs.rs/redact-api"
 description = "REST API service for PII detection and anonymization"
 
 [dependencies]
-redact-core = { path = "../redact-core", version = "0.8.3" }
-redact-ner = { path = "../redact-ner", version = "0.8.3" }
+redact-core = { path = "../redact-core", version = "0.9.0" }
+redact-ner = { path = "../redact-ner", version = "0.9.0" }
 axum = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true }

--- a/crates/redact-cli/Cargo.toml
+++ b/crates/redact-cli/Cargo.toml
@@ -12,8 +12,8 @@ documentation = "https://docs.rs/redact-cli"
 description = "CLI tool for PII detection and anonymization"
 
 [dependencies]
-redact-core = { path = "../redact-core", version = "0.8.3" }
-redact-ner = { path = "../redact-ner", version = "0.8.3" }
+redact-core = { path = "../redact-core", version = "0.9.0" }
+redact-ner = { path = "../redact-ner", version = "0.9.0" }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/redact-gateway/Cargo.toml
+++ b/crates/redact-gateway/Cargo.toml
@@ -26,7 +26,7 @@ oidc = ["dep:jsonwebtoken"]
 prometheus = ["dep:opentelemetry-prometheus", "dep:prometheus"]
 
 [dependencies]
-redact-core = { path = "../redact-core", version = "0.8.3" }
+redact-core = { path = "../redact-core", version = "0.9.0" }
 axum = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true }

--- a/crates/redact-ner/Cargo.toml
+++ b/crates/redact-ner/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/redact-ner"
 description = "Named Entity Recognition for PII detection using ONNX Runtime"
 
 [dependencies]
-redact-core = { path = "../redact-core", version = "0.8.3" }
+redact-core = { path = "../redact-core", version = "0.9.0" }
 ort = { workspace = true }
 ndarray = { workspace = true }
 tokenizers = "0.22"

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -64,7 +64,7 @@ Benchmarks include:
 
 ## Latest Results (2026-04-18)
 
-The **current** release is **[v0.8.2](https://github.com/censgate/redact/releases/tag/v0.8.2)**. Full report: [results-20260418-175909.md](results-20260418-175909.md).
+The **current** release is **[v0.9.0](https://github.com/censgate/redact/releases/tag/v0.9.0)**. The latest published REST API comparison report remains [results-20260418-175909.md](results-20260418-175909.md) (captured against v0.8.2); re-run `./scripts/benchmark-comparison.sh` for fresh numbers.
 
 ### Latency (concurrency=1)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Release **v0.9.0** shipped: privacy gateway, 54 pattern entities (secrets/credentials), real WASM pattern engine, CLI `--fail-on-detect` / multi-file analyze, plus docs/changelog cutover.

**Merged** → **Create Release Tag** created `v0.9.0` → **Release** succeeded: https://github.com/censgate/redact/actions/runs/30232502013

## NER base eval

Kept `ghcr.io/censgate/redact-ner-base:v2` (no `:v3` publish):

- Content drivers unchanged: ORT `1.24.4`, `dslim/bert-base-NER`, `scripts/export_ner_model.py`
- Final image is `FROM scratch` (no OS package CVE surface to refresh by republish)
- Known ORT path-traversal fixed in 1.24.1; `:v2` ships 1.24.4
- Newer ORT (1.25–1.28) would be a deliberate content bump → immutable `:v3`, deferred without a concrete vuln driver
- Release full-image smoke (healthz + NER PERSON/ORG/LOC) passed against `:v2`

## Docs

- `CHANGELOG.md`: `[Unreleased]` → `[0.9.0]`; historical `[0.8.3]` stub
- `README.md`: hero/Quick Start/Features/roadmap foreground gateway + all 0.9.0 features; crate pins `0.9.0`
- `CONTRIBUTING.md` / `AGENTS.md` / `SECURITY.md` / `docs/benchmarks/README.md` / `Dockerfile.ner` aligned

## Verification

- [x] CI green on release PR
- [x] Tag `v0.9.0` created
- [x] Release workflow success (binaries, crates.io, GHCR slim/full/gateway, NER smoke)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e31303d1-3365-490c-ac5a-67ac2f476c36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e31303d1-3365-490c-ac5a-67ac2f476c36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

