### PR TITLE
feat(scan): TABLESAMPLE, JSON paths, report POST, fail-on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `redact-scan`: new workspace crate and `redact-scan` binary for read-only
   Postgres PII discovery. Report types, credential scrubber, CLI preflight,
   a read-only safety session (refuse superuser and write grants), and
-  layers 0 / 0.5 (catalog metadata and `pg_stats`). Reports contain
-  locations and counts only — never sample values.
+  layers 0 / 0.5 / 1 / 2 (catalog, `pg_stats`, bounded `TABLESAMPLE`,
+  JSON paths). Optional `--report-url` POSTs the report JSON; `--fail-on`
+  exits 1 on matching findings. Reports contain locations and counts
+  only — never sample values.
 
 ## [0.9.1] - 2026-08-08
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2990,6 +2990,7 @@ dependencies = [
  "predicates",
  "redact-core",
  "regex",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/crates/redact-scan/Cargo.toml
+++ b/crates/redact-scan/Cargo.toml
@@ -27,6 +27,7 @@ uuid = { workspace = true }
 sha2 = { workspace = true }
 chrono = { workspace = true, features = ["clock"] }
 regex = { workspace = true }
+reqwest = { workspace = true }
 
 [[bin]]
 name = "redact-scan"

--- a/crates/redact-scan/src/bound.rs
+++ b/crates/redact-scan/src/bound.rs
@@ -1,0 +1,35 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Rule of three for negative sampling results.
+
+/// If 0 matches in `n` samples, the 95% CI upper bound is `3/n`.
+pub fn prevalence_upper_95(sampled_rows: u64, match_count: u64) -> Option<f64> {
+    if match_count != 0 || sampled_rows == 0 {
+        return None;
+    }
+    Some(3.0 / sampled_rows as f64)
+}
+
+/// Human-readable rule-of-three note for table output.
+pub fn rule_of_three_message(sampled_rows: u64) -> String {
+    let bound = prevalence_upper_95(sampled_rows, 0).unwrap_or(0.0);
+    format!(
+        "0 matches in {sampled_rows} sampled rows; prevalence above {:.1}% is unlikely at 95% confidence.",
+        bound * 100.0
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn thousand_rows_is_point_three_percent() {
+        let p = prevalence_upper_95(1000, 0).unwrap();
+        assert!((p - 0.003).abs() < 1e-12);
+        let msg = rule_of_three_message(1000);
+        assert!(msg.contains("0.3%"));
+    }
+}

--- a/crates/redact-scan/src/detect.rs
+++ b/crates/redact-scan/src/detect.rs
@@ -72,6 +72,18 @@ pub fn parse_entity_type(s: &str) -> Option<EntityType> {
     Some(EntityType::from(t.to_string()))
 }
 
+/// True when `--fail-on` should exit 1.
+pub fn fail_on_matches(spec: &str, findings: &[crate::report::Finding]) -> bool {
+    if spec.eq_ignore_ascii_case("any") {
+        return !findings.is_empty();
+    }
+    let wanted = parse_entity_type(spec);
+    match wanted {
+        None => !findings.is_empty(),
+        Some(ty) => findings.iter().any(|f| f.entity_type == ty),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -88,5 +100,26 @@ mod tests {
         assert!(label.starts_with("builtin@"));
         let n: usize = label.rsplit('@').next().unwrap().parse().unwrap();
         assert!(n > 0);
+    }
+
+    #[test]
+    fn fail_on_any_and_typed() {
+        use crate::layers::ScanLayer;
+        use crate::report::{EvidenceClass, Finding};
+        let f = Finding {
+            table: "public.t".into(),
+            column: "c".into(),
+            json_path: None,
+            entity_type: EntityType::EmailAddress,
+            layer: ScanLayer::Sample,
+            match_count: 1,
+            sampled_rows: 10,
+            confidence: 0.9,
+            evidence_class: EvidenceClass::TableSample,
+        };
+        assert!(fail_on_matches("any", std::slice::from_ref(&f)));
+        assert!(fail_on_matches("EMAIL_ADDRESS", std::slice::from_ref(&f)));
+        assert!(!fail_on_matches("US_SSN", std::slice::from_ref(&f)));
+        assert!(!fail_on_matches("any", &[]));
     }
 }

--- a/crates/redact-scan/src/format.rs
+++ b/crates/redact-scan/src/format.rs
@@ -1,0 +1,77 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Human-readable table output. Never prints sample values.
+
+use crate::bound::rule_of_three_message;
+use crate::report::ScanReport;
+
+/// Render a tab-separated table of findings.
+pub fn render_table(report: &ScanReport) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "scan {}  {}  fingerprint={}  pack={}\n",
+        report.scan_id, report.scanned_at, report.target.fingerprint, report.scanner.pattern_pack
+    ));
+    if report.findings.is_empty() {
+        out.push_str("No findings.\n");
+        out.push_str(&rule_of_three_message(u64::from(
+            report.sampling.rows_per_column,
+        )));
+        out.push('\n');
+        return out;
+    }
+    out.push_str("table\tcolumn\tpath\tentity\tlayer\tmatches\tsampled\tconfidence\tevidence\n");
+    for f in &report.findings {
+        out.push_str(&format!(
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:.2}\t{:?}\n",
+            f.table,
+            f.column,
+            f.json_path.as_deref().unwrap_or("-"),
+            f.entity_type.as_str(),
+            f.layer,
+            f.match_count,
+            f.sampled_rows,
+            f.confidence,
+            f.evidence_class
+        ));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::layers::ScanLayer;
+    use crate::report::{Sampling, Scanner, Target};
+    use chrono::{TimeZone, Utc};
+    use uuid::Uuid;
+
+    #[test]
+    fn empty_report_mentions_rule_of_three() {
+        let report = ScanReport {
+            scan_id: Uuid::nil(),
+            scanned_at: Utc.with_ymd_and_hms(2026, 8, 15, 0, 0, 0).unwrap(),
+            target: Target {
+                fingerprint: "abc".into(),
+                engine: "postgres".into(),
+                version: "16".into(),
+            },
+            scanner: Scanner {
+                version: "0.9.1".into(),
+                pattern_pack: "builtin@1".into(),
+            },
+            sampling: Sampling {
+                layers: vec![ScanLayer::Sample],
+                rows_per_column: 1000,
+                method: "TABLESAMPLE SYSTEM".into(),
+            },
+            findings: vec![],
+            content_hash: String::new(),
+        };
+        let s = render_table(&report);
+        assert!(s.contains("0.3%"));
+        assert!(!s.contains("user@"));
+    }
+}

--- a/crates/redact-scan/src/ident.rs
+++ b/crates/redact-scan/src/ident.rs
@@ -1,0 +1,35 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Identifier quoting. Only `[A-Za-z0-9_]+` is accepted.
+
+use anyhow::{anyhow, Result};
+
+/// Quote a Postgres identifier after validating it is `[A-Za-z0-9_]+`.
+pub fn quote_ident(name: &str) -> Result<String> {
+    if name.is_empty() || !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        return Err(anyhow!("unsafe identifier"));
+    }
+    Ok(format!("\"{name}\""))
+}
+
+/// `schema.table` with both parts quoted.
+pub fn qualify_table(schema: &str, table: &str) -> Result<String> {
+    Ok(format!("{}.{}", quote_ident(schema)?, quote_ident(table)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_injection() {
+        assert!(quote_ident("foo;drop").is_err());
+        assert!(quote_ident("ok_name").is_ok());
+        assert_eq!(
+            qualify_table("public", "users").unwrap(),
+            "\"public\".\"users\""
+        );
+    }
+}

--- a/crates/redact-scan/src/json_scan.rs
+++ b/crates/redact-scan/src/json_scan.rs
@@ -1,0 +1,130 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Layer 2: JSON/JSONB path sampling.
+
+use serde_json::Value;
+use sqlx::PgPool;
+use std::collections::BTreeMap;
+
+use crate::catalog::ColumnMeta;
+use crate::detect::detect_types;
+use crate::error::ScanError;
+use crate::ident::{qualify_table, quote_ident};
+use crate::layers::ScanLayer;
+use crate::report::{EvidenceClass, Finding};
+use crate::score::is_json_type;
+
+/// Sample JSON columns and emit path-level findings. Values are dropped.
+pub async fn l2_findings(
+    pool: &PgPool,
+    columns: &[&ColumnMeta],
+    sample_rows: u32,
+) -> Result<Vec<Finding>, ScanError> {
+    let mut out = Vec::new();
+    for col in columns {
+        if !is_json_type(&col.udt) {
+            continue;
+        }
+        if col.relkind != "r" && col.relkind != "p" {
+            continue;
+        }
+        out.extend(scan_json_column(pool, col, sample_rows).await?);
+    }
+    Ok(out)
+}
+
+async fn scan_json_column(
+    pool: &PgPool,
+    col: &ColumnMeta,
+    sample_rows: u32,
+) -> Result<Vec<Finding>, ScanError> {
+    let table = qualify_table(&col.schema, &col.table).map_err(ScanError::new)?;
+    let column = quote_ident(&col.column).map_err(ScanError::new)?;
+    let limit = i64::from(sample_rows.max(1));
+    let sql = format!("SELECT {column}::text FROM {table} LIMIT {limit}");
+    let docs: Vec<Option<String>> = sqlx::query_scalar(&sql)
+        .fetch_all(pool)
+        .await
+        .map_err(ScanError::new)?;
+
+    let mut by_path: BTreeMap<String, (u64, u64, redact_core::EntityType, f32)> = BTreeMap::new();
+    let mut sampled_docs = 0u64;
+    for raw in docs.into_iter().flatten() {
+        sampled_docs += 1;
+        let Ok(value) = serde_json::from_str::<Value>(&raw) else {
+            continue;
+        };
+        let mut paths = Vec::new();
+        walk(&value, "$", &mut paths);
+        for (path, text) in paths {
+            let hits = detect_types(&text);
+            if hits.is_empty() {
+                continue;
+            }
+            let (ty, score) = hits
+                .into_iter()
+                .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+                .expect("hits non-empty");
+            let entry = by_path.entry(path).or_insert((0, 0, ty.clone(), score));
+            entry.0 += 1;
+            entry.1 = sampled_docs;
+            if score > entry.3 {
+                entry.2 = ty;
+                entry.3 = score;
+            }
+        }
+    }
+
+    Ok(by_path
+        .into_iter()
+        .map(
+            |(json_path, (match_count, sampled_rows, entity_type, confidence))| Finding {
+                table: format!("{}.{}", col.schema, col.table),
+                column: col.column.clone(),
+                json_path: Some(json_path),
+                entity_type,
+                layer: ScanLayer::Json,
+                match_count,
+                sampled_rows,
+                confidence,
+                evidence_class: EvidenceClass::JsonPath,
+            },
+        )
+        .collect())
+}
+
+fn walk(value: &Value, path: &str, out: &mut Vec<(String, String)>) {
+    match value {
+        Value::String(s) => out.push((path.to_string(), s.clone())),
+        Value::Number(n) => out.push((path.to_string(), n.to_string())),
+        Value::Object(map) => {
+            for (k, v) in map {
+                let child = format!("{path}.{k}");
+                walk(v, &child, out);
+            }
+        }
+        Value::Array(items) => {
+            for (i, v) in items.iter().enumerate() {
+                let child = format!("{path}[{i}]");
+                walk(v, &child, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn walks_nested_paths() {
+        let v = serde_json::json!({"customer":{"email":"a@b.c"},"n":1});
+        let mut paths = Vec::new();
+        walk(&v, "$", &mut paths);
+        assert!(paths.iter().any(|(p, _)| p == "$.customer.email"));
+        assert!(paths.iter().any(|(p, _)| p == "$.n"));
+    }
+}

--- a/crates/redact-scan/src/lib.rs
+++ b/crates/redact-scan/src/lib.rs
@@ -7,6 +7,8 @@
 //! Prefer a replica or staging database. Reports list locations and counts
 //! only — never sample values.
 
+/// Rule-of-three helper for negative samples.
+pub mod bound;
 /// Canonical JSON hashing for [`ScanReport::content_hash`].
 pub mod canonical;
 /// Layer 0 catalog metadata.
@@ -17,12 +19,20 @@ pub mod cli;
 pub mod detect;
 /// Scrubbed scanner errors.
 pub mod error;
+/// Human-readable table output.
+pub mod format;
+/// Identifier quoting.
+pub mod ident;
+/// Layer 2 JSON path sampling.
+pub mod json_scan;
 /// Discovery layer identifiers (`0`, `0.5`, `1`, `2`).
 pub mod layers;
 /// Value-free report types.
 pub mod report;
 /// Read-only session and privilege checks.
 pub mod safety;
+/// Layer 1 table sampling.
+pub mod sample;
 /// Scan orchestration.
 pub mod scan;
 /// Name and type heuristics.
@@ -31,6 +41,8 @@ pub mod score;
 pub mod scrub;
 /// Layer 0.5 planner statistics.
 pub mod stats;
+/// Optional HTTP POST of the report JSON.
+pub mod upload;
 
 pub use error::ScanError;
 pub use report::{Finding, ScanReport};

--- a/crates/redact-scan/src/main.rs
+++ b/crates/redact-scan/src/main.rs
@@ -3,10 +3,13 @@
 // in the project root for license information.
 
 use clap::Parser;
-use redact_scan::cli::Cli;
+use redact_scan::cli::{Cli, OutputFormat};
+use redact_scan::detect::fail_on_matches;
 use redact_scan::error::ScanError;
+use redact_scan::report::DebugSamples;
 use redact_scan::scrub::scrub;
-use redact_scan::{run_scan, EXIT_CLEAN, EXIT_ERROR};
+use redact_scan::upload::post_report;
+use redact_scan::{run_scan, EXIT_CLEAN, EXIT_ERROR, EXIT_FINDINGS};
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
@@ -37,10 +40,44 @@ fn run() -> Result<i32, ScanError> {
     let rt = tokio::runtime::Runtime::new().map_err(ScanError::new)?;
     let report = rt.block_on(run_scan(&cli))?;
     let json = serde_json::to_string_pretty(&report).map_err(ScanError::new)?;
+    let rendered = match cli.format {
+        OutputFormat::Json => json.clone(),
+        OutputFormat::Table => redact_scan::format::render_table(&report),
+    };
+
     if let Some(path) = &cli.out {
         std::fs::write(path, &json).map_err(ScanError::new)?;
     } else {
-        println!("{json}");
+        println!("{rendered}");
+    }
+
+    if cli.include_samples {
+        let samples = DebugSamples {
+            scan_id: report.scan_id,
+            notes: "local debug only; ScanReport contains no values".into(),
+        };
+        if let Some(path) = &cli.samples_out {
+            std::fs::write(
+                path,
+                serde_json::to_vec_pretty(&samples).map_err(ScanError::new)?,
+            )
+            .map_err(ScanError::new)?;
+        }
+    }
+
+    if let Some(url) = &cli.report_url {
+        rt.block_on(post_report(
+            url,
+            cli.api_key.as_deref(),
+            &cli.report_headers,
+            &report,
+        ))?;
+    }
+
+    if let Some(spec) = &cli.fail_on {
+        if fail_on_matches(spec, &report.findings) {
+            return Ok(EXIT_FINDINGS);
+        }
     }
     Ok(EXIT_CLEAN)
 }

--- a/crates/redact-scan/src/sample.rs
+++ b/crates/redact-scan/src/sample.rs
@@ -51,6 +51,9 @@ async fn sample_column(
     let column = quote_ident(&col.column).map_err(ScanError::new)?;
     let n = col.n_live_tup.max(0) as u64;
     let limit = i64::from(sample_rows.max(1));
+    // When the table is no larger than the sample budget, LIMIT is enough.
+    // TABLESAMPLE on a tiny relation still reads the same rows and can
+    // return zero pages; a full-table random scan is not used either way.
     let sql = if n > 0 && n <= u64::from(sample_rows) {
         format!("SELECT {column}::text FROM {table} LIMIT {limit}")
     } else {

--- a/crates/redact-scan/src/sample.rs
+++ b/crates/redact-scan/src/sample.rs
@@ -1,0 +1,111 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Layer 1: bounded `TABLESAMPLE SYSTEM` of candidate columns.
+
+use sqlx::PgPool;
+
+use crate::catalog::ColumnMeta;
+use crate::detect::detect_types;
+use crate::error::ScanError;
+use crate::ident::{qualify_table, quote_ident};
+use crate::layers::ScanLayer;
+use crate::report::{EvidenceClass, Finding};
+
+/// Sample ordinary tables only (`relkind` `r`/`p`). Views are skipped.
+pub async fn l1_findings(
+    pool: &PgPool,
+    columns: &[&ColumnMeta],
+    sample_rows: u32,
+) -> Result<Vec<Finding>, ScanError> {
+    let mut out = Vec::new();
+    for col in columns {
+        if col.relkind != "r" && col.relkind != "p" {
+            continue;
+        }
+        if crate::score::is_json_type(&col.udt) {
+            continue;
+        }
+        if let Some(finding) = sample_column(pool, col, sample_rows).await? {
+            out.push(finding);
+        }
+    }
+    Ok(out)
+}
+
+/// `TABLESAMPLE` percent: `clamp(1, 100, 200 * sample_rows / n_live_tup)`.
+pub fn tablesample_percent(n_live_tup: u64, sample_rows: u32) -> f64 {
+    if n_live_tup == 0 {
+        return 1.0;
+    }
+    (200.0 * f64::from(sample_rows) / n_live_tup as f64).clamp(1.0, 100.0)
+}
+
+async fn sample_column(
+    pool: &PgPool,
+    col: &ColumnMeta,
+    sample_rows: u32,
+) -> Result<Option<Finding>, ScanError> {
+    let table = qualify_table(&col.schema, &col.table).map_err(ScanError::new)?;
+    let column = quote_ident(&col.column).map_err(ScanError::new)?;
+    let n = col.n_live_tup.max(0) as u64;
+    let limit = i64::from(sample_rows.max(1));
+    let sql = if n > 0 && n <= u64::from(sample_rows) {
+        format!("SELECT {column}::text FROM {table} LIMIT {limit}")
+    } else {
+        let pct = (tablesample_percent(n, sample_rows) * 100.0).round() / 100.0;
+        format!("SELECT {column}::text FROM {table} TABLESAMPLE SYSTEM ({pct}) LIMIT {limit}")
+    };
+
+    let values: Vec<Option<String>> = sqlx::query_scalar(&sql)
+        .fetch_all(pool)
+        .await
+        .map_err(ScanError::new)?;
+    let sampled = values.len() as u64;
+    if sampled == 0 {
+        return Ok(None);
+    }
+
+    let mut match_count = 0u64;
+    let mut best: Option<(redact_core::EntityType, f32)> = None;
+    for v in values.into_iter().flatten() {
+        let hits = detect_types(&v);
+        if hits.is_empty() {
+            continue;
+        }
+        match_count += 1;
+        for (ty, score) in hits {
+            match &best {
+                Some((_, s)) if *s >= score => {}
+                _ => best = Some((ty, score)),
+            }
+        }
+    }
+    let Some((entity_type, confidence)) = best else {
+        return Ok(None);
+    };
+    Ok(Some(Finding {
+        table: format!("{}.{}", col.schema, col.table),
+        column: col.column.clone(),
+        json_path: None,
+        entity_type,
+        layer: ScanLayer::Sample,
+        match_count,
+        sampled_rows: sampled,
+        confidence,
+        evidence_class: EvidenceClass::TableSample,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn percent_clamps_and_never_uses_full_random_order() {
+        assert_eq!(tablesample_percent(0, 1000), 1.0);
+        assert!((tablesample_percent(10_000, 1000) - 20.0).abs() < 1e-9);
+        assert_eq!(tablesample_percent(100, 1000), 100.0);
+    }
+}

--- a/crates/redact-scan/src/scan.rs
+++ b/crates/redact-scan/src/scan.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See the LICENSE file
 // in the project root for license information.
 
-//! Scan orchestration for layers 0 and 0.5.
+//! Scan orchestration for layers 0, 0.5, 1, and 2.
 
 use chrono::Utc;
 use uuid::Uuid;
@@ -12,9 +12,11 @@ use crate::catalog::{candidates, l0_findings, load_columns};
 use crate::cli::Cli;
 use crate::detect::pattern_pack_label;
 use crate::error::ScanError;
+use crate::json_scan::l2_findings;
 use crate::layers::ScanLayer;
 use crate::report::{Finding, Sampling, ScanReport, Scanner, Target};
 use crate::safety::{connect_readonly, host_db_from_url};
+use crate::sample::l1_findings;
 use crate::stats::l05_findings;
 
 /// Run the selected layers and return a finalized report.
@@ -47,8 +49,11 @@ pub async fn run_scan(cli: &Cli) -> Result<ScanReport, ScanError> {
     if layers.contains(&ScanLayer::Stats) {
         findings.extend(l05_findings(&safe.pool, &cli.schema, &cand).await?);
     }
-    if layers.contains(&ScanLayer::Sample) || layers.contains(&ScanLayer::Json) {
-        tracing::warn!("layers 1 and 2 are not implemented in this revision");
+    if layers.contains(&ScanLayer::Sample) {
+        findings.extend(l1_findings(&safe.pool, &cand, cli.sample_rows).await?);
+    }
+    if layers.contains(&ScanLayer::Json) {
+        findings.extend(l2_findings(&safe.pool, &cand, cli.sample_rows).await?);
     }
 
     findings = dedup_findings(findings);

--- a/crates/redact-scan/src/upload.rs
+++ b/crates/redact-scan/src/upload.rs
@@ -1,0 +1,60 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Optional HTTP POST of the report JSON.
+
+use crate::error::ScanError;
+use crate::report::ScanReport;
+
+/// POST `report` to `url`. 2xx required. Optional Bearer key and extra headers.
+pub async fn post_report(
+    url: &str,
+    api_key: Option<&str>,
+    headers: &[String],
+    report: &ScanReport,
+) -> Result<(), ScanError> {
+    let client = reqwest::Client::new();
+    let mut req = client
+        .post(url)
+        .header("content-type", "application/json")
+        .json(report);
+    if let Some(key) = api_key {
+        if !key.is_empty() {
+            req = req.bearer_auth(key);
+        }
+    }
+    for h in headers {
+        let (name, value) = parse_header(h)?;
+        req = req.header(name, value);
+    }
+    let resp = req.send().await.map_err(ScanError::new)?;
+    if !resp.status().is_success() {
+        return Err(ScanError::new(format!(
+            "report POST failed with HTTP {}",
+            resp.status()
+        )));
+    }
+    Ok(())
+}
+
+/// Split `Name: value`.
+pub fn parse_header(h: &str) -> Result<(&str, &str), ScanError> {
+    let (name, value) = h
+        .split_once(':')
+        .ok_or_else(|| ScanError::new("invalid --report-header; expected Name: value"))?;
+    Ok((name.trim(), value.trim()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_split() {
+        let (n, v) = parse_header("X-Run: abc").unwrap();
+        assert_eq!(n, "X-Run");
+        assert_eq!(v, "abc");
+        assert!(parse_header("nope").is_err());
+    }
+}


### PR DESCRIPTION
Thank you for contributing to Redact. These checkboxes are acknowledgements;
the CLA bot enforces the Individual CLA signature.

- [x] I have read [CLA.md](../CLA.md) and will sign the Individual CLA via the bot comment (or I have already signed). A Corporate CLA, if required, does not replace the Individual CLA.
- [x] All commits are DCO-signed (`git commit -s`)
- [x] I have read [docs/PROJECT_SCOPE.md](../docs/PROJECT_SCOPE.md); this change is in scope

**Employer time or equipment**

- [x] No — this work was not done on employer time or equipment
- [ ] Yes — my employer has authorised the contribution, or a Corporate CLA is on file

## Summary

Third slice of `redact-scan`:

- Layer 1: `TABLESAMPLE SYSTEM` + `LIMIT` on ordinary tables; identifiers are quoted; never `SELECT *`
- Layer 2: JSON/JSONB path findings; values dropped
- `--report-url` POSTs `ScanReport` with optional Bearer key and `--report-header`
- `--fail-on any|<ENTITY_TYPE>` exits 1
- `--format table` includes the rule-of-three note when there are no findings
- `--out` always writes `ScanReport` JSON

## Test plan

- [x] `cargo test -p redact-scan`
- [x] `cargo clippy -p redact-scan --all-targets -- -D warnings`
- [x] rustdoc `-D missing_docs`