### PR TITLE
test(scan): Postgres acceptance suite and scanning model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,3 +255,24 @@ jobs:
           echo "ERROR: API failed to become healthy within 30s"
           docker logs api-smoke || true
           exit 1
+
+  redact-scan-integration:
+    name: redact-scan Postgres integration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          key: redact-scan-integration
+
+      - name: Run gated Postgres tests
+        env:
+          REDACT_SCAN_INTEGRATION: "1"
+        run: cargo test -p redact-scan --test postgres -- --nocapture

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   layers 0 / 0.5 / 1 / 2 (catalog, `pg_stats`, bounded `TABLESAMPLE`,
   JSON paths). Optional `--report-url` POSTs the report JSON; `--fail-on`
   exits 1 on matching findings. Reports contain locations and counts
-  only — never sample values.
+  only — never sample values. See `docs/scanning-model.md`.
 
 ## [0.9.1] - 2026-08-08
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "astral-tokio-tar"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +347,12 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -346,6 +390,92 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "bollard"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a52479c9237eb04047ddb94788c41ca0d26eaff8b697ecfbb4c32f7fdc3b1b"
+dependencies = [
+ "async-stream",
+ "base64 0.22.1",
+ "bitflags 2.11.0",
+ "bollard-buildkit-proto",
+ "bollard-stubs",
+ "bytes",
+ "chrono",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "home",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-named-pipe",
+ "hyper-rustls",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "num",
+ "pin-project-lite",
+ "rand 0.9.3",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-buildkit-proto"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-prost",
+ "ureq",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.49.1-rc.28.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5731fe885755e92beff1950774068e0cae67ea6ec7587381536fca84f1779623"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-buildkit-proto",
+ "bytes",
+ "chrono",
+ "prost",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "serde_with",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -776,8 +906,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -795,12 +935,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -812,6 +976,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -840,6 +1035,9 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "derive_builder"
@@ -856,7 +1054,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -914,6 +1112,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "docker_credential"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29547a1dc60885a552306986316bc9701ba120c1a8db6769fa68691529ad373d"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +1133,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -986,6 +1201,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c7b13d0780cb82722fd59f6f57f925e143427e4a75313a6c77243bf5326ae6"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,6 +1226,16 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1068,6 +1304,21 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-channel"
@@ -1142,6 +1393,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1227,7 +1479,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.13.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1244,6 +1496,12 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1402,6 +1660,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-named-pipe"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fab3637d6b04a8037af8a266fdf6cf92ea957e8c53981a2bf6136572531025bf"
+dependencies = [
+ "hex",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1453,6 +1725,21 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1596,6 +1883,17 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
@@ -1673,6 +1971,59 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jni"
@@ -1801,7 +2152,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
  "plain",
  "redox_syscall 0.9.2",
@@ -2026,6 +2377,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2086,6 +2451,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2113,7 +2489,7 @@ version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
  "once_cell",
  "onig_sys",
@@ -2147,7 +2523,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2355,6 +2731,31 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "parse-display"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
+dependencies = [
+ "parse-display-derive",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax",
+ "structmeta",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2988,6 +3389,7 @@ dependencies = [
  "chrono",
  "clap",
  "predicates",
+ "rand 0.10.1",
  "redact-core",
  "regex",
  "reqwest",
@@ -2995,6 +3397,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "sqlx",
+ "testcontainers-modules",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3025,7 +3428,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -3034,7 +3437,27 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c93da5bb2c5d4e6c0ef7abeead62c89169a0a4882bfb83ac892f2423aea2fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3190,7 +3613,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3204,6 +3627,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3222,6 +3646,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3304,6 +3737,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3315,7 +3772,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3387,7 +3844,7 @@ version = "0.9.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.1",
  "itoa",
  "ryu",
  "serde",
@@ -3406,6 +3863,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3415,6 +3883,39 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
+dependencies = [
+ "base64 0.22.1",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.13.1",
+ "jiff",
+ "schemars 0.9.0",
+ "schemars 1.2.2",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3596,7 +4097,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap",
+ "indexmap 2.13.1",
  "log",
  "memchr",
  "once_cell",
@@ -3661,7 +4162,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags",
+ "bitflags 2.11.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -3705,12 +4206,12 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags",
+ "bitflags 2.11.0",
  "byteorder",
  "chrono",
  "crc",
  "dotenvy",
- "etcetera",
+ "etcetera 0.8.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -3792,6 +4293,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3868,7 +4392,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -3901,6 +4425,44 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "testcontainers"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3ac71069f20ecfa60c396316c283fbf35e6833a53dff551a31b5458da05edc"
+dependencies = [
+ "astral-tokio-tar",
+ "async-trait",
+ "bollard",
+ "bytes",
+ "docker_credential",
+ "either",
+ "etcetera 0.10.0",
+ "futures",
+ "log",
+ "memchr",
+ "parse-display",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "ulid",
+ "url",
+]
+
+[[package]]
+name = "testcontainers-modules"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1966329d5bb3f89d33602d2db2da971fb839f9297dad16527abf4564e2ae0a6d"
+dependencies = [
+ "testcontainers",
+]
 
 [[package]]
 name = "thiserror"
@@ -4119,8 +4681,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
+ "axum",
  "base64 0.22.1",
  "bytes",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -4129,6 +4693,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
+ "socket2",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
@@ -4168,7 +4733,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 2.13.1",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -4185,7 +4750,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -4314,6 +4879,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.3",
+ "web-time",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4418,6 +4993,7 @@ dependencies = [
  "log",
  "native-tls",
  "percent-encoding",
+ "rustls",
  "rustls-pki-types",
  "socks",
  "ureq-proto",
@@ -4447,6 +5023,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -4685,7 +5262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.1",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -4709,9 +5286,9 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.1",
  "semver",
 ]
 
@@ -4896,6 +5473,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -5189,7 +5775,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.13.1",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -5219,8 +5805,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
- "indexmap",
+ "bitflags 2.11.0",
+ "indexmap 2.13.1",
  "log",
  "serde",
  "serde_derive",
@@ -5239,7 +5825,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.13.1",
  "log",
  "semver",
  "serde",
@@ -5254,6 +5840,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yoke"

--- a/crates/redact-scan/Cargo.toml
+++ b/crates/redact-scan/Cargo.toml
@@ -36,3 +36,9 @@ path = "src/main.rs"
 [dev-dependencies]
 assert_cmd = "2.2"
 predicates = "3.1"
+testcontainers-modules = { version = "0.13", features = ["postgres"] }
+rand = { workspace = true }
+tokio = { workspace = true }
+sqlx = { workspace = true }
+clap = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/redact-scan/README.md
+++ b/crates/redact-scan/README.md
@@ -8,3 +8,41 @@ redact-scan --url postgres://reader@localhost/app --schema public --out report.j
 ```
 
 The report lists table/column locations and entity types. It never includes sample values.
+
+See [docs/scanning-model.md](../../docs/scanning-model.md) for the four discovery layers and safety rails.
+
+## Sample report
+
+```json
+{
+  "scan_id": "00000000-0000-0000-0000-000000000001",
+  "scanned_at": "2026-08-15T00:00:00Z",
+  "target": {
+    "fingerprint": "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+    "engine": "postgres",
+    "version": "16.4"
+  },
+  "scanner": {
+    "version": "0.9.1",
+    "pattern_pack": "builtin@54"
+  },
+  "sampling": {
+    "layers": [0.0, 0.5, 1.0, 2.0],
+    "rows_per_column": 1000,
+    "method": "TABLESAMPLE SYSTEM"
+  },
+  "findings": [
+    {
+      "table": "public.customers",
+      "column": "email",
+      "entity_type": "EMAIL_ADDRESS",
+      "layer": 0.0,
+      "match_count": 0,
+      "sampled_rows": 0,
+      "confidence": 0.85,
+      "evidence_class": "name_heuristic"
+    }
+  ],
+  "content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+```

--- a/crates/redact-scan/README.md
+++ b/crates/redact-scan/README.md
@@ -24,7 +24,7 @@ See [docs/scanning-model.md](../../docs/scanning-model.md) for the four discover
   },
   "scanner": {
     "version": "0.9.1",
-    "pattern_pack": "builtin@54"
+    "pattern_pack": "builtin@<supported-entity-count>"
   },
   "sampling": {
     "layers": [0.0, 0.5, 1.0, 2.0],

--- a/crates/redact-scan/tests/postgres.rs
+++ b/crates/redact-scan/tests/postgres.rs
@@ -1,0 +1,269 @@
+//! Postgres acceptance tests. Skipped unless `REDACT_SCAN_INTEGRATION=1`.
+
+mod support;
+
+use clap::Parser;
+use redact_scan::cli::Cli;
+use redact_scan::layers::ScanLayer;
+use redact_scan::run_scan;
+use redact_scan::safety::connect_readonly;
+use sqlx::postgres::PgPoolOptions;
+use std::time::{Duration, Instant};
+use support::fixture::{self, Fixture};
+use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+use testcontainers_modules::testcontainers::ImageExt;
+
+fn enabled() -> bool {
+    std::env::var("REDACT_SCAN_INTEGRATION").ok().as_deref() == Some("1")
+}
+
+fn seed() -> u64 {
+    std::env::var("REDACT_SCAN_FIXTURE_SEED")
+        .ok()
+        .and_then(|s| {
+            s.strip_prefix("0x")
+                .and_then(|h| u64::from_str_radix(h, 16).ok())
+                .or_else(|| s.parse().ok())
+        })
+        .unwrap_or_else(rand::random)
+}
+
+async fn start_postgres() -> (
+    testcontainers_modules::testcontainers::ContainerAsync<Postgres>,
+    String,
+    String,
+) {
+    let container = Postgres::default()
+        .with_tag("16-alpine")
+        .with_cmd([
+            "postgres",
+            "-c",
+            "shared_preload_libraries=pg_stat_statements",
+        ])
+        .start()
+        .await
+        .expect("start postgres");
+    let host = container.get_host().await.expect("host").to_string();
+    let port = container.get_host_port_ipv4(5432).await.expect("port");
+    let admin = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    let scanner = format!("postgres://scanner:scan-pass-not-super@{host}:{port}/postgres");
+    (container, admin, scanner)
+}
+
+async fn admin_pool(url: &str) -> sqlx::PgPool {
+    PgPoolOptions::new()
+        .max_connections(2)
+        .connect(url)
+        .await
+        .expect("admin connect")
+}
+
+async fn prepare_roles(admin: &sqlx::PgPool) {
+    sqlx::query("CREATE EXTENSION IF NOT EXISTS pg_stat_statements")
+        .execute(admin)
+        .await
+        .expect("pg_stat_statements");
+    sqlx::query(
+        "CREATE ROLE scanner LOGIN PASSWORD 'scan-pass-not-super' NOSUPERUSER NOCREATEDB NOCREATEROLE",
+    )
+    .execute(admin)
+    .await
+    .expect("create scanner");
+    sqlx::query("GRANT USAGE ON SCHEMA public TO scanner")
+        .execute(admin)
+        .await
+        .expect("grant usage");
+    sqlx::query("GRANT pg_read_all_stats TO scanner")
+        .execute(admin)
+        .await
+        .ok();
+}
+
+async fn grant_select(admin: &sqlx::PgPool) {
+    sqlx::query("GRANT SELECT ON ALL TABLES IN SCHEMA public TO scanner")
+        .execute(admin)
+        .await
+        .expect("grant select");
+}
+
+fn scan_cli(url: &str, layers: &str) -> Cli {
+    Cli::parse_from([
+        "redact-scan",
+        "--url",
+        url,
+        "--schema",
+        "public",
+        "--layers",
+        layers,
+        "--sample-rows",
+        "200",
+    ])
+}
+
+#[tokio::test]
+async fn acceptance_randomized_fixture() {
+    if !enabled() {
+        eprintln!("skipping: set REDACT_SCAN_INTEGRATION=1");
+        return;
+    }
+    let seed = seed();
+    eprintln!("redact-scan fixture seed={seed:#x}");
+    let (_c, admin_url, scanner_url) = start_postgres().await;
+    let admin = admin_pool(&admin_url).await;
+    prepare_roles(&admin).await;
+
+    let (fx, stmts) = Fixture::generate(seed);
+    fixture::apply(&admin, &stmts).await.expect("apply fixture");
+    sqlx::query("ANALYZE")
+        .execute(&admin)
+        .await
+        .expect("analyze");
+    grant_select(&admin).await;
+    sqlx::query("SELECT pg_stat_statements_reset()")
+        .execute(&admin)
+        .await
+        .ok();
+
+    let super_err = run_scan(&scan_cli(&admin_url, "0,0.5"))
+        .await
+        .expect_err("superuser must be refused");
+    assert!(
+        super_err
+            .to_string()
+            .to_ascii_lowercase()
+            .contains("superuser"),
+        "{super_err}"
+    );
+
+    let l05 = run_scan(&scan_cli(&scanner_url, "0,0.5"))
+        .await
+        .expect("l0+l0.5");
+    let found: Vec<(String, String)> = l05
+        .findings
+        .iter()
+        .map(|f| {
+            let table = f.table.rsplit('.').next().unwrap_or(&f.table).to_string();
+            (table, f.column.clone())
+        })
+        .collect();
+    let pii_hits = fx
+        .pii
+        .iter()
+        .filter(|p| found.iter().any(|f| f == *p))
+        .count();
+    assert!(
+        pii_hits * 5 >= fx.pii.len() * 4,
+        "L0+L0.5 found {pii_hits}/{} PII columns: {found:?}",
+        fx.pii.len()
+    );
+    for c in &fx.clean {
+        assert!(
+            !found.iter().any(|f| f == c),
+            "clean column {}.{} appeared in L0+L0.5",
+            c.0,
+            c.1
+        );
+    }
+
+    let queries: Vec<String> = sqlx::query_scalar("SELECT query FROM pg_stat_statements")
+        .fetch_all(&admin)
+        .await
+        .unwrap_or_default();
+    for (table, _) in fx.pii.iter().chain(fx.clean.iter()) {
+        for q in &queries {
+            let lower = q.to_ascii_lowercase();
+            if lower.contains(&format!("from {table}"))
+                || lower.contains(&format!("from public.{table}"))
+                || lower.contains(&format!("from \"{table}\""))
+            {
+                panic!("L0+L0.5 issued user-table SELECT: {q}");
+            }
+        }
+    }
+
+    let full = run_scan(&scan_cli(&scanner_url, "0,0.5,1,2"))
+        .await
+        .expect("full scan");
+    let full_found: Vec<(String, String)> = full
+        .findings
+        .iter()
+        .map(|f| {
+            let table = f.table.rsplit('.').next().unwrap_or(&f.table).to_string();
+            (table, f.column.clone())
+        })
+        .collect();
+    for p in &fx.pii {
+        assert!(
+            full_found.iter().any(|f| f == p),
+            "missing PII column {}.{}",
+            p.0,
+            p.1
+        );
+    }
+    for c in &fx.clean {
+        assert!(
+            !full_found.iter().any(|f| f == c),
+            "clean column {}.{} produced a finding",
+            c.0,
+            c.1
+        );
+    }
+
+    let json = serde_json::to_string(&full).expect("json");
+    for secret in &fx.secret_values {
+        assert!(
+            !json.contains(secret),
+            "report leaked fixture value {secret}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn bad_password_is_scrubbed() {
+    if !enabled() {
+        eprintln!("skipping: set REDACT_SCAN_INTEGRATION=1");
+        return;
+    }
+    let (_c, admin_url, _) = start_postgres().await;
+    let secret = "super-secret-db-pass";
+    let bad = admin_url.replace("postgres:postgres", &format!("postgres:{secret}"));
+    let err = match connect_readonly(&bad, Duration::from_secs(5), "public").await {
+        Ok(_) => panic!("auth should fail"),
+        Err(e) => e,
+    };
+    let shown = format!("{err}");
+    let debug = format!("{err:?}");
+    assert!(!shown.contains(secret), "{shown}");
+    assert!(!debug.contains(secret), "{debug}");
+}
+
+#[tokio::test]
+async fn five_hundred_tables_l0_l05_under_ten_seconds() {
+    if !enabled() {
+        eprintln!("skipping: set REDACT_SCAN_INTEGRATION=1");
+        return;
+    }
+    let (_c, admin_url, scanner_url) = start_postgres().await;
+    let admin = admin_pool(&admin_url).await;
+    prepare_roles(&admin).await;
+    for i in 0..500 {
+        sqlx::query(&format!(
+            "CREATE TABLE t_bulk_{i} (id int, note text, email text)"
+        ))
+        .execute(&admin)
+        .await
+        .expect("create");
+    }
+    grant_select(&admin).await;
+    let start = Instant::now();
+    let report = run_scan(&scan_cli(&scanner_url, "0,0.5"))
+        .await
+        .expect("bulk scan");
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "L0+L0.5 on 500 tables took {elapsed:?}"
+    );
+    assert!(report.sampling.layers.contains(&ScanLayer::Metadata));
+}

--- a/crates/redact-scan/tests/support/fixture.rs
+++ b/crates/redact-scan/tests/support/fixture.rs
@@ -1,0 +1,123 @@
+//! Randomized scan fixture. Seed is printed first.
+
+use rand::{Rng, RngExt, SeedableRng};
+use sqlx::PgPool;
+
+/// Known PII and clean columns created for a run.
+pub struct Fixture {
+    pub pii: Vec<(String, String)>,
+    pub clean: Vec<(String, String)>,
+    pub secret_values: Vec<String>,
+}
+
+impl Fixture {
+    pub fn generate(seed: u64) -> (Self, Vec<String>) {
+        eprintln!("redact-scan fixture seed={seed:#x}");
+        let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+        let mut sql = Vec::new();
+        let mut pii = Vec::new();
+        let mut clean = Vec::new();
+        let mut secret_values = Vec::new();
+
+        let t_pii = ident(&mut rng, "t");
+        let t_clean = ident(&mut rng, "t");
+        let c_email = ident(&mut rng, "c");
+        let c_ssn = ident(&mut rng, "c");
+        let c_iban = ident(&mut rng, "c");
+        let c_cc = ident(&mut rng, "c");
+        let c_ip = ident(&mut rng, "c");
+        let c_json = ident(&mut rng, "c");
+        let c_status = ident(&mut rng, "c");
+        let c_qty = ident(&mut rng, "c");
+        let c_note = ident(&mut rng, "c");
+        let c_flag = ident(&mut rng, "c");
+
+        sql.push(format!(
+            r#"
+            CREATE TABLE {t_pii} (
+              {c_email} text,
+              {c_ssn} text,
+              {c_iban} text,
+              {c_cc} text,
+              {c_ip} inet,
+              {c_json} jsonb
+            );
+            CREATE TABLE {t_clean} (
+              {c_status} text,
+              {c_qty} int,
+              {c_note} text,
+              {c_flag} boolean
+            );
+            "#
+        ));
+
+        let email = format!("user{seed}@example.test");
+        let ssn = "856-45-6789";
+        let iban = "GB82WEST12345698765432";
+        let cc = "4111111111111111";
+        let ip = "203.0.113.10";
+        let json = format!(r#"{{"customer":{{"email":"{email}"}}}}"#);
+        secret_values.extend([email.clone(), ssn.into(), iban.into(), cc.into(), ip.into()]);
+
+        // Repeat a subset so ANALYZE fills most_common_vals.
+        for _ in 0..40 {
+            sql.push(format!(
+                "INSERT INTO {t_pii} ({c_email},{c_ssn},{c_iban},{c_cc},{c_ip},{c_json}) VALUES ('{email}','{ssn}','{iban}','{cc}','{ip}','{json}');"
+            ));
+        }
+        // Unique emails so histogram_bounds also holds values.
+        for i in 0..20 {
+            let unique = format!("uniq{seed}{i}@example.test");
+            secret_values.push(unique.clone());
+            sql.push(format!(
+                "INSERT INTO {t_pii} ({c_email},{c_ssn},{c_iban},{c_cc},{c_ip},{c_json}) VALUES ('{unique}','{ssn}','{iban}','{cc}','{ip}','{json}');"
+            ));
+        }
+        for _ in 0..30 {
+            let status = if rng.random_bool(0.5) {
+                "active"
+            } else {
+                "pending"
+            };
+            sql.push(format!(
+                "INSERT INTO {t_clean} ({c_status},{c_qty},{c_note},{c_flag}) VALUES ('{status}',{},'lorem ipsum dolor sit amet',true);",
+                rng.random_range(1..100)
+            ));
+        }
+
+        pii.extend([
+            (t_pii.clone(), c_email),
+            (t_pii.clone(), c_ssn),
+            (t_pii.clone(), c_iban),
+            (t_pii.clone(), c_cc),
+            (t_pii.clone(), c_ip),
+            (t_pii, c_json),
+        ]);
+        clean.extend([
+            (t_clean.clone(), c_status),
+            (t_clean.clone(), c_qty),
+            (t_clean.clone(), c_note),
+            (t_clean, c_flag),
+        ]);
+
+        (
+            Self {
+                pii,
+                clean,
+                secret_values,
+            },
+            sql,
+        )
+    }
+}
+
+fn ident<R: Rng>(rng: &mut R, prefix: &str) -> String {
+    format!("{prefix}_{:08x}", rng.random::<u32>())
+}
+
+pub async fn apply(pool: &PgPool, statements: &[String]) -> sqlx::Result<()> {
+    for s in statements {
+        sqlx::query(s).execute(pool).await?;
+    }
+    Ok(())
+}

--- a/crates/redact-scan/tests/support/fixture.rs
+++ b/crates/redact-scan/tests/support/fixture.rs
@@ -33,22 +33,10 @@ impl Fixture {
         let c_flag = ident(&mut rng, "c");
 
         sql.push(format!(
-            r#"
-            CREATE TABLE {t_pii} (
-              {c_email} text,
-              {c_ssn} text,
-              {c_iban} text,
-              {c_cc} text,
-              {c_ip} inet,
-              {c_json} jsonb
-            );
-            CREATE TABLE {t_clean} (
-              {c_status} text,
-              {c_qty} int,
-              {c_note} text,
-              {c_flag} boolean
-            );
-            "#
+            "CREATE TABLE {t_pii} ({c_email} text, {c_ssn} text, {c_iban} text, {c_cc} text, {c_ip} inet, {c_json} jsonb)"
+        ));
+        sql.push(format!(
+            "CREATE TABLE {t_clean} ({c_status} text, {c_qty} int, {c_note} text, {c_flag} boolean)"
         ));
 
         let email = format!("user{seed}@example.test");
@@ -62,7 +50,7 @@ impl Fixture {
         // Repeat a subset so ANALYZE fills most_common_vals.
         for _ in 0..40 {
             sql.push(format!(
-                "INSERT INTO {t_pii} ({c_email},{c_ssn},{c_iban},{c_cc},{c_ip},{c_json}) VALUES ('{email}','{ssn}','{iban}','{cc}','{ip}','{json}');"
+                "INSERT INTO {t_pii} ({c_email},{c_ssn},{c_iban},{c_cc},{c_ip},{c_json}) VALUES ('{email}','{ssn}','{iban}','{cc}','{ip}','{json}')"
             ));
         }
         // Unique emails so histogram_bounds also holds values.
@@ -70,7 +58,7 @@ impl Fixture {
             let unique = format!("uniq{seed}{i}@example.test");
             secret_values.push(unique.clone());
             sql.push(format!(
-                "INSERT INTO {t_pii} ({c_email},{c_ssn},{c_iban},{c_cc},{c_ip},{c_json}) VALUES ('{unique}','{ssn}','{iban}','{cc}','{ip}','{json}');"
+                "INSERT INTO {t_pii} ({c_email},{c_ssn},{c_iban},{c_cc},{c_ip},{c_json}) VALUES ('{unique}','{ssn}','{iban}','{cc}','{ip}','{json}')"
             ));
         }
         for _ in 0..30 {
@@ -80,7 +68,7 @@ impl Fixture {
                 "pending"
             };
             sql.push(format!(
-                "INSERT INTO {t_clean} ({c_status},{c_qty},{c_note},{c_flag}) VALUES ('{status}',{},'lorem ipsum dolor sit amet',true);",
+                "INSERT INTO {t_clean} ({c_status},{c_qty},{c_note},{c_flag}) VALUES ('{status}',{},'lorem ipsum dolor sit amet',true)",
                 rng.random_range(1..100)
             ));
         }
@@ -117,6 +105,10 @@ fn ident<R: Rng>(rng: &mut R, prefix: &str) -> String {
 
 pub async fn apply(pool: &PgPool, statements: &[String]) -> sqlx::Result<()> {
     for s in statements {
+        let s = s.trim().trim_end_matches(';');
+        if s.is_empty() {
+            continue;
+        }
         sqlx::query(s).execute(pool).await?;
     }
     Ok(())

--- a/crates/redact-scan/tests/support/mod.rs
+++ b/crates/redact-scan/tests/support/mod.rs
@@ -1,0 +1,1 @@
+pub mod fixture;

--- a/docs/scanning-model.md
+++ b/docs/scanning-model.md
@@ -1,0 +1,69 @@
+# Scanning model
+
+`redact-scan` is a **read-only** Postgres PII discovery scanner. Prefer a
+replica or staging database. The report lists locations and counts — never
+sample values.
+
+## Safety
+
+Before any catalog work the scanner:
+
+1. Opens a pool with `max_connections = 1`
+2. Sets `default_transaction_read_only = on`, `statement_timeout`, and
+   `lock_timeout = 5s`
+3. Refuses superuser roles
+4. Refuses `INSERT` / `UPDATE` / `DELETE` / `TRUNCATE` (table and column)
+5. Quotes enumerated identifiers only — never `SELECT *`
+6. Scrubs connection passwords from errors, logs, and the panic hook
+
+`--include-samples` cannot be combined with `--report-url`. Samples are a
+local sidecar file and are never merged into `ScanReport`.
+
+## Layers
+
+Select layers independently with `--layers`. Default: `0,0.5,1,2`.
+
+| Layer | Source | User-table reads |
+| --- | --- | --- |
+| `0` | `pg_catalog` / `information_schema` names, types, comments, unique indexes, FK topology | No |
+| `0.5` | `pg_stats` `most_common_vals` and `histogram_bounds` | No |
+| `1` | `TABLESAMPLE SYSTEM` + `LIMIT` on ordinary tables (`relkind = r`) | Yes, bounded |
+| `2` | JSON/JSONB documents, path-level detections | Yes, bounded |
+
+Layer 0 emits findings for name tokens (`email`, `ssn`, `iban`, …) and for
+`inet` / `cidr` types. `json` / unconstrained `text` without a name match
+are **candidates only**.
+
+Layer 0.5 runs the built-in pattern pack on planner statistics and drops
+the matched text immediately. If `pg_stats` is unreadable the layer is
+skipped and other selected layers continue.
+
+Layer 1 samples candidate columns. Percent is
+`clamp(1, 100, 200 * sample_rows / n_live_tup)`. When the table is no
+larger than `--sample-rows`, `LIMIT` without a full-table random scan is
+used. Views are not sampled.
+
+Layer 2 walks sampled JSON documents and reports paths such as
+`$.customer.email`. Values are discarded.
+
+Value-based layers use a precision entity set (email, phone, SSN, payment
+cards, IBAN, IP, passport, MRN, secrets, …) and exclude high-false-positive
+types such as `DATE_TIME`, `GUID`, and hashes unless layer 0 already
+nominated that type from the column name.
+
+## Report
+
+`ScanReport` includes `scan_id`, `scanned_at`, a hashed target fingerprint
+(`sha256(host|database|schema)`), scanner version, selected layers, and
+findings. `content_hash` is SHA-256 of canonical JSON with that field
+omitted.
+
+`--out` always writes `ScanReport` JSON. `--format table` is for terminals
+and includes a rule-of-three note when a sample found nothing:
+“0 matches in 1,000 rows; prevalence above 0.3% is unlikely.”
+
+`--report-url` optionally POSTs the same JSON to a caller-supplied
+endpoint (`Authorization: Bearer` when `--api-key` is set;
+`--report-header` may be repeated). There is no default host.
+
+Exit codes: `0` clean, `1` when `--fail-on` matches, `2` on error.


### PR DESCRIPTION
Thank you for contributing to Redact. These checkboxes are acknowledgements;
the CLA bot enforces the Individual CLA signature.

- [x] I have read [CLA.md](../CLA.md) and will sign the Individual CLA via the bot comment (or I have already signed). A Corporate CLA, if required, does not replace the Individual CLA.
- [x] All commits are DCO-signed (`git commit -s`)
- [x] I have read [docs/PROJECT_SCOPE.md](../docs/PROJECT_SCOPE.md); this change is in scope

**Employer time or equipment**

- [x] No — this work was not done on employer time or equipment
- [ ] Yes — my employer has authorised the contribution, or a Corporate CLA is on file

## Summary

Fourth slice of `redact-scan`:

- `tests/postgres.rs` skipped unless `REDACT_SCAN_INTEGRATION=1`
- Randomized fixture prints `redact-scan fixture seed=0x…`
- Superuser refused; scan role is SELECT-only
- L0+L0.5 coverage, no user-table SELECT in `pg_stat_statements`
- Report JSON must not contain fixture values
- Auth failure scrubs the password
- 500-table L0+L0.5 budget
- `docs/scanning-model.md` and crate README sample report
- CI job `redact-scan-integration` on Ubuntu

## Test plan

- [x] `cargo test -p redact-scan` (unit tests; integration skipped without Docker)
- [x] `cargo clippy -p redact-scan --all-targets -- -D warnings`
- [ ] CI `redact-scan-integration` job exercises the gated suite