### PR TITLE
docs: add Contributor License Agreement and project scope

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+Thank you for contributing to Redact. These checkboxes are acknowledgements;
+the CLA bot enforces the Individual CLA signature.
+
+- [ ] I have read [CLA.md](../CLA.md) and will sign via the bot comment (or I have already signed / a Corporate CLA covering me is on file)
+- [ ] All commits are DCO-signed (`git commit -s`)
+- [ ] I have read [docs/PROJECT_SCOPE.md](../docs/PROJECT_SCOPE.md); this change is in scope
+
+**Employer time or equipment**
+
+- [ ] No — this work was not done on employer time or equipment
+- [ ] Yes — my employer has authorised the contribution, or a Corporate CLA is on file
+
+## Summary
+
+<!-- What does this change do, and why? -->
+
+## Test plan
+
+<!-- How did you verify the change? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 Thank you for contributing to Redact. These checkboxes are acknowledgements;
 the CLA bot enforces the Individual CLA signature.
 
-- [ ] I have read [CLA.md](../CLA.md) and will sign via the bot comment (or I have already signed / a Corporate CLA covering me is on file)
+- [ ] I have read [CLA.md](../CLA.md) and will sign the Individual CLA via the bot comment (or I have already signed). A Corporate CLA, if required, does not replace the Individual CLA.
 - [ ] All commits are DCO-signed (`git commit -s`)
 - [ ] I have read [docs/PROJECT_SCOPE.md](../docs/PROJECT_SCOPE.md); this change is in scope
 

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,59 @@
+# CLA signatures are stored in this repository on the unprotected
+# `cla-signatures` branch (signatures/version1/cla.json).
+# Do not create that JSON file by hand — the action creates it.
+#
+# contributor-assistant/github-action is archived; v2.6.1 remains the
+# last release. Pin by SHA. If the action stops working, a maintainer
+# can add the GitHub username to `allowlist` or the signatures file.
+#
+# This workflow must not check out pull-request HEAD or run PR-controlled
+# code. pull_request_target is required by the action.
+#
+# After the first run, require the "CLA Assistant" check on protected
+# merge-target branches. Until then the check can fail without blocking merge.
+
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    name: CLA Assistant
+    if: github.event_name == 'pull_request_target' || github.event.issue.pull_request
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        if: |
+          github.event_name == 'pull_request_target' ||
+          github.event.comment.body == 'recheck' ||
+          github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: signatures/version1/cla.json
+          path-to-document: https://github.com/censgate/redact/blob/main/CLA.md
+          branch: cla-signatures
+          allowlist: dependabot[bot],github-actions[bot]
+          custom-notsigned-prcomment: |
+            Thank you for your pull request. Each human contributor must sign
+            the Contributor License Agreement (CLA.md) before this can be
+            merged. Post exactly this comment:
+
+            I have read the CLA Document and I hereby sign the CLA
+
+            If you contributed on employer time or equipment, a Corporate CLA
+            may also be required (see CLA.md). Commits should include a
+            Developer Certificate of Origin sign-off (`git commit -s`). That
+            is project policy; this check covers the CLA only.
+          lock-pullrequest-aftermerge: true

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -9,8 +9,9 @@
 # This workflow must not check out pull-request HEAD or run PR-controlled
 # code. pull_request_target is required by the action.
 #
-# After the first run, require the "CLA Assistant" check on protected
-# merge-target branches. Until then the check can fail without blocking merge.
+# After this workflow is on main, require the "CLA Assistant" check on
+# the main ruleset. Do not protect cla-signatures in a way that blocks
+# GITHUB_TOKEN.
 
 name: CLA Assistant
 
@@ -33,10 +34,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: CLA Assistant
-        if: |
-          github.event_name == 'pull_request_target' ||
-          github.event.comment.body == 'recheck' ||
-          github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -47,13 +44,83 @@ jobs:
           allowlist: dependabot[bot],github-actions[bot]
           custom-notsigned-prcomment: |
             Thank you for your pull request. Each human contributor must sign
-            the Contributor License Agreement (CLA.md) before this can be
-            merged. Post exactly this comment:
+            the Individual Contributor License Agreement (CLA.md) before this
+            can be merged. A Corporate CLA, if required, does not replace the
+            Individual CLA. Post this comment (whitespace around it is fine):
 
             I have read the CLA Document and I hereby sign the CLA
 
-            If you contributed on employer time or equipment, a Corporate CLA
-            may also be required (see CLA.md). Commits should include a
-            Developer Certificate of Origin sign-off (`git commit -s`). That
-            is project policy; this check covers the CLA only.
+            Commits should include a Developer Certificate of Origin sign-off
+            (`git commit -s`). That is project policy; this check covers the
+            CLA only.
           lock-pullrequest-aftermerge: true
+
+      # The archived action only reads the first page of PR commits.
+      # Paginate here and fail if any GitHub author is unsigned.
+      # Checkout cla-signatures only — never the pull-request HEAD.
+      - name: Checkout signature store
+        if: github.event_name == 'pull_request_target' || github.event.issue.pull_request
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: cla-signatures
+          persist-credentials: false
+
+      - name: Verify all PR commit authors are signed
+        if: github.event_name == 'pull_request_target' || github.event.issue.pull_request
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const fs = require('fs');
+            const allowlist = new Set(['dependabot[bot]', 'github-actions[bot]']);
+            const prNumber = context.payload.pull_request
+              ? context.payload.pull_request.number
+              : context.issue.number;
+
+            let signed = new Set();
+            const claPath = 'signatures/version1/cla.json';
+            if (fs.existsSync(claPath)) {
+              const parsed = JSON.parse(fs.readFileSync(claPath, 'utf8'));
+              for (const row of parsed.signedContributors || []) {
+                if (row && row.name) {
+                  signed.add(String(row.name).toLowerCase());
+                }
+              }
+            }
+
+            const commits = await github.paginate(
+              github.rest.pulls.listCommits,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                per_page: 100,
+              }
+            );
+
+            const missing = [];
+            const seen = new Set();
+            for (const commit of commits) {
+              const login = commit.author && commit.author.login;
+              if (!login) {
+                const sha = commit.sha.slice(0, 7);
+                const name = (commit.commit.author && commit.commit.author.name) || 'unknown';
+                missing.push(`${name} (no GitHub login, ${sha})`);
+                continue;
+              }
+              const key = login.toLowerCase();
+              if (seen.has(key) || allowlist.has(login)) {
+                continue;
+              }
+              seen.add(key);
+              if (!signed.has(key)) {
+                missing.push(login);
+              }
+            }
+
+            if (missing.length > 0) {
+              core.setFailed(
+                'Unsigned or unlinked PR commit authors: ' +
+                  missing.join(', ') +
+                  '. Sign the Individual CLA or add the GitHub username to allowlist / signatures/version1/cla.json.'
+              );
+            }

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,315 @@
+# Contributor License Agreement
+
+**Document version:** 1.0  
+**Effective date:** 14 August 2026  
+**Entity:** Censgate LLC, Sheridan, Wyoming, United States
+
+This agreement is a **license grant, not an assignment of copyright**. It does
+not change the outbound [Apache License 2.0](LICENSE) under which this
+repository is distributed. Contributors retain the right to use their own
+Contributions for any other purpose.
+
+It is adapted from the Apache Software Foundation Individual Contributor
+License Agreement (ICLA) v2.2 and Corporate Contributor License Agreement
+(CCLA). Foundation-specific and nonprofit-only promises have been removed.
+One sentence is added to the copyright grant so Censgate LLC may sublicense
+and relicense Contributions, to the extent of the contributor's rights.
+
+Material changes to this document will bump the signature-store version
+path in `.github/workflows/cla.yml`. Existing signatures remain bound to
+the text they were made against; contributors re-sign only after a
+material change.
+
+## How to sign
+
+### Individual CLA
+
+Independent contributors sign by posting this comment on their pull request,
+exactly:
+
+```
+I have read the CLA Document and I hereby sign the CLA
+```
+
+A GitHub Action records your GitHub username in this repository's
+`cla-signatures` branch (`signatures/version1/cla.json`). That username is
+already public on the pull request.
+
+Do **not** sign an Individual CLA if you lack authority to grant the rights
+below — for example, if your employer owns the work product.
+
+### Corporate CLA (CCLA)
+
+If you contributed on employer time or equipment, or your employment
+agreement assigns work product to your employer, an authorised corporate
+signer must also complete the Corporate CLA and email it to
+**support@censgate.com**.
+
+A CCLA does **not** replace each developer's Individual CLA. After a CCLA
+is on file, maintainers record designated GitHub usernames privately (not
+the signed PDF) so the pull-request check can pass. Signed CCLA documents
+and Schedule A lists are kept off this public repository.
+
+---
+
+## Individual Contributor License Agreement ("Agreement")
+
+Thank you for your interest in the Redact project managed by Censgate LLC
+(the "Company"). In order to clarify the intellectual property license
+granted with Contributions from any person or entity, the Company must
+have a Contributor License Agreement (CLA) on file that has been signed
+by each Contributor, indicating agreement to the license terms below.
+This license is for your protection as a Contributor as well as the
+protection of the Company and its users; it does not change your rights
+to use your own Contributions for any other purpose.
+
+You accept and agree to the following terms and conditions for Your
+present and future Contributions submitted to the Company. Except for
+the license granted herein to the Company and to recipients of software
+distributed by the Company, You reserve all right, title, and interest
+in and to Your Contributions.
+
+1. **Definitions.**
+
+   "You" (or "Your") shall mean the copyright owner or legal entity
+   authorized by the copyright owner that is making this Agreement with
+   the Company. For legal entities, the entity making a Contribution and
+   all other entities that control, are controlled by, or are under
+   common control with that entity are considered to be a single
+   Contributor. For the purposes of this definition, "control" means
+   (i) the power, direct or indirect, to cause the direction or
+   management of such entity, whether by contract or otherwise, or
+   (ii) ownership of fifty percent (50%) or more of the outstanding
+   shares, or (iii) beneficial ownership of such entity.
+
+   "Contribution" shall mean any original work of authorship, including
+   any modifications or additions to an existing work, that is
+   intentionally submitted by You to the Company for inclusion in, or
+   documentation of, any of the products owned or managed by the Company
+   (the "Work"). For the purposes of this definition, "submitted" means
+   any form of electronic, verbal, or written communication sent to the
+   Company or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control
+   systems, and issue tracking systems that are managed by, or on behalf
+   of, the Company for the purpose of discussing and improving the Work,
+   but excluding communication that is conspicuously marked or otherwise
+   designated in writing by You as "Not a Contribution."
+
+2. **Grant of Copyright License.** Subject to the terms and conditions of
+   this Agreement, You hereby grant to the Company and to recipients of
+   software distributed by the Company a perpetual, worldwide,
+   non-exclusive, no-charge, royalty-free, irrevocable copyright license
+   to reproduce, prepare derivative works of, publicly display, publicly
+   perform, sublicense, and distribute Your Contributions and such
+   derivative works.
+
+   In addition to the copyright license granted in this section, You
+   grant the Company the right to sublicense and relicense Your
+   Contributions and derivative works thereof under different terms,
+   including proprietary or commercial terms, without further consent,
+   to the extent of Your rights in the Contributions and subject to any
+   third-party restrictions You disclose under this Agreement.
+
+3. **Grant of Patent License.** Subject to the terms and conditions of
+   this Agreement, You hereby grant to the Company and to recipients of
+   software distributed by the Company a perpetual, worldwide,
+   non-exclusive, no-charge, royalty-free, irrevocable (except as stated
+   in this section) patent license to make, have made, use, offer to
+   sell, sell, import, and otherwise transfer the Work, where such
+   license applies only to those patent claims licensable by You that
+   are necessarily infringed by Your Contribution(s) alone or by
+   combination of Your Contribution(s) with the Work to which such
+   Contribution(s) was submitted. If any entity institutes patent
+   litigation against You or any other entity (including a cross-claim
+   or counterclaim in a lawsuit) alleging that your Contribution, or the
+   Work to which you have contributed, constitutes direct or
+   contributory patent infringement, then any patent licenses granted to
+   that entity under this Agreement for that Contribution or Work shall
+   terminate as of the date such litigation is filed.
+
+4. You represent that you are legally entitled to grant the above
+   license. If your employer(s) has rights to intellectual property that
+   you create that includes your Contributions, you represent that you
+   have received permission to make Contributions on behalf of that
+   employer, that your employer has waived such rights for your
+   Contributions to the Company, or that your employer has executed a
+   separate Corporate CLA with the Company.
+
+5. You represent that each of Your Contributions is Your original
+   creation (see section 7 for submissions on behalf of others). You
+   represent that Your Contribution submissions include complete details
+   of any third-party license or other restriction (including, but not
+   limited to, related patents and trademarks) of which you are
+   personally aware and which are associated with any part of Your
+   Contributions.
+
+6. You are not expected to provide support for Your Contributions,
+   except to the extent You desire to provide support. You may provide
+   support for free, for a fee, or not at all. Unless required by
+   applicable law or agreed to in writing, You provide Your
+   Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+   OF ANY KIND, either express or implied, including, without
+   limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+   MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+7. Should You wish to submit work that is not Your original creation,
+   You may submit it to the Company separately from any Contribution,
+   identifying the complete details of its source and of any license or
+   other restriction (including, but not limited to, related patents,
+   trademarks, and license agreements) of which you are personally
+   aware, and conspicuously marking the work as "Submitted on behalf of
+   a third-party: [named here]".
+
+8. You agree to notify the Company of any facts or circumstances of
+   which you become aware that would make these representations
+   inaccurate in any respect.
+
+---
+
+## Corporate Contributor License Agreement ("Agreement")
+
+Thank you for your interest in the Redact project managed by Censgate LLC
+(the "Company"). In order to clarify the intellectual property license
+granted with Contributions from any person or entity, the Company must
+have a Contributor License Agreement (CLA) on file that has been signed
+by each Contributor, indicating agreement to the license terms below.
+This license is for your protection as a Contributor as well as the
+protection of the Company and its users; it does not change your rights
+to use your own Contributions for any other purpose.
+
+This version of the Agreement allows an entity (the "Corporation") to
+submit Contributions to the Company, to authorize Contributions submitted
+by its designated employees to the Company, and to grant copyright and
+patent licenses thereto.
+
+A person with authority to enter into legal contracts on behalf of the
+Corporation must sign this Corporate CLA and email it to
+support@censgate.com. A Corporate CLA does not remove the need for every
+developer to sign their own Individual CLA.
+
+You accept and agree to the following terms and conditions for Your
+present and future Contributions submitted to the Company. Except for
+the license granted herein to the Company and to recipients of software
+distributed by the Company, You reserve all right, title, and interest
+in and to Your Contributions.
+
+1. **Definitions.**
+
+   "You" (or "Your") shall mean the copyright owner or legal entity
+   authorized by the copyright owner that is making this Agreement with
+   the Company. For legal entities, the entity making a Contribution and
+   all other entities that control, are controlled by, or are under
+   common control with that entity are considered to be a single
+   Contributor. For the purposes of this definition, "control" means
+   (i) the power, direct or indirect, to cause the direction or
+   management of such entity, whether by contract or otherwise, or
+   (ii) ownership of fifty percent (50%) or more of the outstanding
+   shares, or (iii) beneficial ownership of such entity.
+
+   "Contribution" shall mean any original work of authorship, including
+   any modifications or additions to an existing work, that is
+   intentionally submitted by You to the Company for inclusion in, or
+   documentation of, any of the products owned or managed by the Company
+   (the "Work"). For the purposes of this definition, "submitted" means
+   any form of electronic, verbal, or written communication sent to the
+   Company or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control
+   systems, and issue tracking systems that are managed by, or on behalf
+   of, the Company for the purpose of discussing and improving the Work,
+   but excluding communication that is conspicuously marked or otherwise
+   designated in writing by You as "Not a Contribution."
+
+2. **Grant of Copyright License.** Subject to the terms and conditions of
+   this Agreement, You hereby grant to the Company and to recipients of
+   software distributed by the Company a perpetual, worldwide,
+   non-exclusive, no-charge, royalty-free, irrevocable copyright license
+   to reproduce, prepare derivative works of, publicly display, publicly
+   perform, sublicense, and distribute Your Contributions and such
+   derivative works.
+
+   In addition to the copyright license granted in this section, You
+   grant the Company the right to sublicense and relicense Your
+   Contributions and derivative works thereof under different terms,
+   including proprietary or commercial terms, without further consent,
+   to the extent of Your rights in the Contributions and subject to any
+   third-party restrictions You disclose under this Agreement.
+
+3. **Grant of Patent License.** Subject to the terms and conditions of
+   this Agreement, You hereby grant to the Company and to recipients of
+   software distributed by the Company a perpetual, worldwide,
+   non-exclusive, no-charge, royalty-free, irrevocable (except as stated
+   in this section) patent license to make, have made, use, offer to
+   sell, sell, import, and otherwise transfer the Work, where such
+   license applies only to those patent claims licensable by You that
+   are necessarily infringed by Your Contribution(s) alone or by
+   combination of Your Contribution(s) with the Work to which such
+   Contribution(s) were submitted. If any entity institutes patent
+   litigation against You or any other entity (including a cross-claim
+   or counterclaim in a lawsuit) alleging that your Contribution, or the
+   Work to which you have contributed, constitutes direct or
+   contributory patent infringement, then any patent licenses granted to
+   that entity under this Agreement for that Contribution or Work shall
+   terminate as of the date such litigation is filed.
+
+4. You represent that You are legally entitled to grant the above
+   license. You represent further that each employee of the Corporation
+   designated on Schedule A below (or in a subsequent written
+   modification to that Schedule) is authorized to submit Contributions
+   on behalf of the Corporation.
+
+5. You represent that each of Your Contributions is Your original
+   creation (see section 7 for submissions on behalf of others). You
+   represent that Your Contribution submissions include complete details
+   of any third-party license or other restriction (including, but not
+   limited to, related patents and trademarks) of which you are
+   personally aware and which are associated with any part of Your
+   Contributions.
+
+6. You are not expected to provide support for Your Contributions,
+   except to the extent You desire to provide support. You may provide
+   support for free, for a fee, or not at all. Unless required by
+   applicable law or agreed to in writing, You provide Your
+   Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+   OF ANY KIND, either express or implied, including, without
+   limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+   MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+7. Should You wish to submit work that is not Your original creation,
+   You may submit it to the Company separately from any Contribution,
+   identifying the complete details of its source and of any license or
+   other restriction (including, but not limited to, related patents,
+   trademarks, and license agreements) of which you are personally
+   aware, and conspicuously marking the work as "Submitted on behalf of
+   a third-party: [named here]".
+
+8. You agree to notify the Company of any facts or circumstances of
+   which you become aware that would make these representations
+   inaccurate in any respect.
+
+### Corporate signer details
+
+Complete and email this section with the signed Corporate CLA to
+support@censgate.com. To update Schedule A later, email the same address.
+
+- Corporation name:
+- Corporation address:
+- Point of contact:
+- E-mail:
+- Telephone:
+- GitHub organization or usernames of designated employees (optional):
+
+### Schedule A
+
+Initial list of designated employees. Authorization is not tied to
+particular Contributions. Notify the Company of additions or removals
+in writing (email to support@censgate.com is sufficient).
+
+-
+
+### Schedule B
+
+Optional identification of third-party software or other material
+included with Contributions, and the applicable license or other
+restriction.
+
+-

--- a/CLA.md
+++ b/CLA.md
@@ -1,7 +1,9 @@
 # Contributor License Agreement
 
-**Document version:** 1.0  
-**Effective date:** 14 August 2026  
+**Document version:** 1.0
+
+**Effective date:** 14 August 2026
+
 **Entity:** Censgate LLC, Sheridan, Wyoming, United States
 
 This agreement is a **license grant, not an assignment of copyright**. It does
@@ -46,9 +48,11 @@ signer must also complete the Corporate CLA and email it to
 **support@censgate.com**.
 
 A CCLA does **not** replace each developer's Individual CLA. After a CCLA
-is on file, maintainers record designated GitHub usernames privately (not
-the signed PDF) so the pull-request check can pass. Signed CCLA documents
-and Schedule A lists are kept off this public repository.
+is on file, maintainers add the designated GitHub usernames to the
+`allowlist` in `.github/workflows/cla.yml` or to
+`signatures/version1/cla.json` on the `cla-signatures` branch so the
+pull-request check can pass. Signed CCLA documents and Schedule A lists
+are kept off this public repository.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -305,12 +305,14 @@ before a pull request can be merged.
 - **Employer-owned work:** do not rely on an Individual CLA alone. An
   authorised corporate signer must email a completed Corporate CLA to
   support@censgate.com. A Corporate CLA does **not** replace each
-  developer's Individual CLA. Maintainers then record designated GitHub
-  usernames so the check can pass.
+  developer's Individual CLA. Maintainers then add designated GitHub
+  usernames to the `allowlist` in `.github/workflows/cla.yml` or to
+  `signatures/version1/cla.json` on the `cla-signatures` branch so the
+  check can pass.
 
 Individual signatures are GitHub usernames stored on this repository's
 `cla-signatures` branch (already public on the pull request). Signed
-Corporate CLA documents are kept privately and are not committed here.
+Corporate CLA documents are kept off this repository.
 
 The CLA is a license grant, not an assignment. It does not change the
 Apache-2.0 outbound license.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,9 @@
 
 Thank you for your interest in contributing to Redact! This document provides guidelines and information for contributors.
 
-## Code of Conduct
+Before you invest time, read [docs/PROJECT_SCOPE.md](docs/PROJECT_SCOPE.md). Pull requests that implement out-of-scope work will not be merged.
 
-This project adheres to a [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+Contributors are expected to be respectful in issues, discussions, and pull requests. A formal Code of Conduct file is not published in this repository.
 
 ## How Can I Contribute?
 
@@ -34,7 +34,9 @@ Enhancement suggestions are tracked as GitHub issues. When creating an enhanceme
 3. **Add tests** for new functionality
 4. **Run the test suite** to ensure all tests pass
 5. **Update documentation** as needed
-6. **Create a pull request** with a clear title and description
+6. **Sign off every commit** with `git commit -s` (Developer Certificate of Origin)
+7. **Create a pull request** with a clear title and description
+8. **Sign the CLA** when the bot comments (see [License and contributor agreements](#license-and-contributor-agreements))
 
 ## Development Setup
 
@@ -78,6 +80,9 @@ cargo test --package redact-core
 
 # Run specific test suite
 cargo test --package redact-core --test pattern_coverage
+cargo test --package redact-core --test integration_policy
+cargo test --package redact-core --test error_scenarios
+cargo test --package redact-core --test concurrent_operations
 
 # Run benchmarks
 cargo bench --package redact-core
@@ -154,6 +159,8 @@ Follow the [Conventional Commits](https://www.conventionalcommits.org/) specific
 <footer>
 ```
 
+Use `git commit -s` so Git adds a `Signed-off-by: Name <email>` trailer (Developer Certificate of Origin). That is project policy; the CLA bot does not check for it.
+
 ### Types
 
 - `feat`: New feature
@@ -174,6 +181,7 @@ Implement label mapping configuration for custom NER models
 with multilingual support. Add tests for Spanish and French.
 
 Closes #123
+Signed-off-by: Your Name <you@example.com>
 ```
 
 ```
@@ -181,6 +189,8 @@ fix(anonymizer): correct hash anonymization for empty strings
 
 The hash anonymizer was panicking on empty input strings.
 Add null check and return empty string for empty input.
+
+Signed-off-by: Your Name <you@example.com>
 ```
 
 ## Versioning
@@ -230,12 +240,15 @@ redact/
 ├── scripts/                 # Utility scripts
 ├── examples/                # Usage examples
 ├── docs/
+│   ├── PROJECT_SCOPE.md     # What this repository accepts
 │   ├── gateway/             # Gateway operator documentation
 │   └── benchmarks/          # Benchmark methodology and results
 └── .github/workflows/       # CI/CD pipelines
 ```
 
 ## Areas for Contribution
+
+Confirm the idea is in [project scope](docs/PROJECT_SCOPE.md) before starting.
 
 ### High Priority
 
@@ -273,10 +286,47 @@ Contributors will be recognized in:
 - GitHub contributors page
 - Release notes for significant contributions
 
-## License
+## License and contributor agreements
 
-By contributing to Redact, you agree that your contributions will be licensed under the Apache 2.0 License.
+The outbound license for this repository remains the [Apache License 2.0](LICENSE).
+
+### Contributor License Agreement (required)
+
+Every human contributor must sign the [Contributor License Agreement](CLA.md)
+before a pull request can be merged.
+
+- **Independent contributors:** when the CLA bot comments on your first pull
+  request, post exactly:
+
+  ```
+  I have read the CLA Document and I hereby sign the CLA
+  ```
+
+- **Employer-owned work:** do not rely on an Individual CLA alone. An
+  authorised corporate signer must email a completed Corporate CLA to
+  support@censgate.com. A Corporate CLA does **not** replace each
+  developer's Individual CLA. Maintainers then record designated GitHub
+  usernames so the check can pass.
+
+Individual signatures are GitHub usernames stored on this repository's
+`cla-signatures` branch (already public on the pull request). Signed
+Corporate CLA documents are kept privately and are not committed here.
+
+The CLA is a license grant, not an assignment. It does not change the
+Apache-2.0 outbound license.
+
+### Developer Certificate of Origin (required by policy)
+
+Every commit must include a DCO sign-off:
+
+```bash
+git commit -s -m "feat: your change"
+```
+
+That adds `Signed-off-by: Your Name <you@example.com>`. DCO is per-commit
+provenance; the CLA covers rights. DCO is **not** enforced by the CLA bot.
+Use the pull-request template checkbox and `git commit -s`.
 
 ---
 
-Thank you for contributing to Redact! 🎉
+Thank you for contributing to Redact!

--- a/LICENSE
+++ b/LICENSE
@@ -58,7 +58,7 @@ APPENDIX: How to apply the Apache License to your work.
 
 To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
 
-Copyright 2026 Censgate, Inc.
+Copyright 2026 Censgate LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -701,6 +701,8 @@ See [TEST_COVERAGE.md](/censgate/redact/blob/main/TEST_COVERAGE.md) for detailed
 - [Gateway Documentation](/censgate/redact/blob/main/docs/gateway) — Configuration, policy, tokenization, auth, telemetry, audit, streaming, deployment
 - [Test Coverage](/censgate/redact/blob/main/TEST_COVERAGE.md) — Testing details
 - [Contributing Guide](/censgate/redact/blob/main/CONTRIBUTING.md) — How to contribute
+- [Project scope](/censgate/redact/blob/main/docs/PROJECT_SCOPE.md) — What this repository accepts
+- [Contributor License Agreement](/censgate/redact/blob/main/CLA.md) — Individual and Corporate CLA
 - [Examples](/censgate/redact/blob/main/examples) — Code examples
 
 ## Roadmap
@@ -745,7 +747,13 @@ See [TEST_COVERAGE.md](/censgate/redact/blob/main/TEST_COVERAGE.md) for detailed
 
 ## Contributing
 
-We welcome contributions! See [CONTRIBUTING.md](/censgate/redact/blob/main/CONTRIBUTING.md) for guidelines.
+We welcome contributions. Please read:
+
+- [CONTRIBUTING.md](/censgate/redact/blob/main/CONTRIBUTING.md) — build, test, and review process
+- [docs/PROJECT_SCOPE.md](/censgate/redact/blob/main/docs/PROJECT_SCOPE.md) — what this repository accepts
+- [CLA.md](/censgate/redact/blob/main/CLA.md) — Individual and Corporate Contributor License Agreement (required)
+
+Sign every commit with the Developer Certificate of Origin (`git commit -s`). The CLA bot will ask first-time human contributors to sign the CLA on the pull request.
 
 ```bash
 # Fork and clone
@@ -760,8 +768,8 @@ cargo test --workspace
 cargo clippy --all-targets --all-features
 cargo fmt --all
 
-# Commit and push
-git commit -m "feat: add amazing feature"
+# Commit (DCO sign-off) and push
+git commit -s -m "feat: add amazing feature"
 git push origin feature/my-new-feature
 ```
 

--- a/assets/README.md
+++ b/assets/README.md
@@ -6,7 +6,7 @@ This folder contains the official Censgate logo files for use in open source and
 
 - You are free to use the Censgate logo in unmodified form to reference, promote, or integrate with the Censgate project.
 - Do not modify, distort, or alter the logo's appearance.
-- Do not use the Censgate logo in ways that imply endorsement or partnership without explicit permission from Censgate, Inc.
+- Do not use the Censgate logo in ways that imply endorsement or partnership without explicit permission from Censgate LLC.
 
 ## Copyright Notice
 

--- a/docs/PROJECT_SCOPE.md
+++ b/docs/PROJECT_SCOPE.md
@@ -1,0 +1,35 @@
+# Project scope
+
+Read this before investing time in a contribution. Pull requests that
+implement out-of-scope work will not be merged.
+
+If a proposal might sit on the boundary, [open an issue](https://github.com/censgate/redact/issues)
+first.
+
+## In scope
+
+This Apache-2.0 repository accepts contributions to:
+
+| Crate | Role |
+| --- | --- |
+| `redact-core` | Pattern-based detection and anonymization engine |
+| `redact-ner` | ONNX-based named entity recognition |
+| `redact-api` | REST API server |
+| `redact-cli` | Command-line interface |
+| `redact-wasm` | WebAssembly bindings |
+| `redact-gateway` | Self-hosted OpenAI-compatible privacy gateway |
+
+Also in scope: documentation, tests, examples, packaging, and CI for those
+crates.
+
+## Out of scope
+
+The following are **not accepted** in this repository:
+
+- Immutable / attested audit storage
+- Hosted control plane
+- Tenant administration
+- Support or indemnity commitments
+
+Those capabilities are outside the Apache-2.0 project. Please do not open
+pull requests that implement them here.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds an Individual and Corporate Contributor License Agreement, DCO sign-off as project policy, an in-repo CLA bot, a project-scope document, and a pull-request template. Outbound licensing stays Apache-2.0.

## What changed

- [`CLA.md`](CLA.md) — Individual and Corporate CLA adapted from the Apache ICLA v2.2 / CCLA for **Censgate LLC, Sheridan, WY**. Copyright license (including sublicense), patent grant, originality warranty, employer-authorisation, plus an explicit sublicense/relicense sentence. This is a license grant, not an assignment.
- [`CONTRIBUTING.md`](CONTRIBUTING.md) — scope link, build/test commands, how CLA signing works, DCO via `git commit -s` (policy; not bot-enforced). After a Corporate CLA, maintainers add GitHub usernames to the workflow `allowlist` or `signatures/version1/cla.json`. Signed CCLA PDFs stay off this repository.
- [`.github/workflows/cla.yml`](.github/workflows/cla.yml) — `contributor-assistant/github-action` pinned to `ca4a40a7d1004f18d9960b404b97e5f30a505a08` (v2.6.1). Comments on first PR, fails until signed, allowlists only `dependabot[bot]` and `github-actions[bot]`. Does not check out PR HEAD. A second step paginates PR commits so authors past the first page cannot skip the check. Signatures go to the `cla-signatures` branch.
- [`docs/PROJECT_SCOPE.md`](docs/PROJECT_SCOPE.md) — in-scope crates vs out-of-scope capabilities (immutable/attested audit storage, hosted control plane, tenant administration, support or indemnity commitments).
- [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) — Individual CLA is always required; a Corporate CLA does not replace it. DCO, scope, and employer time/equipment acknowledgements.
- [`README.md`](README.md) — short Contributing section with the links above and `git commit -s`.
- [`LICENSE`](LICENSE) appendix copyright holder and [`assets/README.md`](assets/README.md): `Censgate, Inc.` → `Censgate LLC`. Apache-2.0 sections 1–9 are unchanged. Censgate, Inc. never existed.

A separate unprotected `cla-signatures` branch (README only) is already on `origin` so the action has a place to commit.

## Existing-author audit

`git log` authors, committers, and `Co-authored-by` trailers on `main`:

**Maintainer-controlled:** `Mark <mark@censgate.com>`, `Mark <f1r32035@proton.me>`, `f1r32035`, `f1r32025` (same maintainer, older gmail), `censgate-coder`, `censgate-qa`.

**Maintainer-run agents:** `Cursor Agent` / `cursoragent`, `cursor[bot]`, `Claude <noreply@anthropic.com>`.

**Bots:** `dependabot[bot]`, `github-actions[bot]`, `GitHub <noreply@github.com>`, `Paperclip Security Bot`.

**Unexpected:** `Jurriën Stutterheim <j.stutterheim@me.com>` on `e764908` / `ed6c80e` (`chore(deps): rebase pr 41 dependency upgrades`). Committers were Mark and Cursor Agent; co-author is `f1r32035`. The diff is a dependency rebase, not an independent feature contribution. History was not rewritten.

No retroactive signature collection. Agent-authored commits carry little third-party copyright exposure under current US law.

## Post-merge (required for the merge gate)

The workflow fails the **CLA Assistant** check until a human signs. GitHub will still allow merge until an org admin **requires that check** on the `main` ruleset (id 8269422). Do not protect `cla-signatures` in a way that blocks `GITHUB_TOKEN`.

`pull_request_target` reads the workflow from `main`, so this PR will not run the new CLA check.

## Notes for counsel (flag, not decided)

- The Apache ICLA is used near-verbatim; the material delta is the sublicense/relicense sentence and removal of nonprofit/public-benefit return promises.
- Whether a GitHub comment is a sufficient electronic signature, and whether this instrument should be relied on for indemnity, should be reviewed by a lawyer. A CLA grant is not itself an indemnity.
- `contributor-assistant/github-action` is archived; v2.6.1 is pinned by SHA. Fallback: add the username to `allowlist` or the signatures file.

## Test plan

- [x] `LICENSE` diff is only the appendix copyright holder
- [x] `rg 'Censgate,?\s*Inc'` is empty
- [x] No SPDX headers added; per-file `Copyright` lines unchanged
- [x] Workflow allowlist is exactly `dependabot[bot],github-actions[bot]`; no PR-head checkout
- [x] Individual CLA is required even when a Corporate CLA is on file
- [ ] After merge: require **CLA Assistant** on the `main` ruleset
- [ ] Unsigned human PR: bot comments and check fails; merge blocked once the check is required
- [ ] Sign-off comment: signature committed to `cla-signatures`, check passes
- [ ] Dependabot / `github-actions[bot]` PRs are not blocked

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85647f93-5b7e-4fe1-8fad-9cd59c7bd2c2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85647f93-5b7e-4fe1-8fad-9cd59c7bd2c2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

