### PR TITLE
feat(scan): scaffold redact-scan report types and CLI preflight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop, feature/*]
+    branches: [main, develop, feature/*, coder*]
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, feature/*, coder*]
 
 permissions:
   contents: read

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           VERSION=${{ env.VERSION }}
           sed -i "s/^version = \"[^\"]*\"/version = \"$VERSION\"/" Cargo.toml
-          for f in crates/redact-ner/Cargo.toml crates/redact-api/Cargo.toml crates/redact-cli/Cargo.toml crates/redact-gateway/Cargo.toml; do
+          for f in crates/redact-ner/Cargo.toml crates/redact-api/Cargo.toml crates/redact-cli/Cargo.toml crates/redact-gateway/Cargo.toml crates/redact-scan/Cargo.toml; do
             sed -i "s/\(redact-core = { path = \"[^\"]*\", version = \"\)[^\"]*/\1$VERSION/" "$f"
             sed -i "s/\(redact-ner = { path = \"[^\"]*\", version = \"\)[^\"]*/\1$VERSION/" "$f"
           done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,8 @@ crates/
 ├── redact-api/     # REST API server (Axum)
 ├── redact-cli/     # Command-line interface (Clap)
 ├── redact-wasm/    # WebAssembly bindings
-└── redact-gateway/ # OpenAI-compatible privacy gateway (embeds redact-core)
+├── redact-gateway/ # OpenAI-compatible privacy gateway (embeds redact-core)
+└── redact-scan/    # Read-only Postgres PII discovery scanner
 ```
 
 ### Crate Dependencies
@@ -32,6 +33,7 @@ redact-api ──────► redact-core
 redact-cli ──────► redact-core
 redact-wasm ─────► redact-core
 redact-gateway ─► redact-core
+redact-scan ────► redact-core
 ```
 
 ### Critical Components
@@ -47,6 +49,10 @@ redact-gateway ─► redact-core
 - `tokenizer_wrapper.rs` - HuggingFace tokenizer integration
 - Uses `ort` crate for ONNX inference
 - Supports quantized int8 models for efficiency
+
+**redact-scan** (`crates/redact-scan/`)
+- Read-only Postgres PII discovery (`redact-scan` binary)
+- Workspace `sqlx` is for this crate only — never add it to `redact-core` (wasm)
 
 ## Development Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `redact-scan`: new workspace crate and `redact-scan` binary for read-only
+  Postgres PII discovery. This revision adds the report types, credential
+  scrubber, and CLI preflight (`--include-samples` cannot be combined with
+  `--report-url`). Reports contain locations and counts only — never sample
+  values.
+
 ## [0.9.1] - 2026-08-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2680,6 +2680,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "redact-scan"
+version = "0.9.1"
+dependencies = [
+ "anyhow",
+ "assert_cmd",
+ "chrono",
+ "clap",
+ "predicates",
+ "redact-core",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "uuid",
+]
+
+[[package]]
 name = "redact-wasm"
 version = "0.9.1"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2693,7 +2693,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "tempfile",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/redact-wasm",
     "crates/redact-cli",
     "crates/redact-gateway",
+    "crates/redact-scan",
 ]
 resolver = "2"
 
@@ -59,7 +60,7 @@ pbkdf2 = { version = "0.13.0-rc.10", features = ["hmac", "sha2"] }
 rand = "0.10"
 
 # Time handling
-chrono = { version = "0.4", default-features = false, features = ["serde", "std"] }
+chrono = { version = "0.4", default-features = false, features = ["serde", "std", "clock"] }
 
 # UUID generation
 uuid = { version = "1.23", features = ["v4", "serde"] }
@@ -72,6 +73,9 @@ criterion = "0.8"
 
 # HTTP client (for examples)
 reqwest = { version = "0.13", features = ["json"] }
+
+# Postgres (redact-scan only — never add to redact-core)
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "postgres", "tls-rustls-ring", "chrono", "uuid", "macros"] }
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ pbkdf2 = { version = "0.13.0-rc.10", features = ["hmac", "sha2"] }
 rand = "0.10"
 
 # Time handling
-chrono = { version = "0.4", default-features = false, features = ["serde", "std", "clock"] }
+chrono = { version = "0.4", default-features = false, features = ["serde", "std"] }
 
 # UUID generation
 uuid = { version = "1.23", features = ["v4", "serde"] }

--- a/README.md
+++ b/README.md
@@ -659,6 +659,7 @@ redact/
 │   ├── redact-ner/       # ONNX NER integration (optional engine add-on)
 │   ├── redact-api/       # REST API service (Axum) over the same engine
 │   ├── redact-cli/       # Command-line tool
+│   ├── redact-scan/      # Read-only Postgres PII discovery scanner
 │   └── redact-wasm/      # WebAssembly bindings (pattern engine)
 ├── docs/
 │   ├── gateway/          # Gateway operator documentation

--- a/crates/redact-scan/Cargo.toml
+++ b/crates/redact-scan/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "redact-scan"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme = "README.md"
+documentation = "https://docs.rs/redact-scan"
+description = "Read-only Postgres PII discovery scanner"
+keywords = ["pii", "postgres", "privacy", "gdpr", "discovery"]
+categories = ["command-line-utilities", "database"]
+
+[dependencies]
+redact-core = { path = "../redact-core", version = "0.9.1" }
+clap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+uuid = { workspace = true }
+sha2 = { workspace = true }
+chrono = { workspace = true }
+regex = { workspace = true }
+
+[[bin]]
+name = "redact-scan"
+path = "src/main.rs"
+
+[dev-dependencies]
+assert_cmd = "2.2"
+predicates = "3.1"
+tempfile = "3.27"
+serde_json = { workspace = true }
+redact-core = { path = "../redact-core", version = "0.9.1" }
+chrono = { workspace = true }
+uuid = { workspace = true }

--- a/crates/redact-scan/Cargo.toml
+++ b/crates/redact-scan/Cargo.toml
@@ -31,8 +31,3 @@ path = "src/main.rs"
 [dev-dependencies]
 assert_cmd = "2.2"
 predicates = "3.1"
-tempfile = "3.27"
-serde_json = { workspace = true }
-redact-core = { path = "../redact-core", version = "0.9.1" }
-chrono = { workspace = true }
-uuid = { workspace = true }

--- a/crates/redact-scan/README.md
+++ b/crates/redact-scan/README.md
@@ -1,0 +1,10 @@
+# redact-scan
+
+Read-only Postgres PII discovery scanner. Prefer a replica or staging database.
+
+```bash
+cargo install --path crates/redact-scan
+redact-scan --url postgres://reader@localhost/app --schema public --out report.json
+```
+
+The report lists table/column locations and entity types. It never includes sample values.

--- a/crates/redact-scan/src/canonical.rs
+++ b/crates/redact-scan/src/canonical.rs
@@ -7,7 +7,9 @@ use serde::Serialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
-/// SHA-256 of canonical JSON with `content_hash` omitted / empty.
+/// SHA-256 hex of RFC 8785-style canonical JSON with `content_hash` omitted.
+///
+/// Object keys are sorted; insignificant whitespace is omitted.
 pub fn content_hash<T: Serialize>(report: &T) -> Result<String> {
     let mut value = serde_json::to_value(report)?;
     if let Value::Object(map) = &mut value {
@@ -47,12 +49,38 @@ fn canonical_value(value: &Value) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
+    use serde::Serialize;
+
+    #[derive(Serialize)]
+    struct First {
+        b: i32,
+        a: i32,
+        content_hash: String,
+    }
+
+    #[derive(Serialize)]
+    struct Second {
+        a: i32,
+        b: i32,
+    }
 
     #[test]
-    fn hash_is_stable_under_key_order() {
-        let a = json!({"b": 1, "a": 2, "content_hash": "x"});
-        let b = json!({"a": 2, "b": 1});
-        assert_eq!(content_hash(&a).unwrap(), content_hash(&b).unwrap());
+    fn hash_is_stable_under_struct_field_order() {
+        let first = First {
+            b: 1,
+            a: 2,
+            content_hash: "ignored".into(),
+        };
+        let second = Second { a: 2, b: 1 };
+        let first_json = serde_json::to_string(&first).unwrap();
+        let second_json = serde_json::to_string(&second).unwrap();
+        assert_ne!(
+            first_json, second_json,
+            "fixture must serialize keys in different orders"
+        );
+        assert_eq!(
+            content_hash(&first).unwrap(),
+            content_hash(&second).unwrap()
+        );
     }
 }

--- a/crates/redact-scan/src/canonical.rs
+++ b/crates/redact-scan/src/canonical.rs
@@ -7,16 +7,16 @@ use serde::Serialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
-/// SHA-256 hex of RFC 8785-style canonical JSON with `content_hash` omitted.
+/// SHA-256 hex of canonical JSON with `content_hash` omitted.
 ///
-/// Object keys are sorted; insignificant whitespace is omitted.
+/// Object keys are sorted recursively; `serde_json` compact encoding is used
+/// (no insignificant whitespace). This is not a full RFC 8785 implementation.
 pub fn content_hash<T: Serialize>(report: &T) -> Result<String> {
     let mut value = serde_json::to_value(report)?;
     if let Value::Object(map) = &mut value {
         map.remove("content_hash");
     }
-    let canonical = canonicalize(&value)?;
-    Ok(hex_sha256(canonical.as_bytes()))
+    Ok(hex_sha256(canonicalize(&value).as_bytes()))
 }
 
 pub(crate) fn hex_sha256(bytes: &[u8]) -> String {
@@ -26,8 +26,8 @@ pub(crate) fn hex_sha256(bytes: &[u8]) -> String {
         .collect()
 }
 
-fn canonicalize(value: &Value) -> Result<String> {
-    Ok(canonical_value(value).to_string())
+fn canonicalize(value: &Value) -> String {
+    canonical_value(value).to_string()
 }
 
 fn canonical_value(value: &Value) -> Value {

--- a/crates/redact-scan/src/canonical.rs
+++ b/crates/redact-scan/src/canonical.rs
@@ -1,0 +1,58 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+use anyhow::Result;
+use serde::Serialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+/// SHA-256 of canonical JSON with `content_hash` omitted / empty.
+pub fn content_hash<T: Serialize>(report: &T) -> Result<String> {
+    let mut value = serde_json::to_value(report)?;
+    if let Value::Object(map) = &mut value {
+        map.remove("content_hash");
+    }
+    let canonical = canonicalize(&value)?;
+    Ok(hex_sha256(canonical.as_bytes()))
+}
+
+pub(crate) fn hex_sha256(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
+
+fn canonicalize(value: &Value) -> Result<String> {
+    Ok(canonical_value(value).to_string())
+}
+
+fn canonical_value(value: &Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            let mut out = serde_json::Map::new();
+            for k in keys {
+                out.insert(k.clone(), canonical_value(&map[k]));
+            }
+            Value::Object(out)
+        }
+        Value::Array(items) => Value::Array(items.iter().map(canonical_value).collect()),
+        other => other.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn hash_is_stable_under_key_order() {
+        let a = json!({"b": 1, "a": 2, "content_hash": "x"});
+        let b = json!({"a": 2, "b": 1});
+        assert_eq!(content_hash(&a).unwrap(), content_hash(&b).unwrap());
+    }
+}

--- a/crates/redact-scan/src/cli.rs
+++ b/crates/redact-scan/src/cli.rs
@@ -1,0 +1,152 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+use anyhow::{anyhow, Result};
+use clap::{Parser, ValueEnum};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use crate::layers::{default_layers, parse_layers, ScanLayer};
+
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
+pub enum OutputFormat {
+    Json,
+    Table,
+}
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "redact-scan",
+    about = "Read-only Postgres PII discovery scanner",
+    version
+)]
+pub struct Cli {
+    /// Postgres connection URL (also reads DATABASE_URL)
+    #[arg(long, env = "DATABASE_URL")]
+    pub url: Option<String>,
+
+    /// Schema to scan
+    #[arg(long, default_value = "public")]
+    pub schema: String,
+
+    /// Comma-separated layers: 0,0.5,1,2
+    #[arg(long, default_value = "0,0.5,1,2")]
+    pub layers: String,
+
+    /// Maximum rows to sample per candidate column
+    #[arg(long, default_value_t = 1000)]
+    pub sample_rows: u32,
+
+    /// Statement timeout (e.g. 30s)
+    #[arg(long, default_value = "30s")]
+    pub statement_timeout: String,
+
+    /// Output format
+    #[arg(long, value_enum, default_value_t = OutputFormat::Json)]
+    pub format: OutputFormat,
+
+    /// Write the report to this path
+    #[arg(long)]
+    pub out: Option<PathBuf>,
+
+    /// Optional HTTP endpoint that receives the report JSON
+    #[arg(long)]
+    pub report_url: Option<String>,
+
+    /// Bearer token for --report-url (also reads REDACT_SCAN_API_KEY)
+    #[arg(long, env = "REDACT_SCAN_API_KEY")]
+    pub api_key: Option<String>,
+
+    /// Extra header for --report-url, repeatable (`Name: value`)
+    #[arg(long = "report-header")]
+    pub report_headers: Vec<String>,
+
+    /// Exit 1 when findings match this entity type, or `any`
+    #[arg(long)]
+    pub fail_on: Option<String>,
+
+    /// Write local debug samples (incompatible with --report-url)
+    #[arg(long)]
+    pub include_samples: bool,
+
+    /// Path for local debug samples (required with --include-samples and --format json)
+    #[arg(long)]
+    pub samples_out: Option<PathBuf>,
+}
+
+impl Cli {
+    pub fn parsed_layers(&self) -> Result<Vec<ScanLayer>> {
+        if self.layers.trim().is_empty() {
+            return Ok(default_layers());
+        }
+        parse_layers(&self.layers)
+    }
+
+    pub fn statement_timeout(&self) -> Result<Duration> {
+        parse_duration(&self.statement_timeout)
+    }
+
+    /// Reject unsafe flag combinations before any network I/O.
+    pub fn validate_preflight(&self) -> Result<()> {
+        if self.include_samples && self.report_url.is_some() {
+            return Err(anyhow!(
+                "--include-samples cannot be used with --report-url"
+            ));
+        }
+        if self.include_samples && self.format == OutputFormat::Json && self.samples_out.is_none() {
+            return Err(anyhow!(
+                "--include-samples with --format json requires --samples-out"
+            ));
+        }
+        if self.url.is_none() && self.report_url.is_none() {
+            // Allow --include-samples + --report-url error path without --url.
+            // A real scan still needs --url; checked in run().
+        }
+        Ok(())
+    }
+}
+
+pub fn parse_duration(s: &str) -> Result<Duration> {
+    let s = s.trim();
+    if let Some(ms) = s.strip_suffix("ms") {
+        let n: u64 = ms.parse()?;
+        return Ok(Duration::from_millis(n));
+    }
+    if let Some(sec) = s.strip_suffix('s') {
+        let n: u64 = sec.parse()?;
+        return Ok(Duration::from_secs(n));
+    }
+    if let Some(min) = s.strip_suffix('m') {
+        let n: u64 = min.parse()?;
+        return Ok(Duration::from_secs(n * 60));
+    }
+    let n: u64 = s.parse()?;
+    Ok(Duration::from_secs(n))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn include_samples_with_report_url_is_rejected() {
+        let cli = Cli::parse_from([
+            "redact-scan",
+            "--include-samples",
+            "--report-url",
+            "http://127.0.0.1:9/hook",
+            "--samples-out",
+            "/tmp/s.json",
+        ]);
+        let err = cli.validate_preflight().unwrap_err().to_string();
+        assert!(err.contains("--include-samples"));
+        assert!(err.contains("--report-url"));
+    }
+
+    #[test]
+    fn duration_parse() {
+        assert_eq!(parse_duration("30s").unwrap(), Duration::from_secs(30));
+        assert_eq!(parse_duration("500ms").unwrap(), Duration::from_millis(500));
+    }
+}

--- a/crates/redact-scan/src/cli.rs
+++ b/crates/redact-scan/src/cli.rs
@@ -4,78 +4,120 @@
 
 use anyhow::{anyhow, Result};
 use clap::{Parser, ValueEnum};
+use std::fmt;
 use std::path::PathBuf;
 use std::time::Duration;
 
 use crate::layers::{default_layers, parse_layers, ScanLayer};
+use crate::scrub::scrub;
 
-#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
+/// Report rendering format.
+#[derive(Clone, Copy, ValueEnum, PartialEq, Eq)]
 pub enum OutputFormat {
+    /// Pretty-printed `ScanReport` JSON.
     Json,
+    /// Human-readable table (no sample values).
     Table,
 }
 
-#[derive(Debug, Parser)]
-#[command(
-    name = "redact-scan",
-    about = "Read-only Postgres PII discovery scanner",
-    version
-)]
+/// Read-only Postgres PII discovery scanner.
+///
+/// Prefer a replica or staging database. Debug formatting redacts
+/// connection URLs and API keys.
+#[derive(Parser)]
+#[command(name = "redact-scan", version)]
 pub struct Cli {
-    /// Postgres connection URL (also reads DATABASE_URL)
+    /// Postgres connection URL (also reads `DATABASE_URL`).
     #[arg(long, env = "DATABASE_URL")]
     pub url: Option<String>,
 
-    /// Schema to scan
+    /// Schema to scan.
     #[arg(long, default_value = "public")]
     pub schema: String,
 
-    /// Comma-separated layers: 0,0.5,1,2
+    /// Comma-separated layers: `0,0.5,1,2`.
     #[arg(long, default_value = "0,0.5,1,2")]
     pub layers: String,
 
-    /// Maximum rows to sample per candidate column
+    /// Maximum rows to sample per candidate column.
     #[arg(long, default_value_t = 1000)]
     pub sample_rows: u32,
 
-    /// Statement timeout (e.g. 30s)
+    /// Statement timeout (for example `30s`).
     #[arg(long, default_value = "30s")]
     pub statement_timeout: String,
 
-    /// Output format
+    /// Output format.
     #[arg(long, value_enum, default_value_t = OutputFormat::Json)]
     pub format: OutputFormat,
 
-    /// Write the report to this path
+    /// Write the report JSON to this path.
     #[arg(long)]
     pub out: Option<PathBuf>,
 
-    /// Optional HTTP endpoint that receives the report JSON
+    /// Optional HTTP endpoint that receives the report JSON.
     #[arg(long)]
     pub report_url: Option<String>,
 
-    /// Bearer token for --report-url (also reads REDACT_SCAN_API_KEY)
+    /// Bearer token for `--report-url` (also reads `REDACT_SCAN_API_KEY`).
     #[arg(long, env = "REDACT_SCAN_API_KEY")]
     pub api_key: Option<String>,
 
-    /// Extra header for --report-url, repeatable (`Name: value`)
+    /// Extra header for `--report-url`, repeatable (`Name: value`).
     #[arg(long = "report-header")]
     pub report_headers: Vec<String>,
 
-    /// Exit 1 when findings match this entity type, or `any`
+    /// Exit 1 when findings match this entity type, or `any`.
     #[arg(long)]
     pub fail_on: Option<String>,
 
-    /// Write local debug samples (incompatible with --report-url)
+    /// Write local debug samples (incompatible with `--report-url`).
     #[arg(long)]
     pub include_samples: bool,
 
-    /// Path for local debug samples (required with --include-samples and --format json)
+    /// Path for local debug samples (required with `--include-samples` and `--format json`).
     #[arg(long)]
     pub samples_out: Option<PathBuf>,
 }
 
+impl fmt::Debug for Cli {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Cli")
+            .field("url", &self.url.as_deref().map(scrub))
+            .field("schema", &self.schema)
+            .field("layers", &self.layers)
+            .field("sample_rows", &self.sample_rows)
+            .field("statement_timeout", &self.statement_timeout)
+            .field("format", &self.format)
+            .field("out", &self.out)
+            .field("report_url", &self.report_url)
+            .field("api_key", &self.api_key.as_ref().map(|_| "***"))
+            .field(
+                "report_headers",
+                &self
+                    .report_headers
+                    .iter()
+                    .map(|h| scrub(h))
+                    .collect::<Vec<_>>(),
+            )
+            .field("fail_on", &self.fail_on)
+            .field("include_samples", &self.include_samples)
+            .field("samples_out", &self.samples_out)
+            .finish()
+    }
+}
+
+impl fmt::Debug for OutputFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OutputFormat::Json => f.write_str("Json"),
+            OutputFormat::Table => f.write_str("Table"),
+        }
+    }
+}
+
 impl Cli {
+    /// Parse `--layers` into unique [`ScanLayer`] values.
     pub fn parsed_layers(&self) -> Result<Vec<ScanLayer>> {
         if self.layers.trim().is_empty() {
             return Ok(default_layers());
@@ -83,6 +125,7 @@ impl Cli {
         parse_layers(&self.layers)
     }
 
+    /// Parse `--statement-timeout` (`30s`, `500ms`, `2m`, or bare seconds).
     pub fn statement_timeout(&self) -> Result<Duration> {
         parse_duration(&self.statement_timeout)
     }
@@ -99,14 +142,11 @@ impl Cli {
                 "--include-samples with --format json requires --samples-out"
             ));
         }
-        if self.url.is_none() && self.report_url.is_none() {
-            // Allow --include-samples + --report-url error path without --url.
-            // A real scan still needs --url; checked in run().
-        }
         Ok(())
     }
 }
 
+/// Parse a human duration used by `--statement-timeout`.
 pub fn parse_duration(s: &str) -> Result<Duration> {
     let s = s.trim();
     if let Some(ms) = s.strip_suffix("ms") {
@@ -148,5 +188,20 @@ mod tests {
     fn duration_parse() {
         assert_eq!(parse_duration("30s").unwrap(), Duration::from_secs(30));
         assert_eq!(parse_duration("500ms").unwrap(), Duration::from_millis(500));
+    }
+
+    #[test]
+    fn debug_redacts_url_and_api_key() {
+        let cli = Cli::parse_from([
+            "redact-scan",
+            "--url",
+            "postgres://alice:s3cret-pass@localhost/app",
+            "--api-key",
+            "tok_live_secret",
+        ]);
+        let shown = format!("{cli:?}");
+        assert!(!shown.contains("s3cret-pass"));
+        assert!(!shown.contains("tok_live_secret"));
+        assert!(shown.contains("***"));
     }
 }

--- a/crates/redact-scan/src/cli.rs
+++ b/crates/redact-scan/src/cli.rs
@@ -90,7 +90,7 @@ impl fmt::Debug for Cli {
             .field("statement_timeout", &self.statement_timeout)
             .field("format", &self.format)
             .field("out", &self.out)
-            .field("report_url", &self.report_url)
+            .field("report_url", &self.report_url.as_deref().map(scrub))
             .field("api_key", &self.api_key.as_ref().map(|_| "***"))
             .field(
                 "report_headers",
@@ -198,10 +198,13 @@ mod tests {
             "postgres://alice:s3cret-pass@localhost/app",
             "--api-key",
             "tok_live_secret",
+            "--report-url",
+            "https://hook:hook-pass@example.test/ingest",
         ]);
         let shown = format!("{cli:?}");
         assert!(!shown.contains("s3cret-pass"));
         assert!(!shown.contains("tok_live_secret"));
+        assert!(!shown.contains("hook-pass"));
         assert!(shown.contains("***"));
     }
 }

--- a/crates/redact-scan/src/error.rs
+++ b/crates/redact-scan/src/error.rs
@@ -5,19 +5,21 @@
 use crate::scrub::scrub_secret;
 use std::fmt;
 
-/// Scanner error. Display/Debug never include raw credentials.
+/// Scanner error. [`Display`](std::fmt::Display) and [`Debug`] never include raw credentials.
 #[derive(Debug)]
 pub struct ScanError {
     message: String,
 }
 
 impl ScanError {
+    /// Build an error after running the credential scrubber on `message`.
     pub fn new(message: impl std::fmt::Display) -> Self {
         Self {
             message: crate::scrub::scrub(&message.to_string()),
         }
     }
 
+    /// Build an error, also replacing every occurrence of `secret`.
     pub fn with_secret(message: impl std::fmt::Display, secret: &str) -> Self {
         Self {
             message: scrub_secret(&message.to_string(), secret),

--- a/crates/redact-scan/src/error.rs
+++ b/crates/redact-scan/src/error.rs
@@ -1,0 +1,40 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+use crate::scrub::scrub_secret;
+use std::fmt;
+
+/// Scanner error. Display/Debug never include raw credentials.
+#[derive(Debug)]
+pub struct ScanError {
+    message: String,
+}
+
+impl ScanError {
+    pub fn new(message: impl std::fmt::Display) -> Self {
+        Self {
+            message: crate::scrub::scrub(&message.to_string()),
+        }
+    }
+
+    pub fn with_secret(message: impl std::fmt::Display, secret: &str) -> Self {
+        Self {
+            message: scrub_secret(&message.to_string(), secret),
+        }
+    }
+}
+
+impl fmt::Display for ScanError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ScanError {}
+
+impl From<anyhow::Error> for ScanError {
+    fn from(err: anyhow::Error) -> Self {
+        Self::new(err)
+    }
+}

--- a/crates/redact-scan/src/layers.rs
+++ b/crates/redact-scan/src/layers.rs
@@ -1,0 +1,134 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+use std::str::FromStr;
+
+/// Discovery layer. Serialized as 0, 0.5, 1, or 2.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ScanLayer {
+    Metadata,
+    Stats,
+    Sample,
+    Json,
+}
+
+impl ScanLayer {
+    pub fn as_f64(self) -> f64 {
+        match self {
+            ScanLayer::Metadata => 0.0,
+            ScanLayer::Stats => 0.5,
+            ScanLayer::Sample => 1.0,
+            ScanLayer::Json => 2.0,
+        }
+    }
+
+    pub fn from_f64(v: f64) -> Result<Self> {
+        if (v - 0.0).abs() < f64::EPSILON {
+            Ok(ScanLayer::Metadata)
+        } else if (v - 0.5).abs() < f64::EPSILON {
+            Ok(ScanLayer::Stats)
+        } else if (v - 1.0).abs() < f64::EPSILON {
+            Ok(ScanLayer::Sample)
+        } else if (v - 2.0).abs() < f64::EPSILON {
+            Ok(ScanLayer::Json)
+        } else {
+            Err(anyhow!("invalid layer {v}; expected 0, 0.5, 1, or 2"))
+        }
+    }
+}
+
+impl fmt::Display for ScanLayer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ScanLayer::Metadata => write!(f, "0"),
+            ScanLayer::Stats => write!(f, "0.5"),
+            ScanLayer::Sample => write!(f, "1"),
+            ScanLayer::Json => write!(f, "2"),
+        }
+    }
+}
+
+impl FromStr for ScanLayer {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let t = s.trim();
+        match t {
+            "0" | "metadata" => Ok(ScanLayer::Metadata),
+            "0.5" | "stats" => Ok(ScanLayer::Stats),
+            "1" | "sample" => Ok(ScanLayer::Sample),
+            "2" | "json" => Ok(ScanLayer::Json),
+            other => {
+                let v: f64 = other
+                    .parse()
+                    .map_err(|_| anyhow!("invalid layer {other}; expected 0, 0.5, 1, or 2"))?;
+                ScanLayer::from_f64(v)
+            }
+        }
+    }
+}
+
+impl Serialize for ScanLayer {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_f64(self.as_f64())
+    }
+}
+
+impl<'de> Deserialize<'de> for ScanLayer {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let v = f64::deserialize(deserializer)?;
+        ScanLayer::from_f64(v).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Parse a comma-separated layer list (`0,0.5,1,2`).
+pub fn parse_layers(s: &str) -> Result<Vec<ScanLayer>> {
+    let mut out = Vec::new();
+    for part in s.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        let layer = ScanLayer::from_str(part)?;
+        if !out.contains(&layer) {
+            out.push(layer);
+        }
+    }
+    if out.is_empty() {
+        return Err(anyhow!("--layers must select at least one layer"));
+    }
+    Ok(out)
+}
+
+pub fn default_layers() -> Vec<ScanLayer> {
+    vec![
+        ScanLayer::Metadata,
+        ScanLayer::Stats,
+        ScanLayer::Sample,
+        ScanLayer::Json,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_default_list() {
+        let layers = parse_layers("0,0.5,1,2").unwrap();
+        assert_eq!(layers.len(), 4);
+        assert_eq!(layers[1], ScanLayer::Stats);
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let json = serde_json::to_string(&ScanLayer::Stats).unwrap();
+        assert_eq!(json, "0.5");
+        let back: ScanLayer = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, ScanLayer::Stats);
+    }
+}

--- a/crates/redact-scan/src/layers.rs
+++ b/crates/redact-scan/src/layers.rs
@@ -7,16 +7,21 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 use std::str::FromStr;
 
-/// Discovery layer. Serialized as 0, 0.5, 1, or 2.
+/// Discovery layer. Serialized as JSON numbers `0`, `0.5`, `1`, or `2`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ScanLayer {
+    /// Layer 0: catalog metadata only (no user-table reads).
     Metadata,
+    /// Layer 0.5: planner statistics (`pg_stats`).
     Stats,
+    /// Layer 1: bounded `TABLESAMPLE` of candidate columns.
     Sample,
+    /// Layer 2: JSON/JSONB path sampling.
     Json,
 }
 
 impl ScanLayer {
+    /// Numeric form used on the CLI and in report JSON.
     pub fn as_f64(self) -> f64 {
         match self {
             ScanLayer::Metadata => 0.0,
@@ -26,6 +31,7 @@ impl ScanLayer {
         }
     }
 
+    /// Parse the numeric layer token.
     pub fn from_f64(v: f64) -> Result<Self> {
         if (v - 0.0).abs() < f64::EPSILON {
             Ok(ScanLayer::Metadata)
@@ -104,6 +110,7 @@ pub fn parse_layers(s: &str) -> Result<Vec<ScanLayer>> {
     Ok(out)
 }
 
+/// Default layer set: `0,0.5,1,2`.
 pub fn default_layers() -> Vec<ScanLayer> {
     vec![
         ScanLayer::Metadata,

--- a/crates/redact-scan/src/lib.rs
+++ b/crates/redact-scan/src/lib.rs
@@ -7,16 +7,25 @@
 //! Prefer a replica or staging database. Reports list locations and counts
 //! only — never sample values.
 
+/// Canonical JSON hashing for [`ScanReport::content_hash`].
 pub mod canonical;
+/// Command-line argument types.
 pub mod cli;
+/// Scrubbed scanner errors.
 pub mod error;
+/// Discovery layer identifiers (`0`, `0.5`, `1`, `2`).
 pub mod layers;
+/// Value-free report types.
 pub mod report;
+/// Credential redaction for logs and errors.
 pub mod scrub;
 
 pub use error::ScanError;
 pub use report::{Finding, ScanReport};
 
+/// Process exit code when the scan completed with no fail-on match.
 pub const EXIT_CLEAN: i32 = 0;
+/// Process exit code when `--fail-on` matched at least one finding.
 pub const EXIT_FINDINGS: i32 = 1;
+/// Process exit code for usage errors, safety refusals, and I/O failures.
 pub const EXIT_ERROR: i32 = 2;

--- a/crates/redact-scan/src/lib.rs
+++ b/crates/redact-scan/src/lib.rs
@@ -1,0 +1,22 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Read-only Postgres PII discovery scanner.
+//!
+//! Prefer a replica or staging database. Reports list locations and counts
+//! only — never sample values.
+
+pub mod canonical;
+pub mod cli;
+pub mod error;
+pub mod layers;
+pub mod report;
+pub mod scrub;
+
+pub use error::ScanError;
+pub use report::{Finding, ScanReport};
+
+pub const EXIT_CLEAN: i32 = 0;
+pub const EXIT_FINDINGS: i32 = 1;
+pub const EXIT_ERROR: i32 = 2;

--- a/crates/redact-scan/src/main.rs
+++ b/crates/redact-scan/src/main.rs
@@ -1,0 +1,41 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+use clap::Parser;
+use redact_scan::cli::Cli;
+use redact_scan::error::ScanError;
+use redact_scan::scrub::scrub;
+use redact_scan::EXIT_ERROR;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    install_panic_hook();
+    match run() {
+        Ok(code) => ExitCode::from(code as u8),
+        Err(err) => {
+            eprintln!("Error: {err}");
+            ExitCode::from(EXIT_ERROR as u8)
+        }
+    }
+}
+
+fn run() -> Result<i32, ScanError> {
+    let cli = Cli::parse();
+    cli.validate_preflight().map_err(ScanError::new)?;
+    if cli.url.is_none() {
+        return Err(ScanError::new("--url is required"));
+    }
+    Err(ScanError::new(
+        "scan execution is not implemented in this revision",
+    ))
+}
+
+fn install_panic_hook() {
+    let default = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let msg = scrub(&info.to_string());
+        eprintln!("panic: {msg}");
+        default(info);
+    }));
+}

--- a/crates/redact-scan/src/main.rs
+++ b/crates/redact-scan/src/main.rs
@@ -32,10 +32,8 @@ fn run() -> Result<i32, ScanError> {
 }
 
 fn install_panic_hook() {
-    let default = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
-        let msg = scrub(&info.to_string());
-        eprintln!("panic: {msg}");
-        default(info);
+        // Do not invoke the default hook: it would print the original payload.
+        eprintln!("panic: {}", scrub(&info.to_string()));
     }));
 }

--- a/crates/redact-scan/src/report.rs
+++ b/crates/redact-scan/src/report.rs
@@ -14,63 +14,98 @@ use crate::layers::ScanLayer;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum EvidenceClass {
+    /// Column or table name matched a known PII token.
     NameHeuristic,
+    /// Native column type (for example `inet`) implied an entity.
     TypeSignal,
+    /// Unique index on text-like data (candidate boost only).
     UniqueIndex,
+    /// Foreign key toward a subject-like table (candidate boost only).
     FkTopology,
+    /// Planner statistics (`most_common_vals` / `histogram_bounds`).
     PgStats,
+    /// Bounded table sample.
     TableSample,
+    /// JSON document path sample.
     JsonPath,
 }
 
 /// A PII location. This type must not grow a field that can hold a sample value.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Finding {
+    /// Qualified table name (`schema.table`).
     pub table: String,
+    /// Column name.
     pub column: String,
+    /// JSON path for layer 2 findings (`$.customer.email`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub json_path: Option<String>,
+    /// Detected entity type (SCREAMING_SNAKE_CASE in JSON).
     pub entity_type: EntityType,
+    /// Layer that produced the finding.
     pub layer: ScanLayer,
+    /// How many sampled cells matched. Zero for metadata-only findings.
     pub match_count: u64,
+    /// How many cells were examined. Zero for metadata-only findings.
     pub sampled_rows: u64,
+    /// Detector or heuristic confidence in `0.0..=1.0`.
     pub confidence: f32,
+    /// Why this location was reported.
     pub evidence_class: EvidenceClass,
 }
 
+/// Hashed scan target. Never a connection string or hostname.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Target {
+    /// `sha256(host|database|schema)` hex digest.
     pub fingerprint: String,
+    /// Database engine (`postgres`).
     pub engine: String,
+    /// Server version string from the engine.
     pub version: String,
 }
 
+/// Scanner identity recorded in the report.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Scanner {
+    /// `CARGO_PKG_VERSION` of `redact-scan`.
     pub version: String,
+    /// Built-in pattern pack label (`builtin@<count>`).
     pub pattern_pack: String,
 }
 
+/// Sampling configuration used for the run.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Sampling {
+    /// Layers that were selected.
     pub layers: Vec<ScanLayer>,
+    /// `--sample-rows` limit.
     pub rows_per_column: u32,
+    /// Sampling method (`TABLESAMPLE SYSTEM`).
     pub method: String,
 }
 
 /// Value-free scan report. `content_hash` is computed after the other fields.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ScanReport {
+    /// Random identifier for this run.
     pub scan_id: Uuid,
+    /// UTC timestamp when the report was assembled.
     pub scanned_at: DateTime<Utc>,
+    /// Hashed target identity.
     pub target: Target,
+    /// Scanner version and pattern pack.
     pub scanner: Scanner,
+    /// Selected layers and sample size.
     pub sampling: Sampling,
+    /// Locations only — never values.
     pub findings: Vec<Finding>,
+    /// SHA-256 of canonical JSON with this field omitted.
     pub content_hash: String,
 }
 
 impl ScanReport {
+    /// Fill [`ScanReport::content_hash`] from the other fields.
     pub fn finalize(mut self) -> Result<Self, anyhow::Error> {
         self.content_hash.clear();
         self.content_hash = content_hash(&self)?;
@@ -81,7 +116,9 @@ impl ScanReport {
 /// Local debug samples. Never serialized into [`ScanReport`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DebugSamples {
+    /// Scan that produced the sidecar file.
     pub scan_id: Uuid,
+    /// Operator note. Must not be merged into [`ScanReport`].
     pub notes: String,
 }
 

--- a/crates/redact-scan/src/report.rs
+++ b/crates/redact-scan/src/report.rs
@@ -1,0 +1,129 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+use chrono::{DateTime, Utc};
+use redact_core::EntityType;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::canonical::content_hash;
+use crate::layers::ScanLayer;
+
+/// How a finding was produced. Never carries a matched value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceClass {
+    NameHeuristic,
+    TypeSignal,
+    UniqueIndex,
+    FkTopology,
+    PgStats,
+    TableSample,
+    JsonPath,
+}
+
+/// A PII location. This type must not grow a field that can hold a sample value.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Finding {
+    pub table: String,
+    pub column: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub json_path: Option<String>,
+    pub entity_type: EntityType,
+    pub layer: ScanLayer,
+    pub match_count: u64,
+    pub sampled_rows: u64,
+    pub confidence: f32,
+    pub evidence_class: EvidenceClass,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Target {
+    pub fingerprint: String,
+    pub engine: String,
+    pub version: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Scanner {
+    pub version: String,
+    pub pattern_pack: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Sampling {
+    pub layers: Vec<ScanLayer>,
+    pub rows_per_column: u32,
+    pub method: String,
+}
+
+/// Value-free scan report. `content_hash` is computed after the other fields.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScanReport {
+    pub scan_id: Uuid,
+    pub scanned_at: DateTime<Utc>,
+    pub target: Target,
+    pub scanner: Scanner,
+    pub sampling: Sampling,
+    pub findings: Vec<Finding>,
+    pub content_hash: String,
+}
+
+impl ScanReport {
+    pub fn finalize(mut self) -> Result<Self, anyhow::Error> {
+        self.content_hash.clear();
+        self.content_hash = content_hash(&self)?;
+        Ok(self)
+    }
+}
+
+/// Local debug samples. Never serialized into [`ScanReport`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DebugSamples {
+    pub scan_id: Uuid,
+    pub notes: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finding_json_has_no_value_keys() {
+        let f = Finding {
+            table: "public.t".into(),
+            column: "c".into(),
+            json_path: None,
+            entity_type: EntityType::EmailAddress,
+            layer: ScanLayer::Sample,
+            match_count: 1,
+            sampled_rows: 10,
+            confidence: 0.9,
+            evidence_class: EvidenceClass::TableSample,
+        };
+        let s = serde_json::to_string(&f).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&s).unwrap();
+        let keys = object_keys(&value);
+        for banned in ["value", "sample", "text", "most_common"] {
+            assert!(
+                !keys.iter().any(|k| k == banned),
+                "finding JSON unexpectedly contains key {banned}: {s}"
+            );
+        }
+    }
+
+    fn object_keys(value: &serde_json::Value) -> Vec<String> {
+        match value {
+            serde_json::Value::Object(map) => {
+                let mut keys: Vec<String> = map.keys().cloned().collect();
+                for v in map.values() {
+                    keys.extend(object_keys(v));
+                }
+                keys
+            }
+            serde_json::Value::Array(items) => items.iter().flat_map(object_keys).collect(),
+            _ => Vec::new(),
+        }
+    }
+}

--- a/crates/redact-scan/src/scrub.rs
+++ b/crates/redact-scan/src/scrub.rs
@@ -1,0 +1,63 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+use regex::Regex;
+use std::sync::OnceLock;
+
+fn url_userinfo() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)([a-z][a-z0-9+.-]*://)([^:/?#]+):([^@/?#]+)@").expect("url userinfo regex")
+    })
+}
+
+fn password_query() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)(password|passwd|pwd|secret)=([^&\s]+)").expect("password query regex")
+    })
+}
+
+/// Redact credentials from any string that may appear in logs or errors.
+pub fn scrub(input: &str) -> String {
+    let mut out = url_userinfo()
+        .replace_all(input, |caps: &regex::Captures| {
+            format!("{}{}:***@", &caps[1], &caps[2])
+        })
+        .into_owned();
+    out = password_query()
+        .replace_all(&out, |caps: &regex::Captures| format!("{}=***", &caps[1]))
+        .into_owned();
+    // Percent-encoded userinfo (`user%3Apass@` is uncommon; cover `pass%40word` leftovers
+    // by also stripping raw password tokens when explicitly provided.
+    out
+}
+
+/// If `secret` is non-empty and appears in `input`, replace every occurrence.
+pub fn scrub_secret(input: &str, secret: &str) -> String {
+    let mut out = scrub(input);
+    if !secret.is_empty() && out.contains(secret) {
+        out = out.replace(secret, "***");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scrubs_url_password() {
+        let s = scrub("postgres://alice:s3cret-pass@db.example/app");
+        assert!(!s.contains("s3cret-pass"));
+        assert!(s.contains("alice:***@"));
+    }
+
+    #[test]
+    fn scrubs_query_password() {
+        let s = scrub("error password=hunter2 extra");
+        assert!(!s.contains("hunter2"));
+        assert!(s.contains("password=***"));
+    }
+}

--- a/crates/redact-scan/src/scrub.rs
+++ b/crates/redact-scan/src/scrub.rs
@@ -19,26 +19,69 @@ fn password_query() -> &'static Regex {
     })
 }
 
-/// Redact credentials from any string that may appear in logs or errors.
-pub fn scrub(input: &str) -> String {
-    let mut out = url_userinfo()
+/// Percent-decode `%XX` sequences. Invalid sequences are left unchanged.
+pub fn percent_decode(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let Ok(v) = u8::from_str_radix(&input[i + 1..i + 3], 16) {
+                out.push(v);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn fully_percent_decode(input: &str) -> String {
+    let mut current = input.to_string();
+    for _ in 0..3 {
+        let next = percent_decode(&current);
+        if next == current {
+            break;
+        }
+        current = next;
+    }
+    current
+}
+
+fn scrub_patterns(input: &str) -> String {
+    let out = url_userinfo()
         .replace_all(input, |caps: &regex::Captures| {
             format!("{}{}:***@", &caps[1], &caps[2])
         })
         .into_owned();
-    out = password_query()
+    password_query()
         .replace_all(&out, |caps: &regex::Captures| format!("{}=***", &caps[1]))
-        .into_owned();
-    // Percent-encoded userinfo (`user%3Apass@` is uncommon; cover `pass%40word` leftovers
-    // by also stripping raw password tokens when explicitly provided.
-    out
+        .into_owned()
+}
+
+/// Redact credentials from any string that may appear in logs or errors.
+///
+/// Handles `user:pass@`, `password=`, and percent-encoded variants
+/// (`user%3Apass`, `password%3D…`, `%40` in passwords) by decoding first.
+pub fn scrub(input: &str) -> String {
+    let decoded = fully_percent_decode(input);
+    scrub_patterns(&decoded)
 }
 
 /// If `secret` is non-empty and appears in `input`, replace every occurrence.
 pub fn scrub_secret(input: &str, secret: &str) -> String {
     let mut out = scrub(input);
-    if !secret.is_empty() && out.contains(secret) {
+    if secret.is_empty() {
+        return out;
+    }
+    if out.contains(secret) {
         out = out.replace(secret, "***");
+    }
+    let decoded_secret = fully_percent_decode(secret);
+    if decoded_secret != secret && out.contains(&decoded_secret) {
+        out = out.replace(&decoded_secret, "***");
     }
     out
 }
@@ -57,6 +100,28 @@ mod tests {
     #[test]
     fn scrubs_query_password() {
         let s = scrub("error password=hunter2 extra");
+        assert!(!s.contains("hunter2"));
+        assert!(s.contains("password=***"));
+    }
+
+    #[test]
+    fn scrubs_percent_encoded_password_in_url() {
+        let s = scrub("postgres://alice:p%40ssword@db.example/app");
+        assert!(!s.contains("p%40ssword"));
+        assert!(!s.contains("p@ssword"));
+        assert!(s.contains("alice:***@"));
+    }
+
+    #[test]
+    fn scrubs_percent_encoded_userinfo_delimiter() {
+        let s = scrub("postgres://alice%3As3cret-pass@db.example/app");
+        assert!(!s.contains("s3cret-pass"));
+        assert!(s.contains("alice:***@"));
+    }
+
+    #[test]
+    fn scrubs_percent_encoded_password_query() {
+        let s = scrub("login failed password%3Dhunter2");
         assert!(!s.contains("hunter2"));
         assert!(s.contains("password=***"));
     }

--- a/crates/redact-scan/src/scrub.rs
+++ b/crates/redact-scan/src/scrub.rs
@@ -47,6 +47,18 @@ fn fully_percent_decode(input: &str) -> String {
     current
 }
 
+fn scrub_decode_rounds(input: &str) -> String {
+    let mut current = scrub_patterns(input);
+    for _ in 0..3 {
+        let next = percent_decode(&current);
+        if next == current {
+            break;
+        }
+        current = scrub_patterns(&next);
+    }
+    current
+}
+
 /// Redact `user:password@` using the last `@` in the URL authority.
 ///
 /// That last `@` is the host delimiter (RFC 3986). Encoded `@` / `:` inside
@@ -106,15 +118,10 @@ fn scrub_patterns(input: &str) -> String {
 /// Handles `user:pass@`, `password=`, and percent-encoded variants
 /// (`user%3Apass`, `password%3D…`, `%40` / `%26` inside passwords).
 /// Patterns run on the raw string first so encoded reserved bytes stay
-/// inside the credential; then the result is decoded and scrubbed again.
+/// inside the credential; then each percent-decode pass is scrubbed again
+/// (nested `%25` encodings included).
 pub fn scrub(input: &str) -> String {
-    let raw = scrub_patterns(input);
-    let decoded = fully_percent_decode(&raw);
-    if decoded == raw {
-        raw
-    } else {
-        scrub_patterns(&decoded)
-    }
+    scrub_decode_rounds(input)
 }
 
 /// If `secret` is non-empty and appears in `input`, replace every occurrence.
@@ -195,6 +202,14 @@ mod tests {
     fn leaves_username_only_url() {
         let s = scrub("postgres://alice@db.example/app");
         assert_eq!(s, "postgres://alice@db.example/app");
+    }
+
+    #[test]
+    fn scrubs_double_encoded_query_password() {
+        let s = scrub("login failed password%253Dpa%2526ss");
+        assert!(!s.contains("pa%26ss"), "{s}");
+        assert!(!s.contains("pa&ss"), "{s}");
+        assert!(s.contains("password=***"), "{s}");
     }
 
     #[test]

--- a/crates/redact-scan/src/scrub.rs
+++ b/crates/redact-scan/src/scrub.rs
@@ -8,8 +8,10 @@ use std::sync::OnceLock;
 fn password_query() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
-        Regex::new(r"(?i)(password|passwd|pwd|secret)(?:=|%3[Dd])([^&\s]+)")
-            .expect("password query regex")
+        Regex::new(
+            r#"(?i)(password|passwd|pwd|secret)(?:=|%3[Dd])(?:'([^']*)'|"([^"]*)"|([^&\s]+))"#,
+        )
+        .expect("password query regex")
     })
 }
 
@@ -156,6 +158,16 @@ mod tests {
         let s = scrub("error password=hunter2 extra");
         assert!(!s.contains("hunter2"));
         assert!(s.contains("password=***"));
+    }
+
+    #[test]
+    fn scrubs_quoted_libpq_password() {
+        let s = scrub("libpq connect failed: host=db user=app password='pa ss' dbname=prod");
+        assert!(!s.contains("pa ss"), "{s}");
+        assert!(s.contains("password=***"), "{s}");
+        let d = scrub(r#"libpq connect failed password="pa ss" dbname=prod"#);
+        assert!(!d.contains("pa ss"), "{d}");
+        assert!(d.contains("password=***"), "{d}");
     }
 
     #[test]

--- a/crates/redact-scan/src/scrub.rs
+++ b/crates/redact-scan/src/scrub.rs
@@ -5,17 +5,11 @@
 use regex::Regex;
 use std::sync::OnceLock;
 
-fn url_userinfo() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        Regex::new(r"(?i)([a-z][a-z0-9+.-]*://)([^:/?#]+):([^@/?#]+)@").expect("url userinfo regex")
-    })
-}
-
 fn password_query() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
-        Regex::new(r"(?i)(password|passwd|pwd|secret)=([^&\s]+)").expect("password query regex")
+        Regex::new(r"(?i)(password|passwd|pwd|secret)(?:=|%3[Dd])([^&\s]+)")
+            .expect("password query regex")
     })
 }
 
@@ -53,23 +47,66 @@ fn fully_percent_decode(input: &str) -> String {
     current
 }
 
-fn scrub_patterns(input: &str) -> String {
-    let out = url_userinfo()
-        .replace_all(input, |caps: &regex::Captures| {
-            format!("{}{}:***@", &caps[1], &caps[2])
-        })
-        .into_owned();
+/// Redact `user:password@` using the last `@` in the URL authority.
+///
+/// That last `@` is the host delimiter (RFC 3986). Encoded `@` / `:` inside
+/// the password therefore cannot split the credential.
+fn scrub_url_userinfo(input: &str) -> String {
+    let lower = input.to_ascii_lowercase();
+    let mut out = String::with_capacity(input.len());
+    let mut i = 0;
+    while i < input.len() {
+        let Some(rel) = lower[i..].find("://") else {
+            out.push_str(&input[i..]);
+            break;
+        };
+        let scheme_end = i + rel + 3;
+        out.push_str(&input[i..scheme_end]);
+        let rest = &input[scheme_end..];
+        let auth_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+        let authority = &rest[..auth_end];
+        if let Some(at) = authority.rfind('@') {
+            let userinfo = &authority[..at];
+            let hostport = &authority[at + 1..];
+            if let Some(user) = userinfo_user(userinfo) {
+                out.push_str(user);
+                out.push_str(":***@");
+                out.push_str(hostport);
+            } else {
+                out.push_str(authority);
+            }
+        } else {
+            out.push_str(authority);
+        }
+        i = scheme_end + auth_end;
+    }
+    out
+}
+
+fn userinfo_user(userinfo: &str) -> Option<&str> {
+    if let Some((user, _)) = userinfo.split_once(':') {
+        return Some(user);
+    }
+    let lower = userinfo.to_ascii_lowercase();
+    lower.find("%3a").map(|idx| &userinfo[..idx])
+}
+
+fn scrub_password_params(input: &str) -> String {
     password_query()
-        .replace_all(&out, |caps: &regex::Captures| format!("{}=***", &caps[1]))
+        .replace_all(input, |caps: &regex::Captures| format!("{}=***", &caps[1]))
         .into_owned()
+}
+
+fn scrub_patterns(input: &str) -> String {
+    scrub_password_params(&scrub_url_userinfo(input))
 }
 
 /// Redact credentials from any string that may appear in logs or errors.
 ///
 /// Handles `user:pass@`, `password=`, and percent-encoded variants
-/// (`user%3Apass`, `password%3D…`, `%40` in passwords). Patterns run on the
-/// raw string first so an encoded `@` inside a password cannot split userinfo
-/// after decode; then the result is decoded and scrubbed again.
+/// (`user%3Apass`, `password%3D…`, `%40` / `%26` inside passwords).
+/// Patterns run on the raw string first so encoded reserved bytes stay
+/// inside the credential; then the result is decoded and scrubbed again.
 pub fn scrub(input: &str) -> String {
     let raw = scrub_patterns(input);
     let decoded = fully_percent_decode(&raw);
@@ -124,6 +161,21 @@ mod tests {
     }
 
     #[test]
+    fn scrubs_percent_encoded_userinfo_delimiter() {
+        let s = scrub("postgres://alice%3As3cret-pass@db.example/app");
+        assert!(!s.contains("s3cret-pass"));
+        assert!(s.contains("alice:***@"));
+    }
+
+    #[test]
+    fn scrubs_combined_encoded_separator_and_at() {
+        let s = scrub("postgres://alice%3As3cret%40pass@db.example/app");
+        assert!(!s.contains("s3cret"), "{s}");
+        assert!(!s.contains("pass@"), "{s}");
+        assert!(s.contains("alice:***@"), "{s}");
+    }
+
+    #[test]
     fn scrubs_password_with_encoded_reserved_bytes() {
         let s = scrub("postgres://alice:a%26b%2Fc%3Fd@db.example/app");
         assert!(!s.contains("a%26b"), "{s}");
@@ -132,23 +184,23 @@ mod tests {
     }
 
     #[test]
+    fn scrubs_encoded_query_password_with_encoded_ampersand() {
+        let s = scrub("login failed password%3Dpa%26ss");
+        assert!(!s.contains("pa%26ss"), "{s}");
+        assert!(!s.contains("pa&ss"), "{s}");
+        assert!(s.contains("password=***"), "{s}");
+    }
+
+    #[test]
+    fn leaves_username_only_url() {
+        let s = scrub("postgres://alice@db.example/app");
+        assert_eq!(s, "postgres://alice@db.example/app");
+    }
+
+    #[test]
     fn percent_decode_leaves_invalid_and_unicode_sequences() {
         assert_eq!(percent_decode("%€"), "%€");
         assert_eq!(percent_decode("%ZZ"), "%ZZ");
         assert_eq!(percent_decode("ok%20x"), "ok x");
-    }
-
-    #[test]
-    fn scrubs_percent_encoded_userinfo_delimiter() {
-        let s = scrub("postgres://alice%3As3cret-pass@db.example/app");
-        assert!(!s.contains("s3cret-pass"));
-        assert!(s.contains("alice:***@"));
-    }
-
-    #[test]
-    fn scrubs_percent_encoded_password_query() {
-        let s = scrub("login failed password%3Dhunter2");
-        assert!(!s.contains("hunter2"));
-        assert!(s.contains("password=***"));
     }
 }

--- a/crates/redact-scan/src/scrub.rs
+++ b/crates/redact-scan/src/scrub.rs
@@ -26,8 +26,11 @@ pub fn percent_decode(input: &str) -> String {
     let mut i = 0;
     while i < bytes.len() {
         if bytes[i] == b'%' && i + 2 < bytes.len() {
-            if let Ok(v) = u8::from_str_radix(&input[i + 1..i + 3], 16) {
-                out.push(v);
+            let h1 = bytes[i + 1];
+            let h2 = bytes[i + 2];
+            if h1.is_ascii_hexdigit() && h2.is_ascii_hexdigit() {
+                let hex = std::str::from_utf8(&bytes[i + 1..i + 3]).expect("ascii hex");
+                out.push(u8::from_str_radix(hex, 16).expect("ascii hex"));
                 i += 3;
                 continue;
             }
@@ -64,10 +67,17 @@ fn scrub_patterns(input: &str) -> String {
 /// Redact credentials from any string that may appear in logs or errors.
 ///
 /// Handles `user:pass@`, `password=`, and percent-encoded variants
-/// (`user%3Apass`, `password%3D…`, `%40` in passwords) by decoding first.
+/// (`user%3Apass`, `password%3D…`, `%40` in passwords). Patterns run on the
+/// raw string first so an encoded `@` inside a password cannot split userinfo
+/// after decode; then the result is decoded and scrubbed again.
 pub fn scrub(input: &str) -> String {
-    let decoded = fully_percent_decode(input);
-    scrub_patterns(&decoded)
+    let raw = scrub_patterns(input);
+    let decoded = fully_percent_decode(&raw);
+    if decoded == raw {
+        raw
+    } else {
+        scrub_patterns(&decoded)
+    }
 }
 
 /// If `secret` is non-empty and appears in `input`, replace every occurrence.
@@ -107,9 +117,25 @@ mod tests {
     #[test]
     fn scrubs_percent_encoded_password_in_url() {
         let s = scrub("postgres://alice:p%40ssword@db.example/app");
-        assert!(!s.contains("p%40ssword"));
-        assert!(!s.contains("p@ssword"));
-        assert!(s.contains("alice:***@"));
+        assert!(!s.contains("p%40ssword"), "{s}");
+        assert!(!s.contains("p@ssword"), "{s}");
+        assert!(!s.contains("ssword"), "{s}");
+        assert!(s.contains("alice:***@"), "{s}");
+    }
+
+    #[test]
+    fn scrubs_password_with_encoded_reserved_bytes() {
+        let s = scrub("postgres://alice:a%26b%2Fc%3Fd@db.example/app");
+        assert!(!s.contains("a%26b"), "{s}");
+        assert!(!s.contains("a&b"), "{s}");
+        assert!(s.contains("alice:***@"), "{s}");
+    }
+
+    #[test]
+    fn percent_decode_leaves_invalid_and_unicode_sequences() {
+        assert_eq!(percent_decode("%€"), "%€");
+        assert_eq!(percent_decode("%ZZ"), "%ZZ");
+        assert_eq!(percent_decode("ok%20x"), "ok x");
     }
 
     #[test]

--- a/crates/redact-scan/src/scrub.rs
+++ b/crates/redact-scan/src/scrub.rs
@@ -9,7 +9,7 @@ fn password_query() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
         Regex::new(
-            r#"(?i)(password|passwd|pwd|secret)(?:=|%3[Dd])(?:'([^']*)'|"([^"]*)"|([^&\s]+))"#,
+            r#"(?i)(password|passwd|pwd|secret)(?:=|%3[Dd])(?:'((?:\\.|[^'\\])*)'|"((?:\\.|[^"\\])*)"|([^&\s]+))"#,
         )
         .expect("password query regex")
     })
@@ -168,6 +168,9 @@ mod tests {
         let d = scrub(r#"libpq connect failed password="pa ss" dbname=prod"#);
         assert!(!d.contains("pa ss"), "{d}");
         assert!(d.contains("password=***"), "{d}");
+        let e = scrub(r"libpq connect failed: password='pa\' ss' dbname=prod");
+        assert!(!e.contains("ss'"), "{e}");
+        assert!(e.contains("password=***"), "{e}");
     }
 
     #[test]

--- a/crates/redact-scan/tests/cli_safety.rs
+++ b/crates/redact-scan/tests/cli_safety.rs
@@ -1,0 +1,56 @@
+//! CLI safety: flag combinations that must fail before any database connect.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::net::TcpListener;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+fn cli() -> Command {
+    Command::cargo_bin("redact-scan").unwrap()
+}
+
+#[test]
+fn include_samples_with_report_url_exits_error_without_connect() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let mut accepted = 0u32;
+        let start = std::time::Instant::now();
+        while start.elapsed() < Duration::from_millis(400) {
+            if listener.accept().is_ok() {
+                accepted += 1;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        let _ = tx.send(accepted);
+    });
+
+    cli()
+        .arg("--include-samples")
+        .arg("--samples-out")
+        .arg("/tmp/redact-scan-samples.json")
+        .arg("--report-url")
+        .arg(format!("http://{addr}/hook"))
+        .arg("--url")
+        .arg("postgres://nobody:should-not-connect@127.0.0.1:1/db")
+        .assert()
+        .failure()
+        .code(2)
+        .stderr(predicate::str::contains("--include-samples"));
+
+    let accepted = rx.recv_timeout(Duration::from_secs(1)).unwrap_or(0);
+    assert_eq!(accepted, 0, "must not open a TCP connection");
+}
+
+#[test]
+fn help_mentions_read_only_scanner() {
+    cli()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Read-only Postgres"));
+}

--- a/crates/redact-scan/tests/report_invariants.rs
+++ b/crates/redact-scan/tests/report_invariants.rs
@@ -1,0 +1,67 @@
+use chrono::{TimeZone, Utc};
+use redact_core::EntityType;
+use redact_scan::layers::ScanLayer;
+use redact_scan::report::{EvidenceClass, Finding, Sampling, ScanReport, Scanner, Target};
+use uuid::Uuid;
+
+#[test]
+fn report_json_omits_value_bearing_keys() {
+    let report = ScanReport {
+        scan_id: Uuid::nil(),
+        scanned_at: Utc.with_ymd_and_hms(2026, 8, 15, 0, 0, 0).unwrap(),
+        target: Target {
+            fingerprint: "abc".into(),
+            engine: "postgres".into(),
+            version: "16".into(),
+        },
+        scanner: Scanner {
+            version: "0.9.1".into(),
+            pattern_pack: "builtin@54".into(),
+        },
+        sampling: Sampling {
+            layers: vec![ScanLayer::Metadata],
+            rows_per_column: 1000,
+            method: "TABLESAMPLE SYSTEM".into(),
+        },
+        findings: vec![Finding {
+            table: "public.t".into(),
+            column: "c".into(),
+            json_path: None,
+            entity_type: EntityType::EmailAddress,
+            layer: ScanLayer::Sample,
+            match_count: 3,
+            sampled_rows: 10,
+            confidence: 0.9,
+            evidence_class: EvidenceClass::TableSample,
+        }],
+        content_hash: String::new(),
+    }
+    .finalize()
+    .unwrap();
+
+    let json = serde_json::to_string(&report).unwrap();
+    let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let keys = object_keys(&value);
+    for banned in ["value", "sample", "text", "most_common"] {
+        assert!(
+            !keys.iter().any(|k| k == banned),
+            "report JSON contains banned key {banned}: {json}"
+        );
+    }
+    assert!(!report.content_hash.is_empty());
+    assert!(!json.contains("postgres://"));
+}
+
+fn object_keys(value: &serde_json::Value) -> Vec<String> {
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut keys: Vec<String> = map.keys().cloned().collect();
+            for v in map.values() {
+                keys.extend(object_keys(v));
+            }
+            keys
+        }
+        serde_json::Value::Array(items) => items.iter().flat_map(object_keys).collect(),
+        _ => Vec::new(),
+    }
+}

--- a/crates/redact-scan/tests/scrub.rs
+++ b/crates/redact-scan/tests/scrub.rs
@@ -2,6 +2,28 @@ use redact_scan::error::ScanError;
 use redact_scan::scrub::{scrub, scrub_secret};
 
 #[test]
+fn new_scrubs_url_password_from_display_and_debug() {
+    let secret = "super-secret-db-pass";
+    let raw = format!("password authentication failed for postgres://app:{secret}@db/prod");
+    let err = ScanError::new(raw);
+    let shown = format!("{err}");
+    let debug = format!("{err:?}");
+    assert!(!shown.contains(secret));
+    assert!(!debug.contains(secret));
+    assert!(shown.contains("app:***@"));
+}
+
+#[test]
+fn new_scrubs_percent_encoded_password() {
+    let err = ScanError::new("connect postgres://app:p%40ssword@db/prod failed");
+    let shown = format!("{err}");
+    let debug = format!("{err:?}");
+    assert!(!shown.contains("p%40ssword"));
+    assert!(!shown.contains("p@ssword"));
+    assert!(!debug.contains("p@ssword"));
+}
+
+#[test]
 fn password_absent_from_formatted_error() {
     let secret = "super-secret-db-pass";
     let raw = format!("password authentication failed for postgres://app:{secret}@db/prod");

--- a/crates/redact-scan/tests/scrub.rs
+++ b/crates/redact-scan/tests/scrub.rs
@@ -20,6 +20,7 @@ fn new_scrubs_percent_encoded_password() {
     let debug = format!("{err:?}");
     assert!(!shown.contains("p%40ssword"));
     assert!(!shown.contains("p@ssword"));
+    assert!(!shown.contains("ssword"));
     assert!(!debug.contains("p@ssword"));
 }
 

--- a/crates/redact-scan/tests/scrub.rs
+++ b/crates/redact-scan/tests/scrub.rs
@@ -1,0 +1,21 @@
+use redact_scan::error::ScanError;
+use redact_scan::scrub::{scrub, scrub_secret};
+
+#[test]
+fn password_absent_from_formatted_error() {
+    let secret = "super-secret-db-pass";
+    let raw = format!("password authentication failed for postgres://app:{secret}@db/prod");
+    let err = ScanError::with_secret(raw, secret);
+    let shown = format!("{err}");
+    let debug = format!("{err:?}");
+    assert!(!shown.contains(secret));
+    assert!(!debug.contains(secret));
+    assert!(!scrub(&shown).contains(secret));
+}
+
+#[test]
+fn scrub_secret_replaces_raw_token() {
+    let out = scrub_secret("boom hunter2 boom", "hunter2");
+    assert!(!out.contains("hunter2"));
+    assert!(out.contains("***"));
+}

--- a/docs/PROJECT_SCOPE.md
+++ b/docs/PROJECT_SCOPE.md
@@ -18,6 +18,7 @@ This Apache-2.0 repository accepts contributions to:
 | `redact-cli` | Command-line interface |
 | `redact-wasm` | WebAssembly bindings |
 | `redact-gateway` | Self-hosted OpenAI-compatible privacy gateway |
+| `redact-scan` | Read-only Postgres PII discovery scanner |
 
 Also in scope: documentation, tests, examples, packaging, and CI for those
 crates.

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -38,6 +38,7 @@ show_usage() {
     echo "  - crates/redact-api/Cargo.toml (redact-core, redact-ner dependencies)"
     echo "  - crates/redact-cli/Cargo.toml (redact-core, redact-ner dependencies)"
     echo "  - crates/redact-gateway/Cargo.toml (redact-core dependency)"
+    echo "  - crates/redact-scan/Cargo.toml (redact-core dependency)"
     echo "  - README.md (library Cargo.toml example versions)"
     echo "  - docs/benchmarks/README.md (current release link)"
     echo "  - CHANGELOG.md (adds new version entry)"
@@ -271,6 +272,7 @@ main() {
     update_crate_dependency "crates/redact-cli/Cargo.toml" "redact-core" "$new_version" "$dry_run"
     update_crate_dependency "crates/redact-cli/Cargo.toml" "redact-ner" "$new_version" "$dry_run"
     update_crate_dependency "crates/redact-gateway/Cargo.toml" "redact-core" "$new_version" "$dry_run"
+    update_crate_dependency "crates/redact-scan/Cargo.toml" "redact-core" "$new_version" "$dry_run"
     update_doc_versions "$new_version" "$dry_run"
     update_changelog "$new_version" "$dry_run"
     


### PR DESCRIPTION
Thank you for contributing to Redact. These checkboxes are acknowledgements;
the CLA bot enforces the Individual CLA signature.

- [x] I have read [CLA.md](../CLA.md) and will sign the Individual CLA via the bot comment (or I have already signed). A Corporate CLA, if required, does not replace the Individual CLA.
- [x] All commits are DCO-signed (`git commit -s`)
- [x] I have read [docs/PROJECT_SCOPE.md](../docs/PROJECT_SCOPE.md); this change is in scope

**Employer time or equipment**

- [x] No — this work was not done on employer time or equipment
- [ ] Yes — my employer has authorised the contribution, or a Corporate CLA is on file

## Summary

Adds the `redact-scan` workspace crate as a local, read-only Postgres PII discovery scanner.

This first slice is types and CLI only:

- `ScanReport` / `Finding` with no value-bearing fields
- Canonical `content_hash` (sorted-key JSON, SHA-256)
- Credential scrubber for URLs and `password=` tokens
- Clap preflight: `--include-samples` + `--report-url` exits 2 before any connect
- Workspace membership, `PROJECT_SCOPE`, CI `coder*` branch filters, release version scripts

Scan execution (catalog, sampling, HTTP export) lands in follow-up PRs on this feature branch.

## Test plan

- [x] `cargo test -p redact-scan`
- [x] `cargo clippy -p redact-scan --all-targets -- -D warnings`
- [x] `cargo fmt --all`
- [x] CLI test binds a local listener and asserts `--include-samples --report-url` accepts zero connections
- [x] Report serde snapshot has no `value` / `sample` / `text` / `most_common` keys