### PR TITLE
docs: sync current release pins to v0.9.1 + automate for future releases

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -56,6 +56,19 @@ jobs:
             sed -i "s/\(redact-core = { path = \"[^\"]*\", version = \"\)[^\"]*/\1$VERSION/" "$f"
             sed -i "s/\(redact-ner = { path = \"[^\"]*\", version = \"\)[^\"]*/\1$VERSION/" "$f"
           done
+          # Keep published docs in sync with the release version.
+          sed -i \
+            -e "s/^redact-core = \"[^\"]*\"/redact-core = \"$VERSION\"/" \
+            -e "s/^redact-ner = \"[^\"]*\"/redact-ner = \"$VERSION\"/" \
+            README.md
+          sed -i -E \
+            "s|The \*\*current\*\* release is \*\*\[v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?\]\(https://github.com/censgate/redact/releases/tag/v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?\)\*\*|The **current** release is **[v${VERSION}](https://github.com/censgate/redact/releases/tag/v${VERSION})**|" \
+            docs/benchmarks/README.md
+          if grep -q "Please upgrade to v" CHANGELOG.md; then
+            sed -i -E \
+              "s/Please upgrade to v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)? or later\./Please upgrade to v${VERSION} or later./" \
+              CHANGELOG.md
+          fi
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,4 +202,4 @@ See [README.md](README.md) for usage examples.
 ## Previous Releases (Go Implementation)
 
 For historical reference, versions v0.1.0 through v0.4.1 were the Go implementation.
-Those versions are no longer maintained. Please upgrade to v0.9.0 or later.
+Those versions are no longer maintained. Please upgrade to v0.9.1 or later.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,8 +195,11 @@ This project follows [Semantic Versioning](https://semver.org/):
 
 Preferred path (GitHub Actions):
 
-1. Update `CHANGELOG.md` and docs on a `release/vX.Y.Z` branch (or merge docs to `main` first)
-2. Bump versions in the workspace `Cargo.toml` and inter-crate dependency pins (`redact-ner`, `redact-api`, `redact-cli`, `redact-gateway`), or dispatch **Prepare Release** with the target version
+1. Update `CHANGELOG.md` release notes on a `release/vX.Y.Z` branch (or merge notes to `main` first)
+2. Bump versions via **Prepare Release** (preferred) or `./scripts/update-version.sh X.Y.Z`.
+   Both update workspace/`Cargo.toml` pins **and** documentation version pins
+   (`README.md` library examples, `docs/benchmarks/README.md` current-release link,
+   CHANGELOG unsupported-version upgrade hint), plus `redact-gateway` crate deps.
 3. Open a PR from `release/vX.Y.Z` → `main` and wait for **CI** to pass
 4. Merge the PR — **Create Release Tag** creates `vX.Y.Z` and dispatches **Release**
 5. The **Release** workflow will:
@@ -210,7 +213,7 @@ Preferred path (GitHub Actions):
 
 The NER base layer (`ghcr.io/<org>/redact-ner-base`) is built separately via the **NER Base Image** workflow and is not republished on every release.
 
-Manual fallback: bump versions, update the changelog, then `git tag -a vX.Y.Z -m "Release vX.Y.Z"` and `git push origin vX.Y.Z`.
+Manual fallback: `./scripts/update-version.sh X.Y.Z`, review the diff (Cargo + docs), then `git tag -a vX.Y.Z -m "Release vX.Y.Z"` and `git push origin vX.Y.Z`.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -301,8 +301,8 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-redact-core = "0.9.0"
-redact-ner = "0.9.0"  # Optional: for ML-based NER
+redact-core = "0.9.1"
+redact-ner = "0.9.1"  # Optional: for ML-based NER
 ```
 
 ### Basic Pattern Detection
@@ -734,6 +734,14 @@ See [TEST_COVERAGE.md](/censgate/redact/blob/main/TEST_COVERAGE.md) for detailed
 - [ ] WebAssembly + inline NER — deferred; ONNX model + runtime do not fit
       Cloudflare Workers limits. Use the hybrid architecture in the
       [WebAssembly](#webassembly) section for name-based detection.
+
+#### v0.9.1
+
+- [x] Docker images: pin Rust builders to `rust:1.93-slim-bookworm` so binaries
+      match `gcr.io/distroless/cc-debian12` (fixes `GLIBC_2.38 not found` on
+      published gateway/API images; #114)
+- [x] CI/release guards: Dockerfile builder/runtime Debian pairing check and
+      gateway/API image smoke tests before publish
 
 ## Contributing
 

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -64,7 +64,7 @@ Benchmarks include:
 
 ## Latest Results (2026-04-18)
 
-The **current** release is **[v0.9.0](https://github.com/censgate/redact/releases/tag/v0.9.0)**. The latest published REST API comparison report remains [results-20260418-175909.md](results-20260418-175909.md) (captured against v0.8.2); re-run `./scripts/benchmark-comparison.sh` for fresh numbers.
+The **current** release is **[v0.9.1](https://github.com/censgate/redact/releases/tag/v0.9.1)**. The latest published REST API comparison report remains [results-20260418-175909.md](results-20260418-175909.md) (captured against v0.8.2); re-run `./scripts/benchmark-comparison.sh` for fresh numbers.
 
 ### Latency (concurrency=1)
 

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -37,6 +37,9 @@ show_usage() {
     echo "  - crates/redact-ner/Cargo.toml (redact-core dependency)"
     echo "  - crates/redact-api/Cargo.toml (redact-core, redact-ner dependencies)"
     echo "  - crates/redact-cli/Cargo.toml (redact-core, redact-ner dependencies)"
+    echo "  - crates/redact-gateway/Cargo.toml (redact-core dependency)"
+    echo "  - README.md (library Cargo.toml example versions)"
+    echo "  - docs/benchmarks/README.md (current release link)"
     echo "  - CHANGELOG.md (adds new version entry)"
 }
 
@@ -141,6 +144,43 @@ update_changelog() {
     print_success "Added $new_version entry to CHANGELOG.md"
 }
 
+update_doc_versions() {
+    local new_version=$1
+    local dry_run=$2
+
+    print_status "Updating documentation version pins to $new_version"
+
+    if [[ $dry_run == "true" ]]; then
+        echo "  Would update README.md library Cargo.toml examples"
+        echo "  Would update docs/benchmarks/README.md current release link"
+        echo "  Would update CHANGELOG.md unsupported-version upgrade hint"
+        return
+    fi
+
+    # README library usage example
+    sed -i.bak \
+        -e "s/^redact-core = \"[^\"]*\"/redact-core = \"$new_version\"/" \
+        -e "s/^redact-ner = \"[^\"]*\"/redact-ner = \"$new_version\"/" \
+        README.md
+    rm -f README.md.bak
+
+    # Benchmarks "current release" pointer
+    sed -i.bak -E \
+        "s|The \*\*current\*\* release is \*\*\[v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?\]\(https://github.com/censgate/redact/releases/tag/v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?\)\*\*|The **current** release is **[v${new_version}](https://github.com/censgate/redact/releases/tag/v${new_version})**|" \
+        docs/benchmarks/README.md
+    rm -f docs/benchmarks/README.md.bak
+
+    # Unsupported Go-era versions hint at bottom of CHANGELOG
+    if grep -q "Please upgrade to v" CHANGELOG.md; then
+        sed -i.bak -E \
+            "s/Please upgrade to v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)? or later\./Please upgrade to v${new_version} or later./" \
+            CHANGELOG.md
+        rm -f CHANGELOG.md.bak
+    fi
+
+    print_success "Updated documentation version pins to $new_version"
+}
+
 verify_build() {
     local dry_run=$1
     
@@ -230,6 +270,8 @@ main() {
     update_crate_dependency "crates/redact-api/Cargo.toml" "redact-ner" "$new_version" "$dry_run"
     update_crate_dependency "crates/redact-cli/Cargo.toml" "redact-core" "$new_version" "$dry_run"
     update_crate_dependency "crates/redact-cli/Cargo.toml" "redact-ner" "$new_version" "$dry_run"
+    update_crate_dependency "crates/redact-gateway/Cargo.toml" "redact-core" "$new_version" "$dry_run"
+    update_doc_versions "$new_version" "$dry_run"
     update_changelog "$new_version" "$dry_run"
     
     echo ""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Answer:** we did *not* previously have automation that updates docs to the new release version. `Prepare Release` / `scripts/update-version.sh` only bumped Cargo.toml (and optionally stubbed CHANGELOG).

This PR:

1. Points current-version doc pins at **v0.9.1**
2. Extends release automation so the next bump keeps those pins in sync

## Doc updates

- `README.md` — `redact-core` / `redact-ner` Cargo examples → `0.9.1`; add Roadmap `v0.9.1` items for #114
- `docs/benchmarks/README.md` — current release link → v0.9.1
- `CHANGELOG.md` — unsupported Go-era upgrade hint → v0.9.1
- `CONTRIBUTING.md` — document the new release automation behavior

Historical `## [0.9.0]` / Roadmap `#### v0.9.0` entries are intentionally left as history.

## Automation

- [`scripts/update-version.sh`](scripts/update-version.sh) — `update_doc_versions` + `redact-gateway` crate pin
- [`.github/workflows/prepare-release.yml`](.github/workflows/prepare-release.yml) — same doc sed updates on prepare

## Test plan

- [x] `./scripts/update-version.sh 0.9.2 --dry-run` shows doc pin updates
- [x] No remaining *current-version* `0.9.0` pins outside historical changelog/roadmap sections
- [ ] CI green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb4cdc1a-f8f1-4138-a371-d1e9a03d2c83?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb4cdc1a-f8f1-4138-a371-d1e9a03d2c83&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

