### PR TITLE
chore: release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-08-08
+
 ### Fixed
 
 - Docker images: pin Rust builders to `rust:1.93-slim-bookworm` so binaries

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2554,7 +2554,7 @@ dependencies = [
 
 [[package]]
 name = "redact-api"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2571,7 +2571,7 @@ dependencies = [
 
 [[package]]
 name = "redact-cli"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2587,7 +2587,7 @@ dependencies = [
 
 [[package]]
 name = "redact-core"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "redact-examples"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "redact-api",
@@ -2621,7 +2621,7 @@ dependencies = [
 
 [[package]]
 name = "redact-gateway"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "redact-ner"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "ndarray",
@@ -2681,7 +2681,7 @@ dependencies = [
 
 [[package]]
 name = "redact-wasm"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "getrandom 0.2.17",
  "getrandom 0.3.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 rust-version = "1.88"
 authors = ["Censgate LLC <support@censgate.com>"]

--- a/crates/redact-api/Cargo.toml
+++ b/crates/redact-api/Cargo.toml
@@ -12,8 +12,8 @@ documentation = "https://docs.rs/redact-api"
 description = "REST API service for PII detection and anonymization"
 
 [dependencies]
-redact-core = { path = "../redact-core", version = "0.9.0" }
-redact-ner = { path = "../redact-ner", version = "0.9.0" }
+redact-core = { path = "../redact-core", version = "0.9.1" }
+redact-ner = { path = "../redact-ner", version = "0.9.1" }
 axum = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true }

--- a/crates/redact-cli/Cargo.toml
+++ b/crates/redact-cli/Cargo.toml
@@ -12,8 +12,8 @@ documentation = "https://docs.rs/redact-cli"
 description = "CLI tool for PII detection and anonymization"
 
 [dependencies]
-redact-core = { path = "../redact-core", version = "0.9.0" }
-redact-ner = { path = "../redact-ner", version = "0.9.0" }
+redact-core = { path = "../redact-core", version = "0.9.1" }
+redact-ner = { path = "../redact-ner", version = "0.9.1" }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/redact-gateway/Cargo.toml
+++ b/crates/redact-gateway/Cargo.toml
@@ -25,7 +25,7 @@ oidc = ["dep:jsonwebtoken"]
 prometheus = ["dep:opentelemetry-prometheus", "dep:prometheus"]
 
 [dependencies]
-redact-core = { path = "../redact-core", version = "0.9.0" }
+redact-core = { path = "../redact-core", version = "0.9.1" }
 axum = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true }

--- a/crates/redact-ner/Cargo.toml
+++ b/crates/redact-ner/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/redact-ner"
 description = "Named Entity Recognition for PII detection using ONNX Runtime"
 
 [dependencies]
-redact-core = { path = "../redact-core", version = "0.9.0" }
+redact-core = { path = "../redact-core", version = "0.9.1" }
 ort = { workspace = true }
 ndarray = { workspace = true }
 tokenizers = "0.22"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Release **v0.9.1** so GHCR can republish working Docker images after #114 / #115.

Includes version bumps (`0.9.0` → `0.9.1`) and changelog promotion of the Docker glibc alignment + CI/release smoke guards.

## After merge

Create tag `v0.9.1` (or run Create Release Tag) to trigger `release.yml`, which rebuilds and pushes:

- `ghcr.io/censgate/redact-gateway:0.9.1` (+ `:latest` / `:0` / `:0.9`)
- `ghcr.io/censgate/redact:0.9.1` (+ related tags)

## Test plan

- [ ] CI green on this PR
- [ ] Tag `v0.9.1` created and release workflow completes
- [ ] `docker run --rm ghcr.io/censgate/redact-gateway:0.9.1 --version` succeeds without GLIBC errors

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb4cdc1a-f8f1-4138-a371-d1e9a03d2c83?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb4cdc1a-f8f1-4138-a371-d1e9a03d2c83&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

