### PR TITLE
fix(gateway): publish redact-gateway to crates.io

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,49 @@
+name: Publish Crates
+
+# Publish selected workspace crates to crates.io from an arbitrary git ref.
+# Used to ship crates that were missed by a tag release (e.g. redact-gateway 0.9.0)
+# and for ad-hoc republish attempts when continue-on-error hid a failure.
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to publish from (branch, tag, or SHA)'
+        required: true
+        type: string
+        default: 'main'
+      packages:
+        description: 'Space-separated crate names (e.g. redact-gateway)'
+        required: true
+        type: string
+        default: 'redact-gateway'
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish ${{ inputs.packages }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Publish packages
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -euo pipefail
+          for pkg in ${{ inputs.packages }}; do
+            echo "=== Publishing $pkg ==="
+            cargo publish --token "$CARGO_REGISTRY_TOKEN" -p "$pkg"
+            echo "Waiting for crates.io index..."
+            sleep 45
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,6 +195,13 @@ jobs:
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p redact-cli
         continue-on-error: true
 
+      - name: Wait for crates.io index
+        run: sleep 45
+
+      - name: Publish redact-gateway
+        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p redact-gateway
+        continue-on-error: true
+
   docker:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Publish `redact-gateway` to crates.io (was incorrectly `publish = false` in the
+  0.9.0 tag). Release automation now publishes it after `redact-cli`.
+
 ## [0.9.0] - 2026-07-27
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,7 +201,7 @@ Preferred path (GitHub Actions):
 4. Merge the PR — **Create Release Tag** creates `vX.Y.Z` and dispatches **Release**
 5. The **Release** workflow will:
    - Build binaries for all platforms (`redact` and `redact-gateway`)
-   - Publish crates to crates.io (`redact-core`, `redact-ner`, `redact-api`, `redact-cli`)
+   - Publish crates to crates.io (`redact-core`, `redact-ner`, `redact-api`, `redact-cli`, `redact-gateway`)
    - Create a GitHub release
    - Build and push Docker images:
      - default (`Dockerfile`) as `:latest`, `:X.Y.Z`, etc.

--- a/README.md
+++ b/README.md
@@ -41,8 +41,12 @@ redact --version
 `redact-gateway` embeds `redact-core` and sits between your app and a model provider. Start with local redaction (no provider), then point an OpenAI SDK at the gateway.
 
 ```bash
-# Local redaction without a model provider
+# Install from crates.io
+cargo install redact-gateway
 export OTEL_SDK_DISABLED=true
+redact-gateway --host 127.0.0.1
+
+# Or run from a source checkout
 cargo run -p redact-gateway -- --host 127.0.0.1
 
 curl -s http://127.0.0.1:8080/v1/redact \
@@ -50,7 +54,7 @@ curl -s http://127.0.0.1:8080/v1/redact \
   -d '{"text":"Email me at alice@example.com"}'
 ```
 
-Full walkthrough (Ollama chat, OpenAI SDK, policy profiles): [`docs/gateway/getting-started.md`](docs/gateway/getting-started.md). Docker image: `ghcr.io/censgate/redact-gateway:latest`.
+Full walkthrough (Ollama chat, OpenAI SDK, policy profiles): [`docs/gateway/getting-started.md`](docs/gateway/getting-started.md). Docker image: `ghcr.io/censgate/redact-gateway:latest`. Crates.io: [`redact-gateway`](https://crates.io/crates/redact-gateway).
 
 ### Analyze Text for PII
 
@@ -205,7 +209,8 @@ Cloudflare Workers AI). Inline WASM NER remains a deferred roadmap item.
 ### Using Cargo (Recommended)
 
 ```bash
-cargo install redact-cli
+cargo install redact-gateway   # OpenAI-compatible privacy gateway
+cargo install redact-cli       # CLI for analyze / anonymize
 ```
 
 ### From Source

--- a/crates/redact-gateway/Cargo.toml
+++ b/crates/redact-gateway/Cargo.toml
@@ -12,7 +12,6 @@ documentation = "https://docs.rs/redact-gateway"
 description = "OpenAI-compatible AI privacy gateway embedding redact-core"
 keywords = ["pii", "redaction", "gateway", "openai", "privacy"]
 categories = ["web-programming", "network-programming"]
-publish = false
 
 [features]
 default = ["otlp", "vault", "oidc", "prometheus"]

--- a/crates/redact-gateway/README.md
+++ b/crates/redact-gateway/README.md
@@ -20,13 +20,23 @@ Further reading:
 | Docker, Compose, Kubernetes | [docs/gateway/deployment.md](../../docs/gateway/deployment.md) |
 | Streaming modes | [docs/gateway/streaming.md](../../docs/gateway/streaming.md) |
 
-## Quick start
-
-The fastest path needs **no model provider**: build, run, and call `/v1/redact`. Full walkthrough: [getting-started.md](../../docs/gateway/getting-started.md).
+## Install
 
 ```bash
-# From the repository root
+cargo install redact-gateway
+```
+
+Crates.io: [`redact-gateway`](https://crates.io/crates/redact-gateway).
+
+## Quick start
+
+The fastest path needs **no model provider**: install or build, run, and call `/v1/redact`. Full walkthrough: [getting-started.md](../../docs/gateway/getting-started.md).
+
+```bash
 export OTEL_SDK_DISABLED=true
+redact-gateway --host 127.0.0.1
+
+# Or from a source checkout
 cargo run -p redact-gateway -- --host 127.0.0.1
 
 # Redact without calling a provider


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`redact-gateway` was left at `publish = false`, so the 0.9.0 Release job never uploaded it to crates.io — that was the point of the release.

- Remove `publish = false` from [`crates/redact-gateway/Cargo.toml`](crates/redact-gateway/Cargo.toml)
- Publish `redact-gateway` in [`.github/workflows/release.yml`](.github/workflows/release.yml) after the other crates
- Add [`.github/workflows/publish-crates.yml`](.github/workflows/publish-crates.yml) to ship the missed **0.9.0** crate from `main` immediately after merge (`cargo publish --dry-run` already passes)
- Docs: `cargo install redact-gateway`, CONTRIBUTING publish list, changelog note

## Test plan

- [x] `cargo publish -p redact-gateway --dry-run --allow-dirty`
- [ ] CI green
- [ ] After merge: dispatch **Publish Crates** for `redact-gateway` @ `main`
- [ ] Confirm https://crates.io/crates/redact-gateway shows `0.9.0`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e31303d1-3365-490c-ac5a-67ac2f476c36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e31303d1-3365-490c-ac5a-67ac2f476c36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

