### PR TITLE
docs(readme): lead with published privacy gateway

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,49 @@
+name: Publish Crates
+
+# Publish selected workspace crates to crates.io from an arbitrary git ref.
+# Used to ship crates that were missed by a tag release (e.g. redact-gateway 0.9.0)
+# and for ad-hoc republish attempts when continue-on-error hid a failure.
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to publish from (branch, tag, or SHA)'
+        required: true
+        type: string
+        default: 'main'
+      packages:
+        description: 'Space-separated crate names (e.g. redact-gateway)'
+        required: true
+        type: string
+        default: 'redact-gateway'
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish ${{ inputs.packages }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Publish packages
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -euo pipefail
+          for pkg in ${{ inputs.packages }}; do
+            echo "=== Publishing $pkg ==="
+            cargo publish --token "$CARGO_REGISTRY_TOKEN" -p "$pkg"
+            echo "Waiting for crates.io index..."
+            sleep 45
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,6 +195,13 @@ jobs:
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p redact-cli
         continue-on-error: true
 
+      - name: Wait for crates.io index
+        run: sleep 45
+
+      - name: Publish redact-gateway
+        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p redact-gateway
+        continue-on-error: true
+
   docker:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Publish `redact-gateway` to crates.io (was incorrectly `publish = false` in the
+  0.9.0 tag). Release automation now publishes it after `redact-cli`.
+
 ## [0.9.0] - 2026-07-27
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,7 +201,7 @@ Preferred path (GitHub Actions):
 4. Merge the PR — **Create Release Tag** creates `vX.Y.Z` and dispatches **Release**
 5. The **Release** workflow will:
    - Build binaries for all platforms (`redact` and `redact-gateway`)
-   - Publish crates to crates.io (`redact-core`, `redact-ner`, `redact-api`, `redact-cli`)
+   - Publish crates to crates.io (`redact-core`, `redact-ner`, `redact-api`, `redact-cli`, `redact-gateway`)
    - Create a GitHub release
    - Build and push Docker images:
      - default (`Dockerfile`) as `:latest`, `:X.Y.Z`, etc.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Rust](https://img.shields.io/badge/rust-1.88%2B-orange.svg)](https://www.rust-lang.org/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![Tests](https://github.com/censgate/redact/workflows/CI/badge.svg)](https://github.com/censgate/redact/actions)
+[![Crates.io](https://img.shields.io/crates/v/redact-gateway.svg)](https://crates.io/crates/redact-gateway)
 [![Crates.io](https://img.shields.io/crates/v/redact-core.svg)](https://crates.io/crates/redact-core)
 
 **OpenAI-compatible AI privacy gateway**
@@ -653,7 +654,7 @@ See [docs/benchmarks/](/censgate/redact/blob/main/docs/benchmarks) for methodolo
 ```
 redact/
 ├── crates/
-│   ├── redact-gateway/   # OpenAI-compatible privacy gateway (primary product surface)
+│   ├── redact-gateway/   # OpenAI-compatible privacy gateway (crates.io: redact-gateway)
 │   ├── redact-core/      # Detection & anonymization engine that powers the gateway
 │   ├── redact-ner/       # ONNX NER integration (optional engine add-on)
 │   ├── redact-api/       # REST API service (Axum) over the same engine

--- a/README.md
+++ b/README.md
@@ -41,8 +41,12 @@ redact --version
 `redact-gateway` embeds `redact-core` and sits between your app and a model provider. Start with local redaction (no provider), then point an OpenAI SDK at the gateway.
 
 ```bash
-# Local redaction without a model provider
+# Install from crates.io
+cargo install redact-gateway
 export OTEL_SDK_DISABLED=true
+redact-gateway --host 127.0.0.1
+
+# Or run from a source checkout
 cargo run -p redact-gateway -- --host 127.0.0.1
 
 curl -s http://127.0.0.1:8080/v1/redact \
@@ -50,7 +54,7 @@ curl -s http://127.0.0.1:8080/v1/redact \
   -d '{"text":"Email me at alice@example.com"}'
 ```
 
-Full walkthrough (Ollama chat, OpenAI SDK, policy profiles): [`docs/gateway/getting-started.md`](docs/gateway/getting-started.md). Docker image: `ghcr.io/censgate/redact-gateway:latest`.
+Full walkthrough (Ollama chat, OpenAI SDK, policy profiles): [`docs/gateway/getting-started.md`](docs/gateway/getting-started.md). Docker image: `ghcr.io/censgate/redact-gateway:latest`. Crates.io: [`redact-gateway`](https://crates.io/crates/redact-gateway).
 
 ### Analyze Text for PII
 
@@ -205,7 +209,8 @@ Cloudflare Workers AI). Inline WASM NER remains a deferred roadmap item.
 ### Using Cargo (Recommended)
 
 ```bash
-cargo install redact-cli
+cargo install redact-gateway   # OpenAI-compatible privacy gateway
+cargo install redact-cli       # CLI for analyze / anonymize
 ```
 
 ### From Source

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 [![Tests](https://github.com/censgate/redact/workflows/CI/badge.svg)](https://github.com/censgate/redact/actions)
 [![Crates.io](https://img.shields.io/crates/v/redact-core.svg)](https://crates.io/crates/redact-core)
 
-**High-performance PII detection, anonymization, and AI privacy gateway**
+**OpenAI-compatible AI privacy gateway**
 
-A production-ready Rust engine — drop-in Presidio replacement for detection and anonymization, plus an OpenAI-compatible gateway that redacts prompts and model answers in flight. Pattern detection covers 54 entity types (including secrets and credentials); WebAssembly ships the same pattern engine for browsers and edge runtimes.
+Redact sits between your application and a model provider: it redacts prompts on the way out and model answers on the way back — with policy profiles, reversible tokenization, auth, and OpenTelemetry. Under the hood, a high-performance Rust detection engine (54 pattern entity types including secrets, plus optional ONNX NER) powers the gateway, CLI, REST API, and WebAssembly builds.
 
 [Quick Start](#quick-start) · [Privacy Gateway](#privacy-gateway) · [Documentation](#documentation) · [Examples](#examples) · [Contributing](#contributing)
 
@@ -18,11 +18,12 @@ A production-ready Rust engine — drop-in Presidio replacement for detection an
 
 ## Features
 
+- **AI Privacy Gateway** — OpenAI-compatible proxy (`redact-gateway`) with policy profiles, reversible tokenization, API key/OIDC auth, OpenTelemetry, and buffered/incremental streaming redaction
+- **Engine-Powered** — In-process `redact-core` detection and anonymization (drop-in Presidio-class accuracy at Rust speed)
+- **Production Ready** — 54 pattern-based entity types with validation (including secrets/credentials), plus transformer-based NER
 - **High Performance** — 10-100x faster than Python-based solutions with sub-millisecond inference
 - **Memory Safe** — Rust's borrow checker eliminates entire classes of security vulnerabilities
-- **Production Ready** — 54 pattern-based entity types with validation (including secrets/credentials), plus transformer-based NER
-- **AI Privacy Gateway** — OpenAI-compatible proxy (`redact-gateway`) with policy profiles, reversible tokenization, API key/OIDC auth, OpenTelemetry, and buffered/incremental streaming redaction
-- **Multi-Platform** — REST API, CLI, WebAssembly (pattern-only), and privacy gateway
+- **Multi-Platform** — Privacy gateway, REST API, CLI, and WebAssembly (pattern-only)
 - **ML-Powered** — Full ONNX Runtime integration for transformer models (BERT, RoBERTa, DistilBERT)
 - **Lightweight** — ~20-50MB memory footprint vs ~300MB for Presidio
 - **Extensible** — Plugin architecture for custom recognizers and anonymization strategies
@@ -647,21 +648,21 @@ See [docs/benchmarks/](/censgate/redact/blob/main/docs/benchmarks) for methodolo
 ```
 redact/
 ├── crates/
-│   ├── redact-core/      # Core detection & anonymization engine
-│   ├── redact-ner/       # ONNX NER integration
-│   ├── redact-api/       # REST API service (Axum)
+│   ├── redact-gateway/   # OpenAI-compatible privacy gateway (primary product surface)
+│   ├── redact-core/      # Detection & anonymization engine that powers the gateway
+│   ├── redact-ner/       # ONNX NER integration (optional engine add-on)
+│   ├── redact-api/       # REST API service (Axum) over the same engine
 │   ├── redact-cli/       # Command-line tool
-│   ├── redact-wasm/      # WebAssembly bindings
-│   └── redact-gateway/   # OpenAI-compatible privacy gateway (embeds redact-core)
-├── patterns/             # PII detection patterns (GDPR, HIPAA, CCPA)
-├── deploy/               # Gateway Collector config and Kubernetes manifests
-├── scripts/              # Utility scripts (model export)
-├── examples/             # Usage examples
+│   └── redact-wasm/      # WebAssembly bindings (pattern engine)
 ├── docs/
 │   ├── gateway/          # Gateway operator documentation
 │   └── benchmarks/       # Benchmark methodology and results
+├── deploy/               # Gateway Collector config and Kubernetes manifests
 ├── Dockerfile.gateway
-└── docker-compose.gateway.yml
+├── docker-compose.gateway.yml
+├── patterns/             # PII detection patterns (GDPR, HIPAA, CCPA)
+├── scripts/              # Utility scripts (model export)
+└── examples/             # Usage examples
 ```
 
 ## Testing

--- a/crates/redact-gateway/Cargo.toml
+++ b/crates/redact-gateway/Cargo.toml
@@ -12,7 +12,6 @@ documentation = "https://docs.rs/redact-gateway"
 description = "OpenAI-compatible AI privacy gateway embedding redact-core"
 keywords = ["pii", "redaction", "gateway", "openai", "privacy"]
 categories = ["web-programming", "network-programming"]
-publish = false
 
 [features]
 default = ["otlp", "vault", "oidc", "prometheus"]

--- a/crates/redact-gateway/README.md
+++ b/crates/redact-gateway/README.md
@@ -20,13 +20,23 @@ Further reading:
 | Docker, Compose, Kubernetes | [docs/gateway/deployment.md](../../docs/gateway/deployment.md) |
 | Streaming modes | [docs/gateway/streaming.md](../../docs/gateway/streaming.md) |
 
-## Quick start
-
-The fastest path needs **no model provider**: build, run, and call `/v1/redact`. Full walkthrough: [getting-started.md](../../docs/gateway/getting-started.md).
+## Install
 
 ```bash
-# From the repository root
+cargo install redact-gateway
+```
+
+Crates.io: [`redact-gateway`](https://crates.io/crates/redact-gateway).
+
+## Quick start
+
+The fastest path needs **no model provider**: install or build, run, and call `/v1/redact`. Full walkthrough: [getting-started.md](../../docs/gateway/getting-started.md).
+
+```bash
 export OTEL_SDK_DISABLED=true
+redact-gateway --host 127.0.0.1
+
+# Or from a source checkout
 cargo run -p redact-gateway -- --host 127.0.0.1
 
 # Redact without calling a provider


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Lead the README with the OpenAI-compatible **privacy gateway** as the product pitch; `redact-core` is the engine underneath.

Also includes publishing `redact-gateway` to crates.io (merged from #111):

- Remove `publish = false` so `cargo install redact-gateway` / crates.io work
- Release workflow publishes `redact-gateway` after the other crates
- Add **Publish Crates** workflow to ship the missed **0.9.0** crate from `main` after merge
- Hero badge + Project Structure call out [`redact-gateway`](https://crates.io/crates/redact-gateway) on crates.io

## Test plan

- [x] Skim README hero + Project Structure for gateway-first framing
- [x] `cargo publish -p redact-gateway --dry-run --allow-dirty`
- [ ] CI green
- [ ] After merge: dispatch **Publish Crates** for `redact-gateway` @ `main`
- [ ] Confirm https://crates.io/crates/redact-gateway shows `0.9.0`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e31303d1-3365-490c-ac5a-67ac2f476c36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e31303d1-3365-490c-ac5a-67ac2f476c36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

