### PR TITLE
fix(docker): align builder glibc with distroless debian12 (#114)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,5 +201,57 @@ jobs:
             cargo run -q -p redact-gateway -- --config "$f" --config-source file validate-config
           done
 
-      - name: Build Dockerfile.gateway
+  # Fast guard against builder/runtime Debian (glibc) drift (#114).
+  docker-base-compat:
+    name: Docker base compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check Dockerfile builder/runtime pairing
+        run: ./scripts/check-docker-base-compat.sh
+
+  # Build and smoke-test publishable images so GLIBC mismatches fail in CI.
+  docker-images:
+    name: Docker image smoke tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build gateway image
         run: docker build -f Dockerfile.gateway -t redact-gateway:ci .
+
+      - name: Smoke test gateway image
+        run: docker run --rm redact-gateway:ci --version
+
+      - name: Build API image
+        run: docker build -f Dockerfile -t redact-api:ci .
+
+      - name: Smoke test API image
+        run: |
+          set -euo pipefail
+          docker run -d --name api-smoke -p 8080:8080 redact-api:ci
+          cleanup() { docker rm -f api-smoke >/dev/null 2>&1 || true; }
+          trap cleanup EXIT
+          echo "Waiting for API to become healthy..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8080/healthz > /dev/null 2>&1; then
+              echo "API ready after ${i}s"
+              curl -sf http://localhost:8080/healthz | python3 -m json.tool
+              exit 0
+            fi
+            if ! docker ps -q -f name=api-smoke | grep -q .; then
+              echo "ERROR: API container exited early"
+              docker logs api-smoke || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "ERROR: API failed to become healthy within 30s"
+          docker logs api-smoke || true
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,6 +234,39 @@ jobs:
           TAGS="${IMAGE}:${VER},${IMAGE}:${MINOR},${IMAGE}:${MAJOR},${IMAGE}:latest"
           echo "tags=$TAGS" >> $GITHUB_OUTPUT
 
+      - name: Build API image for smoke test (amd64 only)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          load: true
+          tags: redact-api:smoke-test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test API image
+        run: |
+          set -euo pipefail
+          docker run -d --name api-smoke -p 8080:8080 redact-api:smoke-test
+          cleanup() { docker rm -f api-smoke >/dev/null 2>&1 || true; }
+          trap cleanup EXIT
+          echo "Waiting for API to become healthy..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8080/healthz > /dev/null 2>&1; then
+              echo "API ready after ${i}s"
+              curl -sf http://localhost:8080/healthz | python3 -m json.tool
+              exit 0
+            fi
+            if ! docker ps -q -f name=api-smoke | grep -q .; then
+              echo "ERROR: API container exited early"
+              docker logs api-smoke || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "ERROR: API failed to become healthy within 30s"
+          docker logs api-smoke || true
+          exit 1
+
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
@@ -386,6 +419,19 @@ jobs:
           IMAGE="ghcr.io/${{ github.repository }}-gateway"
           TAGS="${IMAGE}:${VER},${IMAGE}:${MINOR},${IMAGE}:${MAJOR},${IMAGE}:latest"
           echo "tags=$TAGS" >> $GITHUB_OUTPUT
+
+      - name: Build gateway image for smoke test (amd64 only)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.gateway
+          load: true
+          tags: redact-gateway:smoke-test
+          cache-from: type=gha,scope=gateway
+          cache-to: type=gha,mode=max,scope=gateway
+
+      - name: Smoke test gateway image
+        run: docker run --rm redact-gateway:smoke-test --version
 
       - name: Build and push gateway image
         uses: docker/build-push-action@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Docker images: pin Rust builders to `rust:1.93-slim-bookworm` so binaries
   match `gcr.io/distroless/cc-debian12` glibc (fixes
   `GLIBC_2.38 not found` on `redact-gateway` / API images; #114).
-- CI/release: reject floating `rust:*-slim` builders vs distroless Debian
-  pairing, and smoke-test gateway (`--version`) and slim API (`/healthz`)
-  before publish.
+- CI/release: reject floating `rust:*-slim` builders and enforce that the
+  builder's Debian release matches the distroless runtime; smoke-test
+  gateway (`--version`) and slim API (`/healthz`) before publish.
 - Publish `redact-gateway` to crates.io (was incorrectly `publish = false` in the
   0.9.0 tag). Release automation now publishes it after `redact-cli`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Docker images: pin Rust builders to `rust:1.93-slim-bookworm` so binaries
+  match `gcr.io/distroless/cc-debian12` glibc (fixes
+  `GLIBC_2.38 not found` on `redact-gateway` / API images; #114).
+- CI/release: reject floating `rust:*-slim` builders vs distroless Debian
+  pairing, and smoke-test gateway (`--version`) and slim API (`/healthz`)
+  before publish.
 - Publish `redact-gateway` to crates.io (was incorrectly `publish = false` in the
   0.9.0 tag). Release automation now publishes it after `redact-cli`.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@
 #
 
 # Stage 1: Build
-FROM --platform=$BUILDPLATFORM rust:1.93-slim AS builder
+# Pin to bookworm so the linked glibc matches the distroless cc-debian12 runtime.
+FROM --platform=$BUILDPLATFORM rust:1.93-slim-bookworm AS builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/Dockerfile.gateway
+++ b/Dockerfile.gateway
@@ -12,7 +12,8 @@
 # the same approach as the main API image in ./Dockerfile.
 
 # Stage 1: Build
-FROM --platform=$BUILDPLATFORM rust:1.93-slim AS builder
+# Pin to bookworm so the linked glibc matches the distroless cc-debian12 runtime.
+FROM --platform=$BUILDPLATFORM rust:1.93-slim-bookworm AS builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/Dockerfile.ner
+++ b/Dockerfile.ner
@@ -36,7 +36,8 @@ FROM ${NER_BASE} AS ner-base
 # -----------------------------------------------------------------------------
 # Stage 1: Build redact-api binary
 # -----------------------------------------------------------------------------
-FROM --platform=$BUILDPLATFORM rust:1.93-slim AS builder
+# Pin to bookworm so the linked glibc matches the distroless cc-debian12 runtime.
+FROM --platform=$BUILDPLATFORM rust:1.93-slim-bookworm AS builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -80,6 +80,6 @@ The **current** release is **[v0.9.0](https://github.com/censgate/redact/release
 |--------|---------------|-------------------|---------|
 | Requests/sec | 19,416 | 170 | **114x** |
 
-**Environment:** Darwin arm64, Docker containers (builder: `rust:1.93-slim`; Redact runtime uses distroless). Benchmark tool: oha v1.10.0
+**Environment:** Darwin arm64, Docker containers (builder: `rust:1.93-slim-bookworm`; Redact runtime uses distroless). Benchmark tool: oha v1.10.0
 
 Results vary by hardware. Run `./scripts/benchmark-comparison.sh` to benchmark on your system.

--- a/scripts/benchmark-comparison.sh
+++ b/scripts/benchmark-comparison.sh
@@ -255,7 +255,7 @@ Entities detected: EMAIL_ADDRESS, PHONE_NUMBER, US_SSN
 
 ## Environment Details
 
-- **Redact:** Docker container (rust:1.93-slim base)
+- **Redact:** Docker container (rust:1.93-slim-bookworm base)
 - **Presidio:** Docker container (mcr.microsoft.com/presidio-analyzer:latest)
 - **Benchmark tool:** oha v$("$OHABIN" --version 2>/dev/null | head -1 | awk '{print $2}' || echo "unknown")
 

--- a/scripts/check-docker-base-compat.sh
+++ b/scripts/check-docker-base-compat.sh
@@ -25,22 +25,17 @@ fail() {
   exit 1
 }
 
-check_file() {
+# Strip optional --platform=... and AS/as stage name from a FROM line.
+parse_image() {
+  sed -E 's/^FROM[[:space:]]+(--platform=[^[:space:]]+[[:space:]]+)?//; s/[[:space:]]+[Aa][Ss][[:space:]].*$//' <<<"$1"
+}
+
+# Validate one rust builder image against the expected distroless Debian major.
+check_builder_image() {
   local file="$1"
-  local builder_line runtime_line builder_image runtime_image
-  local codename debian_major expected
-
-  [[ -f "$file" ]] || fail "missing Dockerfile: $file"
-
-  builder_line="$(grep -E '^FROM[[:space:]]' "$file" | grep -E 'rust:' | tail -n1 || true)"
-  runtime_line="$(grep -E '^FROM[[:space:]]' "$file" | grep -E 'distroless/cc-debian' | tail -n1 || true)"
-
-  [[ -n "$builder_line" ]] || fail "$file: no rust builder FROM line found"
-  [[ -n "$runtime_line" ]] || fail "$file: no distroless/cc-debian runtime FROM line found"
-
-  # Strip optional --platform=... and AS stage name
-  builder_image="$(sed -E 's/^FROM[[:space:]]+(--platform=[^[:space:]]+[[:space:]]+)?//; s/[[:space:]]+AS[[:space:]].*$//' <<<"$builder_line")"
-  runtime_image="$(sed -E 's/^FROM[[:space:]]+(--platform=[^[:space:]]+[[:space:]]+)?//; s/[[:space:]]+AS[[:space:]].*$//' <<<"$runtime_line")"
+  local builder_image="$2"
+  local expected="$3"
+  local codename
 
   if [[ "$builder_image" =~ ^rust:([0-9]+\.[0-9]+(\.[0-9]+)?)-slim$ ]]; then
     fail "$file: floating builder '$builder_image' (use an explicit Debian codename, e.g. rust:${BASH_REMATCH[1]}-slim-bookworm)"
@@ -54,20 +49,43 @@ check_file() {
     fail "$file: builder '$builder_image' must include an explicit Debian codename (-bookworm/-trixie/-bullseye)"
   fi
 
-  expected="$(expected_debian_major "$codename")" \
+  local builder_expected
+  builder_expected="$(expected_debian_major "$codename")" \
     || fail "$file: unsupported builder Debian codename '$codename'"
+
+  if [[ "$builder_expected" != "$expected" ]]; then
+    fail "$file: builder '$builder_image' (codename $codename) expects distroless/cc-debian${builder_expected}, runtime requires debian${expected}"
+  fi
+}
+
+check_file() {
+  local file="$1"
+  local runtime_line runtime_image debian_major expected
+  local -a builder_lines=()
+  local builder_line builder_image
+
+  [[ -f "$file" ]] || fail "missing Dockerfile: $file"
+
+  mapfile -t builder_lines < <(grep -E '^FROM[[:space:]]' "$file" | grep -E 'rust:' || true)
+  runtime_line="$(grep -E '^FROM[[:space:]]' "$file" | grep -E 'distroless/cc-debian' | tail -n1 || true)"
+
+  [[ ${#builder_lines[@]} -gt 0 ]] || fail "$file: no rust builder FROM line found"
+  [[ -n "$runtime_line" ]] || fail "$file: no distroless/cc-debian runtime FROM line found"
+
+  runtime_image="$(parse_image "$runtime_line")"
 
   if [[ "$runtime_image" =~ distroless/cc-debian([0-9]+) ]]; then
     debian_major="${BASH_REMATCH[1]}"
   else
     fail "$file: could not parse distroless Debian major from '$runtime_image'"
   fi
+  expected="$debian_major"
 
-  if [[ "$debian_major" != "$expected" ]]; then
-    fail "$file: builder codename '$codename' expects distroless/cc-debian${expected}, found '$runtime_image'"
-  fi
-
-  echo "OK: $(basename "$file") builder=$builder_image runtime=$runtime_image"
+  for builder_line in "${builder_lines[@]}"; do
+    builder_image="$(parse_image "$builder_line")"
+    check_builder_image "$file" "$builder_image" "$expected"
+    echo "OK: $(basename "$file") builder=$builder_image runtime=$runtime_image"
+  done
 }
 
 main() {

--- a/scripts/check-docker-base-compat.sh
+++ b/scripts/check-docker-base-compat.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Verify multi-stage Dockerfiles pin the Rust builder Debian train to match
+# the distroless runtime (avoids GLIBC symbol mismatches like #114).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FILES=(
+  "${ROOT}/Dockerfile"
+  "${ROOT}/Dockerfile.gateway"
+  "${ROOT}/Dockerfile.ner"
+)
+
+# bookworm -> debian12, trixie -> debian13, bullseye -> debian11
+expected_debian_major() {
+  case "$1" in
+    bookworm) echo 12 ;;
+    trixie) echo 13 ;;
+    bullseye) echo 11 ;;
+    *) return 1 ;;
+  esac
+}
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+check_file() {
+  local file="$1"
+  local builder_line runtime_line builder_image runtime_image
+  local codename debian_major expected
+
+  [[ -f "$file" ]] || fail "missing Dockerfile: $file"
+
+  builder_line="$(grep -E '^FROM[[:space:]]' "$file" | grep -E 'rust:' | tail -n1 || true)"
+  runtime_line="$(grep -E '^FROM[[:space:]]' "$file" | grep -E 'distroless/cc-debian' | tail -n1 || true)"
+
+  [[ -n "$builder_line" ]] || fail "$file: no rust builder FROM line found"
+  [[ -n "$runtime_line" ]] || fail "$file: no distroless/cc-debian runtime FROM line found"
+
+  # Strip optional --platform=... and AS stage name
+  builder_image="$(sed -E 's/^FROM[[:space:]]+(--platform=[^[:space:]]+[[:space:]]+)?//; s/[[:space:]]+AS[[:space:]].*$//' <<<"$builder_line")"
+  runtime_image="$(sed -E 's/^FROM[[:space:]]+(--platform=[^[:space:]]+[[:space:]]+)?//; s/[[:space:]]+AS[[:space:]].*$//' <<<"$runtime_line")"
+
+  if [[ "$builder_image" =~ ^rust:([0-9]+\.[0-9]+(\.[0-9]+)?)-slim$ ]]; then
+    fail "$file: floating builder '$builder_image' (use an explicit Debian codename, e.g. rust:${BASH_REMATCH[1]}-slim-bookworm)"
+  fi
+
+  if [[ "$builder_image" =~ ^rust:[^[:space:]]+-slim-(bookworm|trixie|bullseye)(@.+)?$ ]]; then
+    codename="${BASH_REMATCH[1]}"
+  elif [[ "$builder_image" =~ ^rust:[^[:space:]]+-(bookworm|trixie|bullseye)(@.+)?$ ]]; then
+    codename="${BASH_REMATCH[1]}"
+  else
+    fail "$file: builder '$builder_image' must include an explicit Debian codename (-bookworm/-trixie/-bullseye)"
+  fi
+
+  expected="$(expected_debian_major "$codename")" \
+    || fail "$file: unsupported builder Debian codename '$codename'"
+
+  if [[ "$runtime_image" =~ distroless/cc-debian([0-9]+) ]]; then
+    debian_major="${BASH_REMATCH[1]}"
+  else
+    fail "$file: could not parse distroless Debian major from '$runtime_image'"
+  fi
+
+  if [[ "$debian_major" != "$expected" ]]; then
+    fail "$file: builder codename '$codename' expects distroless/cc-debian${expected}, found '$runtime_image'"
+  fi
+
+  echo "OK: $(basename "$file") builder=$builder_image runtime=$runtime_image"
+}
+
+main() {
+  local f
+  for f in "${FILES[@]}"; do
+    check_file "$f"
+  done
+  echo "All Dockerfiles have matching builder/runtime Debian trains."
+}
+
+main "$@"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #114: published `ghcr.io/censgate/redact-gateway:0.9.0` (and `:latest`) cannot start because the binary was linked against Debian 13 glibc (`rust:1.93-slim` == `slim-trixie`) while the runtime is `gcr.io/distroless/cc-debian12`.

## Changes

- Pin builders in `Dockerfile`, `Dockerfile.gateway`, and `Dockerfile.ner` to `rust:1.93-slim-bookworm`
- Add `scripts/check-docker-base-compat.sh` to reject floating `rust:*-slim` and enforce bookworm↔debian12 / trixie↔debian13 pairing
- CI: `docker-base-compat` job + gateway `--version` and API `/healthz` smoke tests
- Release: smoke-test slim API and gateway images before GHCR push

## Follow-up (required for usable images)

A merge alone does not repair GHCR tags. Cut **v0.9.1** after merge so `redact-gateway:0.9.1` / `:latest` are rebuilt.

## Test plan

- [x] `./scripts/check-docker-base-compat.sh` passes on fixed Dockerfiles
- [x] Script rejects floating `rust:1.93-slim` + `cc-debian12`
- [ ] CI `docker-base-compat` and `docker-images` jobs green
- [ ] After v0.9.1: `docker run --rm ghcr.io/censgate/redact-gateway:0.9.1 --version` has no GLIBC errors

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb4cdc1a-f8f1-4138-a371-d1e9a03d2c83?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb4cdc1a-f8f1-4138-a371-d1e9a03d2c83&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

