### PR TITLE
feat(scan): read-only safety session and layers 0/0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `redact-scan`: new workspace crate and `redact-scan` binary for read-only
-  Postgres PII discovery. This revision adds the report types, credential
-  scrubber, and CLI preflight (`--include-samples` cannot be combined with
-  `--report-url`). Reports contain locations and counts only — never sample
-  values.
+  Postgres PII discovery. Report types, credential scrubber, CLI preflight,
+  a read-only safety session (refuse superuser and write grants), and
+  layers 0 / 0.5 (catalog metadata and `pg_stats`). Reports contain
+  locations and counts only — never sample values.
 
 ## [0.9.1] - 2026-08-08
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +194,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,6 +312,9 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "blake3"
@@ -310,6 +328,15 @@ dependencies = [
  "cfg-if",
  "constant_time_eq",
  "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -555,6 +582,12 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -610,6 +643,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,6 +707,15 @@ name = "crossbeam-epoch"
 version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -759,11 +816,22 @@ dependencies = [
 
 [[package]]
 name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
- "pem-rfc7468",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -812,12 +880,24 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
+name = "digest"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
- "block-buffer",
- "const-oid",
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
  "crypto-common 0.2.1",
  "ctutils",
 ]
@@ -834,6 +914,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +930,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -886,6 +975,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -904,6 +1014,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
 ]
 
 [[package]]
@@ -973,6 +1094,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1119,6 +1251,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -1129,10 +1263,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "hmac"
@@ -1140,7 +1307,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1148,6 +1315,15 @@ name = "hmac-sha256"
 version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "http"
@@ -1587,6 +1763,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -1615,6 +1794,28 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall 0.9.2",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1694,6 +1895,16 @@ checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
 dependencies = [
  "autocfg",
  "rawpointer",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1825,6 +2036,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.7",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1845,6 +2072,16 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
  "num-traits",
 ]
 
@@ -2092,6 +2329,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2109,7 +2352,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -2126,9 +2369,9 @@ version = "0.13.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f24f3eb2f4471b1730d59e4b730b747939960a8c7eb0c33c5a9076f2d3dddea"
 dependencies = [
- "digest",
- "hmac",
- "sha2",
+ "digest 0.11.2",
+ "hmac 0.13.0",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -2139,6 +2382,15 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64 0.22.1",
  "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -2183,10 +2435,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der 0.7.10",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.10",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -2462,11 +2741,22 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -2479,6 +2769,16 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.2",
  "rand_core 0.10.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2601,7 +2901,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tracing",
  "uuid",
@@ -2648,7 +2948,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_norway",
- "sha2",
+ "sha2 0.11.0",
  "subtle",
  "tempfile",
  "thiserror 2.0.18",
@@ -2692,7 +2992,11 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
+ "sqlx",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -2719,6 +3023,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1c93da5bb2c5d4e6c0ef7abeead62c89169a0a4882bfb83ac892f2423aea2fe"
 dependencies = [
  "bitflags",
 ]
@@ -2811,6 +3124,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2871,6 +3204,7 @@ checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3083,6 +3417,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3090,7 +3446,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -3124,6 +3480,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -3150,6 +3507,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -3173,6 +3533,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der 0.7.10",
+]
+
+[[package]]
 name = "spm_precompiled"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3182,6 +3561,204 @@ dependencies = [
  "nom",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 2.0.117",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest 0.10.7",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac 0.12.1",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.7",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac 0.12.1",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.7",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -3195,6 +3772,17 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -3725,10 +4313,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-normalization-alignments"
@@ -3738,6 +4341,12 @@ checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
 dependencies = [
  "smallvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -3804,7 +4413,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
- "der",
+ "der 0.8.0",
  "log",
  "native-tls",
  "percent-encoding",
@@ -3957,6 +4566,12 @@ checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -4129,6 +4744,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4240,6 +4883,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4278,6 +4930,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4321,6 +4988,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4339,6 +5012,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4354,6 +5033,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4387,6 +5072,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4402,6 +5093,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4423,6 +5120,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4438,6 +5141,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/redact-scan/Cargo.toml
+++ b/crates/redact-scan/Cargo.toml
@@ -15,13 +15,17 @@ categories = ["command-line-utilities", "database"]
 
 [dependencies]
 redact-core = { path = "../redact-core", version = "0.9.1" }
+sqlx = { workspace = true }
+tokio = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
 sha2 = { workspace = true }
-chrono = { workspace = true }
+chrono = { workspace = true, features = ["clock"] }
 regex = { workspace = true }
 
 [[bin]]

--- a/crates/redact-scan/src/catalog.rs
+++ b/crates/redact-scan/src/catalog.rs
@@ -119,30 +119,13 @@ pub fn l0_findings(columns: &[ColumnMeta]) -> Vec<Finding> {
                 confidence: 0.8,
                 evidence_class: EvidenceClass::TypeSignal,
             });
-            continue;
-        }
-        if is_date_type(&col.udt) {
-            if let Some((entity_type, confidence)) = name_entity(&col.column) {
-                if matches!(entity_type, redact_core::EntityType::DateTime) {
-                    out.push(Finding {
-                        table,
-                        column: col.column.clone(),
-                        json_path: None,
-                        entity_type,
-                        layer: ScanLayer::Metadata,
-                        match_count: 0,
-                        sampled_rows: 0,
-                        confidence,
-                        evidence_class: EvidenceClass::NameHeuristic,
-                    });
-                }
-            }
         }
         let _ = (
             col.unique_text,
             col.fk_to_subject,
             is_json_type(&col.udt),
             is_textish(&col.udt),
+            is_date_type(&col.udt),
             &col.comment,
         );
     }

--- a/crates/redact-scan/src/catalog.rs
+++ b/crates/redact-scan/src/catalog.rs
@@ -1,0 +1,210 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Layer 0: `pg_catalog` / `information_schema` metadata. No user-table reads.
+
+use sqlx::PgPool;
+
+use crate::error::ScanError;
+use crate::layers::ScanLayer;
+use crate::report::{EvidenceClass, Finding};
+use crate::score::{is_date_type, is_inet_type, is_json_type, is_textish, name_entity};
+
+/// Catalog row for one column.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct ColumnMeta {
+    /// Schema name.
+    pub schema: String,
+    /// Table / view name.
+    pub table: String,
+    /// Column name.
+    pub column: String,
+    /// `pg_type.typname`.
+    pub udt: String,
+    /// `pg_class.relkind` (`r`, `p`, `v`, `m`).
+    pub relkind: String,
+    /// Estimated live tuples (`0` if unknown).
+    pub n_live_tup: i64,
+    /// Column comment, if any.
+    pub comment: Option<String>,
+    /// Unique btree on this text-like column.
+    pub unique_text: bool,
+    /// Table has an FK toward a subject-like table.
+    pub fk_to_subject: bool,
+}
+
+/// Load column metadata for `schema`. Never `SELECT`s user tables.
+pub async fn load_columns(pool: &PgPool, schema: &str) -> Result<Vec<ColumnMeta>, ScanError> {
+    let rows = sqlx::query_as::<_, ColumnMeta>(
+        r#"
+        SELECT
+          n.nspname AS schema,
+          c.relname AS table,
+          a.attname AS column,
+          t.typname AS udt,
+          c.relkind::text AS relkind,
+          COALESCE(s.n_live_tup, 0) AS n_live_tup,
+          col_description(c.oid, a.attnum) AS comment,
+          EXISTS (
+            SELECT 1
+            FROM pg_index i
+            JOIN pg_attribute ia ON ia.attrelid = i.indrelid AND ia.attnum = ANY (i.indkey)
+            WHERE i.indrelid = c.oid
+              AND i.indisunique
+              AND ia.attname = a.attname
+              AND t.typname IN ('varchar', 'text', 'bpchar', 'citext')
+          ) AS unique_text,
+          EXISTS (
+            SELECT 1
+            FROM pg_constraint fk
+            JOIN pg_class ref ON ref.oid = fk.confrelid
+            WHERE fk.conrelid = c.oid
+              AND fk.contype = 'f'
+              AND (
+                ref.relname ILIKE '%user%'
+                OR ref.relname ILIKE '%customer%'
+                OR ref.relname ILIKE '%subject%'
+                OR ref.relname ILIKE '%patient%'
+                OR ref.relname ILIKE '%account%'
+              )
+          ) AS fk_to_subject
+        FROM pg_attribute a
+        JOIN pg_class c ON c.oid = a.attrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        JOIN pg_type t ON t.oid = a.atttypid
+        LEFT JOIN pg_stat_user_tables s ON s.relid = c.oid
+        WHERE n.nspname = $1
+          AND a.attnum > 0
+          AND NOT a.attisdropped
+          AND c.relkind IN ('r', 'p', 'v', 'm')
+        ORDER BY c.relname, a.attnum
+        "#,
+    )
+    .bind(schema)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+/// Emit L0 findings from names and native types. JSON/unconstrained text
+/// without a name match are candidates only.
+pub fn l0_findings(columns: &[ColumnMeta]) -> Vec<Finding> {
+    let mut out = Vec::new();
+    for col in columns {
+        let table = format!("{}.{}", col.schema, col.table);
+        if let Some((entity_type, confidence)) = name_entity(&col.column) {
+            out.push(Finding {
+                table,
+                column: col.column.clone(),
+                json_path: None,
+                entity_type,
+                layer: ScanLayer::Metadata,
+                match_count: 0,
+                sampled_rows: 0,
+                confidence,
+                evidence_class: EvidenceClass::NameHeuristic,
+            });
+            continue;
+        }
+        if is_inet_type(&col.udt) {
+            out.push(Finding {
+                table,
+                column: col.column.clone(),
+                json_path: None,
+                entity_type: redact_core::EntityType::IpAddress,
+                layer: ScanLayer::Metadata,
+                match_count: 0,
+                sampled_rows: 0,
+                confidence: 0.8,
+                evidence_class: EvidenceClass::TypeSignal,
+            });
+            continue;
+        }
+        if is_date_type(&col.udt) {
+            if let Some((entity_type, confidence)) = name_entity(&col.column) {
+                if matches!(entity_type, redact_core::EntityType::DateTime) {
+                    out.push(Finding {
+                        table,
+                        column: col.column.clone(),
+                        json_path: None,
+                        entity_type,
+                        layer: ScanLayer::Metadata,
+                        match_count: 0,
+                        sampled_rows: 0,
+                        confidence,
+                        evidence_class: EvidenceClass::NameHeuristic,
+                    });
+                }
+            }
+        }
+        let _ = (
+            col.unique_text,
+            col.fk_to_subject,
+            is_json_type(&col.udt),
+            is_textish(&col.udt),
+            &col.comment,
+        );
+    }
+    out
+}
+
+/// Columns worth examining in later layers.
+pub fn candidates<'a>(columns: &'a [ColumnMeta], findings: &[Finding]) -> Vec<&'a ColumnMeta> {
+    columns
+        .iter()
+        .filter(|c| {
+            if is_json_type(&c.udt) || is_inet_type(&c.udt) || is_textish(&c.udt) {
+                return true;
+            }
+            if c.unique_text || c.fk_to_subject {
+                return true;
+            }
+            let q = format!("{}.{}", c.schema, c.table);
+            findings
+                .iter()
+                .any(|f| f.table == q && f.column == c.column)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn col(name: &str, udt: &str) -> ColumnMeta {
+        ColumnMeta {
+            schema: "public".into(),
+            table: "t".into(),
+            column: name.into(),
+            udt: udt.into(),
+            relkind: "r".into(),
+            n_live_tup: 10,
+            comment: None,
+            unique_text: false,
+            fk_to_subject: false,
+        }
+    }
+
+    #[test]
+    fn name_match_is_finding_json_is_candidate_only() {
+        let cols = vec![
+            col("email", "text"),
+            col("payload", "jsonb"),
+            col("n", "int4"),
+        ];
+        let findings = l0_findings(&cols);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].column, "email");
+        let cand = candidates(&cols, &findings);
+        assert!(cand.iter().any(|c| c.column == "payload"));
+        assert!(cand.iter().all(|c| c.column != "n"));
+    }
+
+    #[test]
+    fn inet_without_name_is_type_signal() {
+        let cols = vec![col("src", "inet")];
+        let findings = l0_findings(&cols);
+        assert_eq!(findings[0].evidence_class, EvidenceClass::TypeSignal);
+    }
+}

--- a/crates/redact-scan/src/detect.rs
+++ b/crates/redact-scan/src/detect.rs
@@ -1,0 +1,92 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Pattern-engine wrapper that drops matched text immediately.
+
+use redact_core::recognizers::{pattern::PatternRecognizer, Recognizer};
+use redact_core::{AnalyzerEngine, EntityType};
+
+/// Entity types used for value-based layers (L0.5 / L1 / L2).
+///
+/// Excludes high-false-positive types (`DATE_TIME`, `GUID`, hashes, `URL`)
+/// unless a name heuristic already nominated them.
+pub fn precision_entities() -> &'static [EntityType] {
+    &[
+        EntityType::EmailAddress,
+        EntityType::PhoneNumber,
+        EntityType::IpAddress,
+        EntityType::CreditCard,
+        EntityType::IbanCode,
+        EntityType::Iban,
+        EntityType::UsSsn,
+        EntityType::UsBankNumber,
+        EntityType::UsPassport,
+        EntityType::UsDriverLicense,
+        EntityType::UkNhs,
+        EntityType::UkNino,
+        EntityType::PassportNumber,
+        EntityType::MedicalRecordNumber,
+        EntityType::MedicalLicense,
+        EntityType::PrivateKey,
+        EntityType::JwtToken,
+        EntityType::AwsAccessKey,
+        EntityType::GithubToken,
+        EntityType::GitlabToken,
+        EntityType::SlackToken,
+        EntityType::StripeApiKey,
+        EntityType::DatabaseConnectionString,
+    ]
+}
+
+/// Built-in pattern pack label (`builtin@<supported count>`).
+pub fn pattern_pack_label() -> String {
+    let rec = PatternRecognizer::new();
+    format!("builtin@{}", rec.supported_entities().len())
+}
+
+/// Run the pattern engine and drop matched text immediately.
+pub fn detect_types(text: &str) -> Vec<(EntityType, f32)> {
+    detect_types_filtered(text, precision_entities())
+}
+
+/// Detect only the listed entity types; never retain `RecognizerResult.text`.
+pub fn detect_types_filtered(text: &str, allowed: &[EntityType]) -> Vec<(EntityType, f32)> {
+    let engine = AnalyzerEngine::new();
+    let Ok(result) = engine.analyze_with_entities(text, allowed, Some("en")) else {
+        return Vec::new();
+    };
+    result
+        .detected_entities
+        .into_iter()
+        .map(|e| (e.entity_type, e.score))
+        .collect()
+}
+
+/// Parse a `--fail-on` entity token. `any` returns `None`.
+pub fn parse_entity_type(s: &str) -> Option<EntityType> {
+    let t = s.trim();
+    if t.eq_ignore_ascii_case("any") {
+        return None;
+    }
+    Some(EntityType::from(t.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn drops_text_and_finds_email() {
+        let hits = detect_types("contact me at user@example.com please");
+        assert!(hits.iter().any(|(t, _)| *t == EntityType::EmailAddress));
+    }
+
+    #[test]
+    fn pattern_pack_is_not_hardcoded() {
+        let label = pattern_pack_label();
+        assert!(label.starts_with("builtin@"));
+        let n: usize = label.rsplit('@').next().unwrap().parse().unwrap();
+        assert!(n > 0);
+    }
+}

--- a/crates/redact-scan/src/error.rs
+++ b/crates/redact-scan/src/error.rs
@@ -40,3 +40,9 @@ impl From<anyhow::Error> for ScanError {
         Self::new(err)
     }
 }
+
+impl From<sqlx::Error> for ScanError {
+    fn from(err: sqlx::Error) -> Self {
+        Self::new(err)
+    }
+}

--- a/crates/redact-scan/src/lib.rs
+++ b/crates/redact-scan/src/lib.rs
@@ -9,19 +9,32 @@
 
 /// Canonical JSON hashing for [`ScanReport::content_hash`].
 pub mod canonical;
+/// Layer 0 catalog metadata.
+pub mod catalog;
 /// Command-line argument types.
 pub mod cli;
+/// Pattern-engine wrapper that drops matched text.
+pub mod detect;
 /// Scrubbed scanner errors.
 pub mod error;
 /// Discovery layer identifiers (`0`, `0.5`, `1`, `2`).
 pub mod layers;
 /// Value-free report types.
 pub mod report;
+/// Read-only session and privilege checks.
+pub mod safety;
+/// Scan orchestration.
+pub mod scan;
+/// Name and type heuristics.
+pub mod score;
 /// Credential redaction for logs and errors.
 pub mod scrub;
+/// Layer 0.5 planner statistics.
+pub mod stats;
 
 pub use error::ScanError;
 pub use report::{Finding, ScanReport};
+pub use scan::run_scan;
 
 /// Process exit code when the scan completed with no fail-on match.
 pub const EXIT_CLEAN: i32 = 0;

--- a/crates/redact-scan/src/main.rs
+++ b/crates/redact-scan/src/main.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 use redact_scan::cli::Cli;
 use redact_scan::error::ScanError;
 use redact_scan::scrub::scrub;
-use redact_scan::EXIT_ERROR;
+use redact_scan::{run_scan, EXIT_CLEAN, EXIT_ERROR};
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
@@ -26,14 +26,27 @@ fn run() -> Result<i32, ScanError> {
     if cli.url.is_none() {
         return Err(ScanError::new("--url is required"));
     }
-    Err(ScanError::new(
-        "scan execution is not implemented in this revision",
-    ))
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("redact_scan=info")),
+        )
+        .init();
+
+    let rt = tokio::runtime::Runtime::new().map_err(ScanError::new)?;
+    let report = rt.block_on(run_scan(&cli))?;
+    let json = serde_json::to_string_pretty(&report).map_err(ScanError::new)?;
+    if let Some(path) = &cli.out {
+        std::fs::write(path, &json).map_err(ScanError::new)?;
+    } else {
+        println!("{json}");
+    }
+    Ok(EXIT_CLEAN)
 }
 
 fn install_panic_hook() {
     std::panic::set_hook(Box::new(move |info| {
-        // Do not invoke the default hook: it would print the original payload.
         eprintln!("panic: {}", scrub(&info.to_string()));
     }));
 }

--- a/crates/redact-scan/src/safety.rs
+++ b/crates/redact-scan/src/safety.rs
@@ -103,6 +103,22 @@ async fn verify_readonly(safe: &SafePool, schema: &str) -> Result<(), ScanError>
         ));
     }
 
+    let column_writes: Vec<String> = sqlx::query_scalar(
+        r#"
+        SELECT privilege_type
+        FROM information_schema.column_privileges
+        WHERE grantee = current_user
+        "#,
+    )
+    .fetch_all(&safe.pool)
+    .await
+    .map_err(|e| safe.scrub(e))?;
+    if has_write_grants(column_writes.iter().map(String::as_str)) {
+        return Err(ScanError::new(
+            "refusing to run: role holds column write grants (INSERT/UPDATE)",
+        ));
+    }
+
     let acl_writes: i64 = sqlx::query_scalar(
         r#"
         SELECT COUNT(*)::bigint

--- a/crates/redact-scan/src/safety.rs
+++ b/crates/redact-scan/src/safety.rs
@@ -1,0 +1,178 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Read-only session setup and privilege refusal.
+
+use sqlx::{postgres::PgConnectOptions, postgres::PgPoolOptions, PgPool};
+use std::str::FromStr;
+use std::time::Duration;
+
+use crate::error::ScanError;
+
+/// Privilege names that must not be present on a scan role.
+pub const WRITE_PRIVILEGES: &[&str] = &["INSERT", "UPDATE", "DELETE", "TRUNCATE"];
+
+/// Open a single-connection pool, force read-only, and refuse write roles.
+pub struct SafePool {
+    /// sqlx pool (`max_connections = 1`).
+    pub pool: PgPool,
+    secret: String,
+}
+
+impl SafePool {
+    /// Wrap an error with this connection's password scrubbed.
+    pub fn scrub(&self, msg: impl std::fmt::Display) -> ScanError {
+        ScanError::with_secret(msg, &self.secret)
+    }
+}
+
+/// Connect and enforce the safety session.
+pub async fn connect_readonly(
+    url: &str,
+    statement_timeout: Duration,
+    schema: &str,
+) -> Result<SafePool, ScanError> {
+    let secret = password_from_url(url).unwrap_or_default();
+    let timeout_ms = statement_timeout.as_millis().max(1);
+    let options = PgConnectOptions::from_str(url)
+        .map_err(|e| ScanError::with_secret(e, &secret))?
+        .application_name("redact-scan");
+
+    let pool = PgPoolOptions::new()
+        .max_connections(1)
+        .after_connect(move |conn, _| {
+            Box::pin(async move {
+                sqlx::query("SET default_transaction_read_only = on")
+                    .execute(&mut *conn)
+                    .await?;
+                sqlx::query(&format!("SET statement_timeout = '{timeout_ms}ms'"))
+                    .execute(&mut *conn)
+                    .await?;
+                sqlx::query("SET lock_timeout = '5s'")
+                    .execute(&mut *conn)
+                    .await?;
+                Ok(())
+            })
+        })
+        .connect_with(options)
+        .await
+        .map_err(|e| ScanError::with_secret(e, &secret))?;
+
+    let safe = SafePool { pool, secret };
+    verify_readonly(&safe, schema).await?;
+    Ok(safe)
+}
+
+async fn verify_readonly(safe: &SafePool, schema: &str) -> Result<(), ScanError> {
+    let ro: String = sqlx::query_scalar("SHOW default_transaction_read_only")
+        .fetch_one(&safe.pool)
+        .await
+        .map_err(|e| safe.scrub(e))?;
+    if !ro.eq_ignore_ascii_case("on") {
+        return Err(ScanError::new(
+            "refusing to run: default_transaction_read_only is not on",
+        ));
+    }
+
+    let is_super: bool = sqlx::query_scalar(
+        "SELECT COALESCE((SELECT rolsuper FROM pg_roles WHERE rolname = current_user), false)",
+    )
+    .fetch_one(&safe.pool)
+    .await
+    .map_err(|e| safe.scrub(e))?;
+    if is_super {
+        return Err(ScanError::new(
+            "refusing to run: role is superuser; use a SELECT-only role",
+        ));
+    }
+
+    let info_writes: Vec<String> = sqlx::query_scalar(
+        r#"
+        SELECT privilege_type
+        FROM information_schema.role_table_grants
+        WHERE grantee = current_user
+        "#,
+    )
+    .fetch_all(&safe.pool)
+    .await
+    .map_err(|e| safe.scrub(e))?;
+    if has_write_grants(info_writes.iter().map(String::as_str)) {
+        return Err(ScanError::new(
+            "refusing to run: role holds write grants (INSERT/UPDATE/DELETE/TRUNCATE)",
+        ));
+    }
+
+    let acl_writes: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)::bigint
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = $1
+          AND c.relkind IN ('r', 'p', 'v', 'm')
+          AND (
+            has_table_privilege(current_user, c.oid, 'INSERT')
+            OR has_table_privilege(current_user, c.oid, 'UPDATE')
+            OR has_table_privilege(current_user, c.oid, 'DELETE')
+            OR has_table_privilege(current_user, c.oid, 'TRUNCATE')
+          )
+        "#,
+    )
+    .bind(schema)
+    .fetch_one(&safe.pool)
+    .await
+    .map_err(|e| safe.scrub(e))?;
+    if acl_writes > 0 {
+        return Err(ScanError::new(
+            "refusing to run: role holds write grants (INSERT/UPDATE/DELETE/TRUNCATE)",
+        ));
+    }
+    Ok(())
+}
+
+/// True when any privilege is a table write grant.
+pub fn has_write_grants<'a>(privileges: impl IntoIterator<Item = &'a str>) -> bool {
+    privileges
+        .into_iter()
+        .any(|p| WRITE_PRIVILEGES.iter().any(|w| p.eq_ignore_ascii_case(w)))
+}
+
+/// Extract the password from a Postgres URL, percent-decoded.
+pub fn password_from_url(url: &str) -> Option<String> {
+    let rest = url.split("://").nth(1)?;
+    let creds = rest.split('@').next()?;
+    let pass = creds.split_once(':')?.1;
+    if pass.is_empty() {
+        return None;
+    }
+    Some(crate::scrub::percent_decode(pass))
+}
+
+/// Host and database name from a connection URL. The host is hashed later.
+pub fn host_db_from_url(url: &str) -> Result<(String, String), ScanError> {
+    let opts = PgConnectOptions::from_str(url).map_err(ScanError::new)?;
+    let host = opts.get_host().to_string();
+    let db = opts
+        .get_database()
+        .ok_or_else(|| ScanError::new("connection URL is missing a database name"))?
+        .to_string();
+    Ok((host, db))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_percent_decoded_password() {
+        let p = password_from_url("postgres://u:p%40ss@localhost/db").unwrap();
+        assert_eq!(p, "p@ss");
+    }
+
+    #[test]
+    fn write_grant_rows_are_refused() {
+        assert!(has_write_grants(["SELECT", "INSERT"]));
+        assert!(has_write_grants(["truncate"]));
+        assert!(!has_write_grants(["SELECT", "USAGE"]));
+    }
+}

--- a/crates/redact-scan/src/safety.rs
+++ b/crates/redact-scan/src/safety.rs
@@ -103,17 +103,27 @@ async fn verify_readonly(safe: &SafePool, schema: &str) -> Result<(), ScanError>
         ));
     }
 
-    let column_writes: Vec<String> = sqlx::query_scalar(
+    let column_writes: i64 = sqlx::query_scalar(
         r#"
-        SELECT privilege_type
-        FROM information_schema.column_privileges
-        WHERE grantee = current_user
+        SELECT COUNT(*)::bigint
+        FROM pg_attribute a
+        JOIN pg_class c ON c.oid = a.attrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = $1
+          AND a.attnum > 0
+          AND NOT a.attisdropped
+          AND c.relkind IN ('r', 'p', 'v', 'm')
+          AND (
+            has_column_privilege(current_user, c.oid, a.attname, 'INSERT')
+            OR has_column_privilege(current_user, c.oid, a.attname, 'UPDATE')
+          )
         "#,
     )
-    .fetch_all(&safe.pool)
+    .bind(schema)
+    .fetch_one(&safe.pool)
     .await
     .map_err(|e| safe.scrub(e))?;
-    if has_write_grants(column_writes.iter().map(String::as_str)) {
+    if column_writes > 0 {
         return Err(ScanError::new(
             "refusing to run: role holds column write grants (INSERT/UPDATE)",
         ));

--- a/crates/redact-scan/src/scan.rs
+++ b/crates/redact-scan/src/scan.rs
@@ -1,0 +1,132 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Scan orchestration for layers 0 and 0.5.
+
+use chrono::Utc;
+use uuid::Uuid;
+
+use crate::canonical::hex_sha256;
+use crate::catalog::{candidates, l0_findings, load_columns};
+use crate::cli::Cli;
+use crate::detect::pattern_pack_label;
+use crate::error::ScanError;
+use crate::layers::ScanLayer;
+use crate::report::{Finding, Sampling, ScanReport, Scanner, Target};
+use crate::safety::{connect_readonly, host_db_from_url};
+use crate::stats::l05_findings;
+
+/// Run the selected layers and return a finalized report.
+pub async fn run_scan(cli: &Cli) -> Result<ScanReport, ScanError> {
+    let url = cli
+        .url
+        .as_deref()
+        .ok_or_else(|| ScanError::new("--url is required to scan"))?;
+    let layers = cli.parsed_layers().map_err(ScanError::new)?;
+    let timeout = cli.statement_timeout().map_err(ScanError::new)?;
+    let (host, database) = host_db_from_url(url)?;
+    let fingerprint = fingerprint(&host, &database, &cli.schema);
+    drop(host);
+
+    let safe = connect_readonly(url, timeout, &cli.schema).await?;
+    let version: String = sqlx::query_scalar("SHOW server_version")
+        .fetch_one(&safe.pool)
+        .await
+        .map_err(|e| safe.scrub(e))?;
+
+    let columns = load_columns(&safe.pool, &cli.schema)
+        .await
+        .map_err(|e| safe.scrub(e))?;
+
+    let mut findings: Vec<Finding> = Vec::new();
+    if layers.contains(&ScanLayer::Metadata) {
+        findings.extend(l0_findings(&columns));
+    }
+    let cand = candidates(&columns, &findings);
+    if layers.contains(&ScanLayer::Stats) {
+        findings.extend(l05_findings(&safe.pool, &cli.schema, &cand).await?);
+    }
+    if layers.contains(&ScanLayer::Sample) || layers.contains(&ScanLayer::Json) {
+        tracing::warn!("layers 1 and 2 are not implemented in this revision");
+    }
+
+    findings = dedup_findings(findings);
+
+    let report = ScanReport {
+        scan_id: Uuid::new_v4(),
+        scanned_at: Utc::now(),
+        target: Target {
+            fingerprint,
+            engine: "postgres".into(),
+            version,
+        },
+        scanner: Scanner {
+            version: env!("CARGO_PKG_VERSION").into(),
+            pattern_pack: pattern_pack_label(),
+        },
+        sampling: Sampling {
+            layers,
+            rows_per_column: cli.sample_rows,
+            method: "TABLESAMPLE SYSTEM".into(),
+        },
+        findings,
+        content_hash: String::new(),
+    };
+    report.finalize().map_err(ScanError::new)
+}
+
+fn fingerprint(host: &str, database: &str, schema: &str) -> String {
+    hex_sha256(format!("{host}|{database}|{schema}").as_bytes())
+}
+
+fn dedup_findings(mut findings: Vec<Finding>) -> Vec<Finding> {
+    findings.sort_by(|a, b| {
+        a.table
+            .cmp(&b.table)
+            .then(a.column.cmp(&b.column))
+            .then(a.json_path.cmp(&b.json_path))
+            .then(a.entity_type.as_str().cmp(b.entity_type.as_str()))
+    });
+    findings.dedup_by(|a, b| {
+        a.table == b.table
+            && a.column == b.column
+            && a.json_path == b.json_path
+            && a.entity_type == b.entity_type
+    });
+    findings
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::report::EvidenceClass;
+    use redact_core::EntityType;
+
+    #[test]
+    fn fingerprint_is_hex_and_stable() {
+        let a = fingerprint("db.example", "app", "public");
+        let b = fingerprint("db.example", "app", "public");
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 64);
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_ne!(a, fingerprint("other", "app", "public"));
+    }
+
+    #[test]
+    fn dedup_keeps_one_row_per_location_type() {
+        let f = Finding {
+            table: "public.t".into(),
+            column: "c".into(),
+            json_path: None,
+            entity_type: EntityType::EmailAddress,
+            layer: ScanLayer::Metadata,
+            match_count: 0,
+            sampled_rows: 0,
+            confidence: 0.8,
+            evidence_class: EvidenceClass::NameHeuristic,
+        };
+        let out = dedup_findings(vec![f.clone(), f]);
+        assert_eq!(out.len(), 1);
+    }
+}

--- a/crates/redact-scan/src/score.rs
+++ b/crates/redact-scan/src/score.rs
@@ -1,0 +1,94 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Name and type heuristics for layer 0.
+
+use redact_core::EntityType;
+
+/// Map a column name token to an entity type and confidence.
+pub fn name_entity(column: &str) -> Option<(EntityType, f32)> {
+    let n = normalize(column);
+    let rules: &[(&str, EntityType, f32)] = &[
+        ("email", EntityType::EmailAddress, 0.85),
+        ("e_mail", EntityType::EmailAddress, 0.85),
+        ("ssn", EntityType::UsSsn, 0.9),
+        ("social_security", EntityType::UsSsn, 0.9),
+        ("dob", EntityType::DateTime, 0.7),
+        ("date_of_birth", EntityType::DateTime, 0.75),
+        ("birth_date", EntityType::DateTime, 0.75),
+        ("phone", EntityType::PhoneNumber, 0.8),
+        ("mobile", EntityType::PhoneNumber, 0.7),
+        ("addr", EntityType::Location, 0.55),
+        ("address", EntityType::Location, 0.6),
+        ("tax_id", EntityType::UsSsn, 0.65),
+        ("iban", EntityType::IbanCode, 0.9),
+        ("passport", EntityType::PassportNumber, 0.8),
+        ("mrn", EntityType::MedicalRecordNumber, 0.8),
+        ("medical_record", EntityType::MedicalRecordNumber, 0.8),
+        ("first_name", EntityType::Person, 0.7),
+        ("last_name", EntityType::Person, 0.7),
+        ("full_name", EntityType::Person, 0.7),
+        ("credit_card", EntityType::CreditCard, 0.9),
+        ("card_number", EntityType::CreditCard, 0.85),
+        ("ip_address", EntityType::IpAddress, 0.8),
+        ("ipv4", EntityType::IpAddress, 0.8),
+        ("ipv6", EntityType::IpAddress, 0.8),
+    ];
+    for (needle, ty, conf) in rules {
+        if n == *needle || n.contains(needle) {
+            return Some((ty.clone(), *conf));
+        }
+    }
+    None
+}
+
+/// True for `json` / `jsonb` (candidates only, not L0 findings).
+pub fn is_json_type(udt: &str) -> bool {
+    matches!(udt, "json" | "jsonb")
+}
+
+/// True for `inet` / `cidr`.
+pub fn is_inet_type(udt: &str) -> bool {
+    matches!(udt, "inet" | "cidr")
+}
+
+/// True for date/timestamp types.
+pub fn is_date_type(udt: &str) -> bool {
+    matches!(udt, "date" | "timestamp" | "timestamptz")
+}
+
+/// True for text-like types that may hold identifiers.
+pub fn is_textish(udt: &str) -> bool {
+    matches!(udt, "text" | "varchar" | "bpchar" | "citext")
+}
+
+fn normalize(name: &str) -> String {
+    name.to_ascii_lowercase()
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn email_name() {
+        let (ty, _) = name_entity("user_email").unwrap();
+        assert_eq!(ty, EntityType::EmailAddress);
+    }
+
+    #[test]
+    fn dob_name() {
+        let (ty, _) = name_entity("date_of_birth").unwrap();
+        assert_eq!(ty, EntityType::DateTime);
+    }
+
+    #[test]
+    fn status_is_not_pii() {
+        assert!(name_entity("status").is_none());
+        assert!(name_entity("active").is_none());
+    }
+}

--- a/crates/redact-scan/src/score.rs
+++ b/crates/redact-scan/src/score.rs
@@ -35,7 +35,9 @@ pub fn name_entity(column: &str) -> Option<(EntityType, f32)> {
         ("ipv4", EntityType::IpAddress, 0.8),
         ("ipv6", EntityType::IpAddress, 0.8),
     ];
-    for (needle, ty, conf) in rules {
+    let mut ranked: Vec<_> = rules.iter().collect();
+    ranked.sort_by_key(|(needle, _, _)| std::cmp::Reverse(needle.len()));
+    for (needle, ty, conf) in ranked {
         if n == *needle || n.contains(needle) {
             return Some((ty.clone(), *conf));
         }
@@ -90,5 +92,13 @@ mod tests {
     fn status_is_not_pii() {
         assert!(name_entity("status").is_none());
         assert!(name_entity("active").is_none());
+    }
+
+    #[test]
+    fn ip_address_is_not_location() {
+        let (ty, _) = name_entity("ip_address").unwrap();
+        assert_eq!(ty, EntityType::IpAddress);
+        let (ty, _) = name_entity("client_ipv4").unwrap();
+        assert_eq!(ty, EntityType::IpAddress);
     }
 }

--- a/crates/redact-scan/src/stats.rs
+++ b/crates/redact-scan/src/stats.rs
@@ -1,0 +1,87 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Layer 0.5: `pg_stats` most-common values and histogram bounds.
+
+use sqlx::PgPool;
+
+use crate::catalog::ColumnMeta;
+use crate::detect::detect_types;
+use crate::error::ScanError;
+use crate::layers::ScanLayer;
+use crate::report::{EvidenceClass, Finding};
+
+/// Scan planner statistics. Never echoes MCV / histogram values into findings.
+pub async fn l05_findings(
+    pool: &PgPool,
+    schema: &str,
+    candidates: &[&ColumnMeta],
+) -> Result<Vec<Finding>, ScanError> {
+    let rows = sqlx::query_as::<_, (String, String, Option<String>, Option<String>, Option<f32>)>(
+        r#"
+        SELECT tablename, attname,
+               most_common_vals::text,
+               histogram_bounds::text,
+               n_distinct
+        FROM pg_stats
+        WHERE schemaname = $1
+        "#,
+    )
+    .bind(schema)
+    .fetch_all(pool)
+    .await;
+    let rows = match rows {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!("layer 0.5 skipped (pg_stats unavailable): {e}");
+            return Ok(Vec::new());
+        }
+    };
+
+    let wanted: std::collections::HashSet<(&str, &str)> = candidates
+        .iter()
+        .map(|c| (c.table.as_str(), c.column.as_str()))
+        .collect();
+
+    let mut out = Vec::new();
+    for (table, column, mcv, hist, _n_distinct) in rows {
+        if !wanted.contains(&(table.as_str(), column.as_str())) {
+            continue;
+        }
+        let mut texts = Vec::new();
+        if let Some(v) = mcv {
+            texts.push(v);
+        }
+        if let Some(v) = hist {
+            texts.push(v);
+        }
+        if texts.is_empty() {
+            continue;
+        }
+        let blob = texts.join(" ");
+        let hits = detect_types(&blob);
+        drop(blob);
+        drop(texts);
+        if hits.is_empty() {
+            continue;
+        }
+        let sampled = hits.len() as u64;
+        let (entity_type, confidence) = hits
+            .into_iter()
+            .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+            .expect("hits non-empty");
+        out.push(Finding {
+            table: format!("{schema}.{table}"),
+            column,
+            json_path: None,
+            entity_type,
+            layer: ScanLayer::Stats,
+            match_count: sampled,
+            sampled_rows: sampled,
+            confidence,
+            evidence_class: EvidenceClass::PgStats,
+        });
+    }
+    Ok(out)
+}


### PR DESCRIPTION
Thank you for contributing to Redact. These checkboxes are acknowledgements;
the CLA bot enforces the Individual CLA signature.

- [x] I have read [CLA.md](../CLA.md) and will sign the Individual CLA via the bot comment (or I have already signed). A Corporate CLA, if required, does not replace the Individual CLA.
- [x] All commits are DCO-signed (`git commit -s`)
- [x] I have read [docs/PROJECT_SCOPE.md](../docs/PROJECT_SCOPE.md); this change is in scope

**Employer time or equipment**

- [x] No — this work was not done on employer time or equipment
- [ ] Yes — my employer has authorised the contribution, or a Corporate CLA is on file

## Summary

Second slice of `redact-scan`:

- Safety session: `default_transaction_read_only`, statement/lock timeouts, pool max 1
- Refuse superuser and INSERT/UPDATE/DELETE/TRUNCATE (information_schema + `has_table_privilege`)
- Layer 0: catalog name/type heuristics; JSON/unconstrained text are candidates only
- Layer 0.5: `pg_stats` MCV/histogram via the pattern engine; matched text is dropped
- Layers 1 and 2 are not implemented in this revision

## Test plan

- [x] `cargo test -p redact-scan`
- [x] `cargo clippy -p redact-scan --all-targets -- -D warnings`
- [x] rustdoc `-D missing_docs`