### PR TITLE
feat(scan): add redact-scan read-only Postgres PII discovery

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,8 @@
+# cargo-audit config for CI (`cargo audit` in .github/workflows/ci.yml).
+#
+# RUSTSEC-2023-0071 has no patched `rsa` release. The crate is in the lockfile
+# only because sqlx lists optional `sqlx-mysql`; redact-scan enables the
+# `postgres` feature and never talks to MySQL. Revisit if a crate starts
+# enabling sqlx `mysql` or otherwise decrypts RSA PKCS#1 v1.5.
+[advisories]
+ignore = ["RUSTSEC-2023-0071"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,3 +255,24 @@ jobs:
           echo "ERROR: API failed to become healthy within 30s"
           docker logs api-smoke || true
           exit 1
+
+  redact-scan-integration:
+    name: redact-scan Postgres integration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          key: redact-scan-integration
+
+      - name: Run gated Postgres tests
+        env:
+          REDACT_SCAN_INTEGRATION: "1"
+        run: cargo test -p redact-scan --test postgres -- --nocapture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop, feature/*]
+    branches: [main, develop, feature/*, coder*]
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, feature/*, coder*]
 
 permissions:
   contents: read

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           VERSION=${{ env.VERSION }}
           sed -i "s/^version = \"[^\"]*\"/version = \"$VERSION\"/" Cargo.toml
-          for f in crates/redact-ner/Cargo.toml crates/redact-api/Cargo.toml crates/redact-cli/Cargo.toml crates/redact-gateway/Cargo.toml; do
+          for f in crates/redact-ner/Cargo.toml crates/redact-api/Cargo.toml crates/redact-cli/Cargo.toml crates/redact-gateway/Cargo.toml crates/redact-scan/Cargo.toml; do
             sed -i "s/\(redact-core = { path = \"[^\"]*\", version = \"\)[^\"]*/\1$VERSION/" "$f"
             sed -i "s/\(redact-ner = { path = \"[^\"]*\", version = \"\)[^\"]*/\1$VERSION/" "$f"
           done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,8 @@ crates/
 ├── redact-api/     # REST API server (Axum)
 ├── redact-cli/     # Command-line interface (Clap)
 ├── redact-wasm/    # WebAssembly bindings
-└── redact-gateway/ # OpenAI-compatible privacy gateway (embeds redact-core)
+├── redact-gateway/ # OpenAI-compatible privacy gateway (embeds redact-core)
+└── redact-scan/    # Read-only Postgres PII discovery scanner
 ```
 
 ### Crate Dependencies
@@ -32,6 +33,7 @@ redact-api ──────► redact-core
 redact-cli ──────► redact-core
 redact-wasm ─────► redact-core
 redact-gateway ─► redact-core
+redact-scan ────► redact-core
 ```
 
 ### Critical Components
@@ -47,6 +49,10 @@ redact-gateway ─► redact-core
 - `tokenizer_wrapper.rs` - HuggingFace tokenizer integration
 - Uses `ort` crate for ONNX inference
 - Supports quantized int8 models for efficiency
+
+**redact-scan** (`crates/redact-scan/`)
+- Read-only Postgres PII discovery (`redact-scan` binary)
+- Workspace `sqlx` is for this crate only — never add it to `redact-core` (wasm)
 
 ## Development Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   layers 0 / 0.5 / 1 / 2 (catalog, `pg_stats`, bounded `TABLESAMPLE`,
   JSON paths). Optional `--report-url` POSTs the report JSON; `--fail-on`
   exits 1 on matching findings. Reports contain locations and counts
-  only — never sample values.
+  only — never sample values. See `docs/scanning-model.md`.
 
 ## [0.9.1] - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `redact-scan`: new workspace crate and `redact-scan` binary for read-only
   Postgres PII discovery. Report types, credential scrubber, CLI preflight,
   a read-only safety session (refuse superuser and write grants), and
-  layers 0 / 0.5 (catalog metadata and `pg_stats`). Reports contain
-  locations and counts only — never sample values.
+  layers 0 / 0.5 / 1 / 2 (catalog, `pg_stats`, bounded `TABLESAMPLE`,
+  JSON paths). Optional `--report-url` POSTs the report JSON; `--fail-on`
+  exits 1 on matching findings. Reports contain locations and counts
+  only — never sample values.
 
 ## [0.9.1] - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `redact-scan`: new workspace crate and `redact-scan` binary for read-only
+  Postgres PII discovery. This revision adds the report types, credential
+  scrubber, and CLI preflight (`--include-samples` cannot be combined with
+  `--report-url`). Reports contain locations and counts only — never sample
+  values.
+
 ## [0.9.1] - 2026-08-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exits 1 on matching findings. Reports contain locations and counts
   only — never sample values. See `docs/scanning-model.md`.
 
+### Fixed
+
+- `redact-scan`: upgrade `testcontainers-modules` so CI `cargo audit` is not
+  failed by `astral-tokio-tar` advisories in the Postgres acceptance-test
+  tree. Ignore unfixed `RUSTSEC-2023-0071` (`rsa` / Marvin) which is pulled
+  only by unused optional `sqlx-mysql` — this crate enables Postgres only.
+
 ## [0.9.1] - 2026-08-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `redact-scan`: new workspace crate and `redact-scan` binary for read-only
-  Postgres PII discovery. This revision adds the report types, credential
-  scrubber, and CLI preflight (`--include-samples` cannot be combined with
-  `--report-url`). Reports contain locations and counts only — never sample
-  values.
+  Postgres PII discovery. Report types, credential scrubber, CLI preflight,
+  a read-only safety session (refuse superuser and write grants), and
+  layers 0 / 0.5 (catalog metadata and `pg_stats`). Reports contain
+  locations and counts only — never sample values.
 
 ## [0.9.1] - 2026-08-08
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2680,6 +2680,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "redact-scan"
+version = "0.9.1"
+dependencies = [
+ "anyhow",
+ "assert_cmd",
+ "chrono",
+ "clap",
+ "predicates",
+ "redact-core",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "uuid",
+]
+
+[[package]]
 name = "redact-wasm"
 version = "0.9.1"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2990,6 +2990,7 @@ dependencies = [
  "predicates",
  "redact-core",
  "regex",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "astral-tokio-tar"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +347,12 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -346,6 +390,92 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "bollard"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a52479c9237eb04047ddb94788c41ca0d26eaff8b697ecfbb4c32f7fdc3b1b"
+dependencies = [
+ "async-stream",
+ "base64 0.22.1",
+ "bitflags 2.11.0",
+ "bollard-buildkit-proto",
+ "bollard-stubs",
+ "bytes",
+ "chrono",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "home",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-named-pipe",
+ "hyper-rustls",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "num",
+ "pin-project-lite",
+ "rand 0.9.3",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-buildkit-proto"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-prost",
+ "ureq",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.49.1-rc.28.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5731fe885755e92beff1950774068e0cae67ea6ec7587381536fca84f1779623"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-buildkit-proto",
+ "bytes",
+ "chrono",
+ "prost",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "serde_with",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -776,8 +906,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -795,12 +935,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -812,6 +976,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -840,6 +1035,9 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "derive_builder"
@@ -856,7 +1054,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -914,6 +1112,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "docker_credential"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29547a1dc60885a552306986316bc9701ba120c1a8db6769fa68691529ad373d"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +1133,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -986,6 +1201,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c7b13d0780cb82722fd59f6f57f925e143427e4a75313a6c77243bf5326ae6"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,6 +1226,16 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1068,6 +1304,21 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-channel"
@@ -1142,6 +1393,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1227,7 +1479,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.13.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1244,6 +1496,12 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1402,6 +1660,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-named-pipe"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fab3637d6b04a8037af8a266fdf6cf92ea957e8c53981a2bf6136572531025bf"
+dependencies = [
+ "hex",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1453,6 +1725,21 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1596,6 +1883,17 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
@@ -1673,6 +1971,59 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jni"
@@ -1801,7 +2152,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
  "plain",
  "redox_syscall 0.9.2",
@@ -2026,6 +2377,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2086,6 +2451,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2113,7 +2489,7 @@ version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
  "once_cell",
  "onig_sys",
@@ -2147,7 +2523,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2355,6 +2731,31 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "parse-display"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
+dependencies = [
+ "parse-display-derive",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax",
+ "structmeta",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2988,6 +3389,7 @@ dependencies = [
  "chrono",
  "clap",
  "predicates",
+ "rand 0.10.1",
  "redact-core",
  "regex",
  "reqwest",
@@ -2995,6 +3397,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "sqlx",
+ "testcontainers-modules",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3025,7 +3428,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -3034,7 +3437,27 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c93da5bb2c5d4e6c0ef7abeead62c89169a0a4882bfb83ac892f2423aea2fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3190,7 +3613,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3204,6 +3627,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3222,6 +3646,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3304,6 +3737,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3315,7 +3772,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3387,7 +3844,7 @@ version = "0.9.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.1",
  "itoa",
  "ryu",
  "serde",
@@ -3406,6 +3863,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3415,6 +3883,39 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
+dependencies = [
+ "base64 0.22.1",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.13.1",
+ "jiff",
+ "schemars 0.9.0",
+ "schemars 1.2.2",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3596,7 +4097,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap",
+ "indexmap 2.13.1",
  "log",
  "memchr",
  "once_cell",
@@ -3661,7 +4162,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags",
+ "bitflags 2.11.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -3705,12 +4206,12 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags",
+ "bitflags 2.11.0",
  "byteorder",
  "chrono",
  "crc",
  "dotenvy",
- "etcetera",
+ "etcetera 0.8.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -3792,6 +4293,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3868,7 +4392,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -3901,6 +4425,44 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "testcontainers"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3ac71069f20ecfa60c396316c283fbf35e6833a53dff551a31b5458da05edc"
+dependencies = [
+ "astral-tokio-tar",
+ "async-trait",
+ "bollard",
+ "bytes",
+ "docker_credential",
+ "either",
+ "etcetera 0.10.0",
+ "futures",
+ "log",
+ "memchr",
+ "parse-display",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "ulid",
+ "url",
+]
+
+[[package]]
+name = "testcontainers-modules"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1966329d5bb3f89d33602d2db2da971fb839f9297dad16527abf4564e2ae0a6d"
+dependencies = [
+ "testcontainers",
+]
 
 [[package]]
 name = "thiserror"
@@ -4119,8 +4681,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
+ "axum",
  "base64 0.22.1",
  "bytes",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -4129,6 +4693,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
+ "socket2",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
@@ -4168,7 +4733,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 2.13.1",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -4185,7 +4750,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -4314,6 +4879,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.3",
+ "web-time",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4418,6 +4993,7 @@ dependencies = [
  "log",
  "native-tls",
  "percent-encoding",
+ "rustls",
  "rustls-pki-types",
  "socks",
  "ureq-proto",
@@ -4447,6 +5023,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -4685,7 +5262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.1",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -4709,9 +5286,9 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.1",
  "semver",
 ]
 
@@ -4896,6 +5473,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -5189,7 +5775,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.13.1",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -5219,8 +5805,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
- "indexmap",
+ "bitflags 2.11.0",
+ "indexmap 2.13.1",
  "log",
  "serde",
  "serde_derive",
@@ -5239,7 +5825,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.13.1",
  "log",
  "semver",
  "serde",
@@ -5254,6 +5840,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -137,7 +137,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -184,15 +184,15 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.5.6"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
+checksum = "b18457efd137254e016bbde5e1d88df61c4e1a5ae2223746e56123bac6af2463"
 dependencies = [
- "filetime",
  "futures-core",
  "libc",
  "portable-atomic",
  "rustc-hash",
+ "rustix",
  "tokio",
  "tokio-stream",
  "xattr",
@@ -394,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "bollard"
-version = "0.19.4"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a52479c9237eb04047ddb94788c41ca0d26eaff8b697ecfbb4c32f7fdc3b1b"
+checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -404,7 +404,6 @@ dependencies = [
  "bollard-buildkit-proto",
  "bollard-stubs",
  "bytes",
- "chrono",
  "futures-core",
  "futures-util",
  "hex",
@@ -422,14 +421,13 @@ dependencies = [
  "rand 0.9.3",
  "rustls",
  "rustls-native-certs",
- "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_derive",
  "serde_json",
- "serde_repr",
  "serde_urlencoded",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -454,19 +452,18 @@ dependencies = [
 
 [[package]]
 name = "bollard-stubs"
-version = "1.49.1-rc.28.4.0"
+version = "1.52.1-rc.29.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5731fe885755e92beff1950774068e0cae67ea6ec7587381536fca84f1779623"
+checksum = "0f0a8ca8799131c1837d1282c3f81f31e76ceb0ce426e04a7fe1ccee3287c066"
 dependencies = [
  "base64 0.22.1",
  "bollard-buildkit-proto",
  "bytes",
- "chrono",
  "prost",
  "serde",
  "serde_json",
  "serde_repr",
- "serde_with",
+ "time",
 ]
 
 [[package]]
@@ -1177,7 +1174,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1202,13 +1199,12 @@ dependencies = [
 
 [[package]]
 name = "etcetera"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c7b13d0780cb82722fd59f6f57f925e143427e4a75313a6c77243bf5326ae6"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
- "home",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1228,13 +1224,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
-name = "filetime"
-version = "0.2.29"
+name = "ferroid"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+checksum = "ee93edf3c501f0035bbeffeccfed0b79e14c311f12195ec0e661e114a0f60da4"
 dependencies = [
- "cfg-if",
- "libc",
+ "portable-atomic",
+ "rand 0.10.1",
+ "web-time",
 ]
 
 [[package]]
@@ -2373,7 +2370,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3028,7 +3025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3617,7 +3614,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3649,15 +3646,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3685,7 +3673,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4020,7 +4008,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4417,7 +4405,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4428,9 +4416,9 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "testcontainers"
-version = "0.25.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f3ac71069f20ecfa60c396316c283fbf35e6833a53dff551a31b5458da05edc"
+checksum = "bfd5785b5483672915ed5fe3cddf9f546802779fc1eceff0a6fb7321fac81c1e"
 dependencies = [
  "astral-tokio-tar",
  "async-trait",
@@ -4438,8 +4426,11 @@ dependencies = [
  "bytes",
  "docker_credential",
  "either",
- "etcetera 0.10.0",
+ "etcetera 0.11.0",
+ "ferroid",
  "futures",
+ "http",
+ "itertools 0.14.0",
  "log",
  "memchr",
  "parse-display",
@@ -4451,15 +4442,14 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "ulid",
  "url",
 ]
 
 [[package]]
 name = "testcontainers-modules"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1966329d5bb3f89d33602d2db2da971fb839f9297dad16527abf4564e2ae0a6d"
+checksum = "e5985fde5befe4ffa77a052e035e16c2da86e8bae301baa9f9904ad3c494d357"
 dependencies = [
  "testcontainers",
 ]
@@ -4877,16 +4867,6 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
-name = "ulid"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
-dependencies = [
- "rand 0.9.3",
- "web-time",
-]
 
 [[package]]
 name = "unicode-bidi"
@@ -5371,7 +5351,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5473,15 +5453,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2693,7 +2693,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "tempfile",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +194,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,6 +312,9 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "blake3"
@@ -310,6 +328,15 @@ dependencies = [
  "cfg-if",
  "constant_time_eq",
  "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -555,6 +582,12 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -610,6 +643,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,6 +707,15 @@ name = "crossbeam-epoch"
 version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -759,11 +816,22 @@ dependencies = [
 
 [[package]]
 name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
- "pem-rfc7468",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -812,12 +880,24 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
+name = "digest"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
- "block-buffer",
- "const-oid",
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
  "crypto-common 0.2.1",
  "ctutils",
 ]
@@ -834,6 +914,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +930,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -886,6 +975,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -904,6 +1014,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
 ]
 
 [[package]]
@@ -973,6 +1094,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1119,6 +1251,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -1129,10 +1263,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "hmac"
@@ -1140,7 +1307,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1148,6 +1315,15 @@ name = "hmac-sha256"
 version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "http"
@@ -1587,6 +1763,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -1615,6 +1794,28 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall 0.9.2",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1694,6 +1895,16 @@ checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
 dependencies = [
  "autocfg",
  "rawpointer",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1825,6 +2036,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.7",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1845,6 +2072,16 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
  "num-traits",
 ]
 
@@ -2092,6 +2329,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2109,7 +2352,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -2126,9 +2369,9 @@ version = "0.13.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f24f3eb2f4471b1730d59e4b730b747939960a8c7eb0c33c5a9076f2d3dddea"
 dependencies = [
- "digest",
- "hmac",
- "sha2",
+ "digest 0.11.2",
+ "hmac 0.13.0",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -2139,6 +2382,15 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64 0.22.1",
  "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -2183,10 +2435,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der 0.7.10",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.10",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -2462,11 +2741,22 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -2479,6 +2769,16 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.2",
  "rand_core 0.10.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2601,7 +2901,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tracing",
  "uuid",
@@ -2648,7 +2948,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_norway",
- "sha2",
+ "sha2 0.11.0",
  "subtle",
  "tempfile",
  "thiserror 2.0.18",
@@ -2692,7 +2992,11 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
+ "sqlx",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -2719,6 +3023,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1c93da5bb2c5d4e6c0ef7abeead62c89169a0a4882bfb83ac892f2423aea2fe"
 dependencies = [
  "bitflags",
 ]
@@ -2811,6 +3124,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2871,6 +3204,7 @@ checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3083,6 +3417,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3090,7 +3446,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -3124,6 +3480,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -3150,6 +3507,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -3173,6 +3533,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der 0.7.10",
+]
+
+[[package]]
 name = "spm_precompiled"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3182,6 +3561,204 @@ dependencies = [
  "nom",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 2.0.117",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest 0.10.7",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac 0.12.1",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.7",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac 0.12.1",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.7",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -3195,6 +3772,17 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -3725,10 +4313,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-normalization-alignments"
@@ -3738,6 +4341,12 @@ checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
 dependencies = [
  "smallvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -3804,7 +4413,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
- "der",
+ "der 0.8.0",
  "log",
  "native-tls",
  "percent-encoding",
@@ -3957,6 +4566,12 @@ checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -4129,6 +4744,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4240,6 +4883,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4278,6 +4930,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4321,6 +4988,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4339,6 +5012,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4354,6 +5033,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4387,6 +5072,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4402,6 +5093,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4423,6 +5120,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4438,6 +5141,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/redact-wasm",
     "crates/redact-cli",
     "crates/redact-gateway",
+    "crates/redact-scan",
 ]
 resolver = "2"
 
@@ -59,7 +60,7 @@ pbkdf2 = { version = "0.13.0-rc.10", features = ["hmac", "sha2"] }
 rand = "0.10"
 
 # Time handling
-chrono = { version = "0.4", default-features = false, features = ["serde", "std"] }
+chrono = { version = "0.4", default-features = false, features = ["serde", "std", "clock"] }
 
 # UUID generation
 uuid = { version = "1.23", features = ["v4", "serde"] }
@@ -72,6 +73,9 @@ criterion = "0.8"
 
 # HTTP client (for examples)
 reqwest = { version = "0.13", features = ["json"] }
+
+# Postgres (redact-scan only — never add to redact-core)
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "postgres", "tls-rustls-ring", "chrono", "uuid", "macros"] }
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ pbkdf2 = { version = "0.13.0-rc.10", features = ["hmac", "sha2"] }
 rand = "0.10"
 
 # Time handling
-chrono = { version = "0.4", default-features = false, features = ["serde", "std", "clock"] }
+chrono = { version = "0.4", default-features = false, features = ["serde", "std"] }
 
 # UUID generation
 uuid = { version = "1.23", features = ["v4", "serde"] }

--- a/README.md
+++ b/README.md
@@ -659,6 +659,7 @@ redact/
 │   ├── redact-ner/       # ONNX NER integration (optional engine add-on)
 │   ├── redact-api/       # REST API service (Axum) over the same engine
 │   ├── redact-cli/       # Command-line tool
+│   ├── redact-scan/      # Read-only Postgres PII discovery scanner
 │   └── redact-wasm/      # WebAssembly bindings (pattern engine)
 ├── docs/
 │   ├── gateway/          # Gateway operator documentation

--- a/crates/redact-scan/Cargo.toml
+++ b/crates/redact-scan/Cargo.toml
@@ -27,6 +27,7 @@ uuid = { workspace = true }
 sha2 = { workspace = true }
 chrono = { workspace = true, features = ["clock"] }
 regex = { workspace = true }
+reqwest = { workspace = true }
 
 [[bin]]
 name = "redact-scan"

--- a/crates/redact-scan/Cargo.toml
+++ b/crates/redact-scan/Cargo.toml
@@ -36,7 +36,7 @@ path = "src/main.rs"
 [dev-dependencies]
 assert_cmd = "2.2"
 predicates = "3.1"
-testcontainers-modules = { version = "0.13", features = ["postgres"] }
+testcontainers-modules = { version = "0.15", features = ["postgres"] }
 rand = { workspace = true }
 tokio = { workspace = true }
 sqlx = { workspace = true }

--- a/crates/redact-scan/Cargo.toml
+++ b/crates/redact-scan/Cargo.toml
@@ -15,13 +15,17 @@ categories = ["command-line-utilities", "database"]
 
 [dependencies]
 redact-core = { path = "../redact-core", version = "0.9.1" }
+sqlx = { workspace = true }
+tokio = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
 sha2 = { workspace = true }
-chrono = { workspace = true }
+chrono = { workspace = true, features = ["clock"] }
 regex = { workspace = true }
 
 [[bin]]

--- a/crates/redact-scan/Cargo.toml
+++ b/crates/redact-scan/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "redact-scan"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme = "README.md"
+documentation = "https://docs.rs/redact-scan"
+description = "Read-only Postgres PII discovery scanner"
+keywords = ["pii", "postgres", "privacy", "gdpr", "discovery"]
+categories = ["command-line-utilities", "database"]
+
+[dependencies]
+redact-core = { path = "../redact-core", version = "0.9.1" }
+clap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+uuid = { workspace = true }
+sha2 = { workspace = true }
+chrono = { workspace = true }
+regex = { workspace = true }
+
+[[bin]]
+name = "redact-scan"
+path = "src/main.rs"
+
+[dev-dependencies]
+assert_cmd = "2.2"
+predicates = "3.1"
+tempfile = "3.27"
+serde_json = { workspace = true }
+redact-core = { path = "../redact-core", version = "0.9.1" }
+chrono = { workspace = true }
+uuid = { workspace = true }

--- a/crates/redact-scan/Cargo.toml
+++ b/crates/redact-scan/Cargo.toml
@@ -31,8 +31,3 @@ path = "src/main.rs"
 [dev-dependencies]
 assert_cmd = "2.2"
 predicates = "3.1"
-tempfile = "3.27"
-serde_json = { workspace = true }
-redact-core = { path = "../redact-core", version = "0.9.1" }
-chrono = { workspace = true }
-uuid = { workspace = true }

--- a/crates/redact-scan/Cargo.toml
+++ b/crates/redact-scan/Cargo.toml
@@ -36,3 +36,9 @@ path = "src/main.rs"
 [dev-dependencies]
 assert_cmd = "2.2"
 predicates = "3.1"
+testcontainers-modules = { version = "0.13", features = ["postgres"] }
+rand = { workspace = true }
+tokio = { workspace = true }
+sqlx = { workspace = true }
+clap = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/redact-scan/README.md
+++ b/crates/redact-scan/README.md
@@ -8,3 +8,41 @@ redact-scan --url postgres://reader@localhost/app --schema public --out report.j
 ```
 
 The report lists table/column locations and entity types. It never includes sample values.
+
+See [docs/scanning-model.md](../../docs/scanning-model.md) for the four discovery layers and safety rails.
+
+## Sample report
+
+```json
+{
+  "scan_id": "00000000-0000-0000-0000-000000000001",
+  "scanned_at": "2026-08-15T00:00:00Z",
+  "target": {
+    "fingerprint": "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+    "engine": "postgres",
+    "version": "16.4"
+  },
+  "scanner": {
+    "version": "0.9.1",
+    "pattern_pack": "builtin@54"
+  },
+  "sampling": {
+    "layers": [0.0, 0.5, 1.0, 2.0],
+    "rows_per_column": 1000,
+    "method": "TABLESAMPLE SYSTEM"
+  },
+  "findings": [
+    {
+      "table": "public.customers",
+      "column": "email",
+      "entity_type": "EMAIL_ADDRESS",
+      "layer": 0.0,
+      "match_count": 0,
+      "sampled_rows": 0,
+      "confidence": 0.85,
+      "evidence_class": "name_heuristic"
+    }
+  ],
+  "content_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+```

--- a/crates/redact-scan/README.md
+++ b/crates/redact-scan/README.md
@@ -1,0 +1,10 @@
+# redact-scan
+
+Read-only Postgres PII discovery scanner. Prefer a replica or staging database.
+
+```bash
+cargo install --path crates/redact-scan
+redact-scan --url postgres://reader@localhost/app --schema public --out report.json
+```
+
+The report lists table/column locations and entity types. It never includes sample values.

--- a/crates/redact-scan/README.md
+++ b/crates/redact-scan/README.md
@@ -24,7 +24,7 @@ See [docs/scanning-model.md](../../docs/scanning-model.md) for the four discover
   },
   "scanner": {
     "version": "0.9.1",
-    "pattern_pack": "builtin@54"
+    "pattern_pack": "builtin@<supported-entity-count>"
   },
   "sampling": {
     "layers": [0.0, 0.5, 1.0, 2.0],

--- a/crates/redact-scan/src/bound.rs
+++ b/crates/redact-scan/src/bound.rs
@@ -1,0 +1,35 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Rule of three for negative sampling results.
+
+/// If 0 matches in `n` samples, the 95% CI upper bound is `3/n`.
+pub fn prevalence_upper_95(sampled_rows: u64, match_count: u64) -> Option<f64> {
+    if match_count != 0 || sampled_rows == 0 {
+        return None;
+    }
+    Some(3.0 / sampled_rows as f64)
+}
+
+/// Human-readable rule-of-three note for table output.
+pub fn rule_of_three_message(sampled_rows: u64) -> String {
+    let bound = prevalence_upper_95(sampled_rows, 0).unwrap_or(0.0);
+    format!(
+        "0 matches in {sampled_rows} sampled rows; prevalence above {:.1}% is unlikely at 95% confidence.",
+        bound * 100.0
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn thousand_rows_is_point_three_percent() {
+        let p = prevalence_upper_95(1000, 0).unwrap();
+        assert!((p - 0.003).abs() < 1e-12);
+        let msg = rule_of_three_message(1000);
+        assert!(msg.contains("0.3%"));
+    }
+}

--- a/crates/redact-scan/src/canonical.rs
+++ b/crates/redact-scan/src/canonical.rs
@@ -7,7 +7,9 @@ use serde::Serialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
-/// SHA-256 of canonical JSON with `content_hash` omitted / empty.
+/// SHA-256 hex of RFC 8785-style canonical JSON with `content_hash` omitted.
+///
+/// Object keys are sorted; insignificant whitespace is omitted.
 pub fn content_hash<T: Serialize>(report: &T) -> Result<String> {
     let mut value = serde_json::to_value(report)?;
     if let Value::Object(map) = &mut value {
@@ -47,12 +49,38 @@ fn canonical_value(value: &Value) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
+    use serde::Serialize;
+
+    #[derive(Serialize)]
+    struct First {
+        b: i32,
+        a: i32,
+        content_hash: String,
+    }
+
+    #[derive(Serialize)]
+    struct Second {
+        a: i32,
+        b: i32,
+    }
 
     #[test]
-    fn hash_is_stable_under_key_order() {
-        let a = json!({"b": 1, "a": 2, "content_hash": "x"});
-        let b = json!({"a": 2, "b": 1});
-        assert_eq!(content_hash(&a).unwrap(), content_hash(&b).unwrap());
+    fn hash_is_stable_under_struct_field_order() {
+        let first = First {
+            b: 1,
+            a: 2,
+            content_hash: "ignored".into(),
+        };
+        let second = Second { a: 2, b: 1 };
+        let first_json = serde_json::to_string(&first).unwrap();
+        let second_json = serde_json::to_string(&second).unwrap();
+        assert_ne!(
+            first_json, second_json,
+            "fixture must serialize keys in different orders"
+        );
+        assert_eq!(
+            content_hash(&first).unwrap(),
+            content_hash(&second).unwrap()
+        );
     }
 }

--- a/crates/redact-scan/src/canonical.rs
+++ b/crates/redact-scan/src/canonical.rs
@@ -7,16 +7,16 @@ use serde::Serialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
-/// SHA-256 hex of RFC 8785-style canonical JSON with `content_hash` omitted.
+/// SHA-256 hex of canonical JSON with `content_hash` omitted.
 ///
-/// Object keys are sorted; insignificant whitespace is omitted.
+/// Object keys are sorted recursively; `serde_json` compact encoding is used
+/// (no insignificant whitespace). This is not a full RFC 8785 implementation.
 pub fn content_hash<T: Serialize>(report: &T) -> Result<String> {
     let mut value = serde_json::to_value(report)?;
     if let Value::Object(map) = &mut value {
         map.remove("content_hash");
     }
-    let canonical = canonicalize(&value)?;
-    Ok(hex_sha256(canonical.as_bytes()))
+    Ok(hex_sha256(canonicalize(&value).as_bytes()))
 }
 
 pub(crate) fn hex_sha256(bytes: &[u8]) -> String {
@@ -26,8 +26,8 @@ pub(crate) fn hex_sha256(bytes: &[u8]) -> String {
         .collect()
 }
 
-fn canonicalize(value: &Value) -> Result<String> {
-    Ok(canonical_value(value).to_string())
+fn canonicalize(value: &Value) -> String {
+    canonical_value(value).to_string()
 }
 
 fn canonical_value(value: &Value) -> Value {

--- a/crates/redact-scan/src/canonical.rs
+++ b/crates/redact-scan/src/canonical.rs
@@ -1,0 +1,58 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+use anyhow::Result;
+use serde::Serialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+/// SHA-256 of canonical JSON with `content_hash` omitted / empty.
+pub fn content_hash<T: Serialize>(report: &T) -> Result<String> {
+    let mut value = serde_json::to_value(report)?;
+    if let Value::Object(map) = &mut value {
+        map.remove("content_hash");
+    }
+    let canonical = canonicalize(&value)?;
+    Ok(hex_sha256(canonical.as_bytes()))
+}
+
+pub(crate) fn hex_sha256(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
+
+fn canonicalize(value: &Value) -> Result<String> {
+    Ok(canonical_value(value).to_string())
+}
+
+fn canonical_value(value: &Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            let mut out = serde_json::Map::new();
+            for k in keys {
+                out.insert(k.clone(), canonical_value(&map[k]));
+            }
+            Value::Object(out)
+        }
+        Value::Array(items) => Value::Array(items.iter().map(canonical_value).collect()),
+        other => other.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn hash_is_stable_under_key_order() {
+        let a = json!({"b": 1, "a": 2, "content_hash": "x"});
+        let b = json!({"a": 2, "b": 1});
+        assert_eq!(content_hash(&a).unwrap(), content_hash(&b).unwrap());
+    }
+}

--- a/crates/redact-scan/src/canonical.rs
+++ b/crates/redact-scan/src/canonical.rs
@@ -12,7 +12,9 @@ use sha2::{Digest, Sha256};
 /// Object keys are sorted recursively; `serde_json` compact encoding is used
 /// (no insignificant whitespace). This is not a full RFC 8785 implementation.
 pub fn content_hash<T: Serialize>(report: &T) -> Result<String> {
-    let mut value = serde_json::to_value(report)?;
+    // Serialize first so f32 confidence matches the JSON written to --out.
+    let text = serde_json::to_string(report)?;
+    let mut value: Value = serde_json::from_str(&text)?;
     if let Value::Object(map) = &mut value {
         map.remove("content_hash");
     }

--- a/crates/redact-scan/src/catalog.rs
+++ b/crates/redact-scan/src/catalog.rs
@@ -119,30 +119,13 @@ pub fn l0_findings(columns: &[ColumnMeta]) -> Vec<Finding> {
                 confidence: 0.8,
                 evidence_class: EvidenceClass::TypeSignal,
             });
-            continue;
-        }
-        if is_date_type(&col.udt) {
-            if let Some((entity_type, confidence)) = name_entity(&col.column) {
-                if matches!(entity_type, redact_core::EntityType::DateTime) {
-                    out.push(Finding {
-                        table,
-                        column: col.column.clone(),
-                        json_path: None,
-                        entity_type,
-                        layer: ScanLayer::Metadata,
-                        match_count: 0,
-                        sampled_rows: 0,
-                        confidence,
-                        evidence_class: EvidenceClass::NameHeuristic,
-                    });
-                }
-            }
         }
         let _ = (
             col.unique_text,
             col.fk_to_subject,
             is_json_type(&col.udt),
             is_textish(&col.udt),
+            is_date_type(&col.udt),
             &col.comment,
         );
     }

--- a/crates/redact-scan/src/catalog.rs
+++ b/crates/redact-scan/src/catalog.rs
@@ -1,0 +1,210 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Layer 0: `pg_catalog` / `information_schema` metadata. No user-table reads.
+
+use sqlx::PgPool;
+
+use crate::error::ScanError;
+use crate::layers::ScanLayer;
+use crate::report::{EvidenceClass, Finding};
+use crate::score::{is_date_type, is_inet_type, is_json_type, is_textish, name_entity};
+
+/// Catalog row for one column.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct ColumnMeta {
+    /// Schema name.
+    pub schema: String,
+    /// Table / view name.
+    pub table: String,
+    /// Column name.
+    pub column: String,
+    /// `pg_type.typname`.
+    pub udt: String,
+    /// `pg_class.relkind` (`r`, `p`, `v`, `m`).
+    pub relkind: String,
+    /// Estimated live tuples (`0` if unknown).
+    pub n_live_tup: i64,
+    /// Column comment, if any.
+    pub comment: Option<String>,
+    /// Unique btree on this text-like column.
+    pub unique_text: bool,
+    /// Table has an FK toward a subject-like table.
+    pub fk_to_subject: bool,
+}
+
+/// Load column metadata for `schema`. Never `SELECT`s user tables.
+pub async fn load_columns(pool: &PgPool, schema: &str) -> Result<Vec<ColumnMeta>, ScanError> {
+    let rows = sqlx::query_as::<_, ColumnMeta>(
+        r#"
+        SELECT
+          n.nspname AS schema,
+          c.relname AS table,
+          a.attname AS column,
+          t.typname AS udt,
+          c.relkind::text AS relkind,
+          COALESCE(s.n_live_tup, 0) AS n_live_tup,
+          col_description(c.oid, a.attnum) AS comment,
+          EXISTS (
+            SELECT 1
+            FROM pg_index i
+            JOIN pg_attribute ia ON ia.attrelid = i.indrelid AND ia.attnum = ANY (i.indkey)
+            WHERE i.indrelid = c.oid
+              AND i.indisunique
+              AND ia.attname = a.attname
+              AND t.typname IN ('varchar', 'text', 'bpchar', 'citext')
+          ) AS unique_text,
+          EXISTS (
+            SELECT 1
+            FROM pg_constraint fk
+            JOIN pg_class ref ON ref.oid = fk.confrelid
+            WHERE fk.conrelid = c.oid
+              AND fk.contype = 'f'
+              AND (
+                ref.relname ILIKE '%user%'
+                OR ref.relname ILIKE '%customer%'
+                OR ref.relname ILIKE '%subject%'
+                OR ref.relname ILIKE '%patient%'
+                OR ref.relname ILIKE '%account%'
+              )
+          ) AS fk_to_subject
+        FROM pg_attribute a
+        JOIN pg_class c ON c.oid = a.attrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        JOIN pg_type t ON t.oid = a.atttypid
+        LEFT JOIN pg_stat_user_tables s ON s.relid = c.oid
+        WHERE n.nspname = $1
+          AND a.attnum > 0
+          AND NOT a.attisdropped
+          AND c.relkind IN ('r', 'p', 'v', 'm')
+        ORDER BY c.relname, a.attnum
+        "#,
+    )
+    .bind(schema)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+/// Emit L0 findings from names and native types. JSON/unconstrained text
+/// without a name match are candidates only.
+pub fn l0_findings(columns: &[ColumnMeta]) -> Vec<Finding> {
+    let mut out = Vec::new();
+    for col in columns {
+        let table = format!("{}.{}", col.schema, col.table);
+        if let Some((entity_type, confidence)) = name_entity(&col.column) {
+            out.push(Finding {
+                table,
+                column: col.column.clone(),
+                json_path: None,
+                entity_type,
+                layer: ScanLayer::Metadata,
+                match_count: 0,
+                sampled_rows: 0,
+                confidence,
+                evidence_class: EvidenceClass::NameHeuristic,
+            });
+            continue;
+        }
+        if is_inet_type(&col.udt) {
+            out.push(Finding {
+                table,
+                column: col.column.clone(),
+                json_path: None,
+                entity_type: redact_core::EntityType::IpAddress,
+                layer: ScanLayer::Metadata,
+                match_count: 0,
+                sampled_rows: 0,
+                confidence: 0.8,
+                evidence_class: EvidenceClass::TypeSignal,
+            });
+            continue;
+        }
+        if is_date_type(&col.udt) {
+            if let Some((entity_type, confidence)) = name_entity(&col.column) {
+                if matches!(entity_type, redact_core::EntityType::DateTime) {
+                    out.push(Finding {
+                        table,
+                        column: col.column.clone(),
+                        json_path: None,
+                        entity_type,
+                        layer: ScanLayer::Metadata,
+                        match_count: 0,
+                        sampled_rows: 0,
+                        confidence,
+                        evidence_class: EvidenceClass::NameHeuristic,
+                    });
+                }
+            }
+        }
+        let _ = (
+            col.unique_text,
+            col.fk_to_subject,
+            is_json_type(&col.udt),
+            is_textish(&col.udt),
+            &col.comment,
+        );
+    }
+    out
+}
+
+/// Columns worth examining in later layers.
+pub fn candidates<'a>(columns: &'a [ColumnMeta], findings: &[Finding]) -> Vec<&'a ColumnMeta> {
+    columns
+        .iter()
+        .filter(|c| {
+            if is_json_type(&c.udt) || is_inet_type(&c.udt) || is_textish(&c.udt) {
+                return true;
+            }
+            if c.unique_text || c.fk_to_subject {
+                return true;
+            }
+            let q = format!("{}.{}", c.schema, c.table);
+            findings
+                .iter()
+                .any(|f| f.table == q && f.column == c.column)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn col(name: &str, udt: &str) -> ColumnMeta {
+        ColumnMeta {
+            schema: "public".into(),
+            table: "t".into(),
+            column: name.into(),
+            udt: udt.into(),
+            relkind: "r".into(),
+            n_live_tup: 10,
+            comment: None,
+            unique_text: false,
+            fk_to_subject: false,
+        }
+    }
+
+    #[test]
+    fn name_match_is_finding_json_is_candidate_only() {
+        let cols = vec![
+            col("email", "text"),
+            col("payload", "jsonb"),
+            col("n", "int4"),
+        ];
+        let findings = l0_findings(&cols);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].column, "email");
+        let cand = candidates(&cols, &findings);
+        assert!(cand.iter().any(|c| c.column == "payload"));
+        assert!(cand.iter().all(|c| c.column != "n"));
+    }
+
+    #[test]
+    fn inet_without_name_is_type_signal() {
+        let cols = vec![col("src", "inet")];
+        let findings = l0_findings(&cols);
+        assert_eq!(findings[0].evidence_class, EvidenceClass::TypeSignal);
+    }
+}

--- a/crates/redact-scan/src/cli.rs
+++ b/crates/redact-scan/src/cli.rs
@@ -1,0 +1,152 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+use anyhow::{anyhow, Result};
+use clap::{Parser, ValueEnum};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use crate::layers::{default_layers, parse_layers, ScanLayer};
+
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
+pub enum OutputFormat {
+    Json,
+    Table,
+}
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "redact-scan",
+    about = "Read-only Postgres PII discovery scanner",
+    version
+)]
+pub struct Cli {
+    /// Postgres connection URL (also reads DATABASE_URL)
+    #[arg(long, env = "DATABASE_URL")]
+    pub url: Option<String>,
+
+    /// Schema to scan
+    #[arg(long, default_value = "public")]
+    pub schema: String,
+
+    /// Comma-separated layers: 0,0.5,1,2
+    #[arg(long, default_value = "0,0.5,1,2")]
+    pub layers: String,
+
+    /// Maximum rows to sample per candidate column
+    #[arg(long, default_value_t = 1000)]
+    pub sample_rows: u32,
+
+    /// Statement timeout (e.g. 30s)
+    #[arg(long, default_value = "30s")]
+    pub statement_timeout: String,
+
+    /// Output format
+    #[arg(long, value_enum, default_value_t = OutputFormat::Json)]
+    pub format: OutputFormat,
+
+    /// Write the report to this path
+    #[arg(long)]
+    pub out: Option<PathBuf>,
+
+    /// Optional HTTP endpoint that receives the report JSON
+    #[arg(long)]
+    pub report_url: Option<String>,
+
+    /// Bearer token for --report-url (also reads REDACT_SCAN_API_KEY)
+    #[arg(long, env = "REDACT_SCAN_API_KEY")]
+    pub api_key: Option<String>,
+
+    /// Extra header for --report-url, repeatable (`Name: value`)
+    #[arg(long = "report-header")]
+    pub report_headers: Vec<String>,
+
+    /// Exit 1 when findings match this entity type, or `any`
+    #[arg(long)]
+    pub fail_on: Option<String>,
+
+    /// Write local debug samples (incompatible with --report-url)
+    #[arg(long)]
+    pub include_samples: bool,
+
+    /// Path for local debug samples (required with --include-samples and --format json)
+    #[arg(long)]
+    pub samples_out: Option<PathBuf>,
+}
+
+impl Cli {
+    pub fn parsed_layers(&self) -> Result<Vec<ScanLayer>> {
+        if self.layers.trim().is_empty() {
+            return Ok(default_layers());
+        }
+        parse_layers(&self.layers)
+    }
+
+    pub fn statement_timeout(&self) -> Result<Duration> {
+        parse_duration(&self.statement_timeout)
+    }
+
+    /// Reject unsafe flag combinations before any network I/O.
+    pub fn validate_preflight(&self) -> Result<()> {
+        if self.include_samples && self.report_url.is_some() {
+            return Err(anyhow!(
+                "--include-samples cannot be used with --report-url"
+            ));
+        }
+        if self.include_samples && self.format == OutputFormat::Json && self.samples_out.is_none() {
+            return Err(anyhow!(
+                "--include-samples with --format json requires --samples-out"
+            ));
+        }
+        if self.url.is_none() && self.report_url.is_none() {
+            // Allow --include-samples + --report-url error path without --url.
+            // A real scan still needs --url; checked in run().
+        }
+        Ok(())
+    }
+}
+
+pub fn parse_duration(s: &str) -> Result<Duration> {
+    let s = s.trim();
+    if let Some(ms) = s.strip_suffix("ms") {
+        let n: u64 = ms.parse()?;
+        return Ok(Duration::from_millis(n));
+    }
+    if let Some(sec) = s.strip_suffix('s') {
+        let n: u64 = sec.parse()?;
+        return Ok(Duration::from_secs(n));
+    }
+    if let Some(min) = s.strip_suffix('m') {
+        let n: u64 = min.parse()?;
+        return Ok(Duration::from_secs(n * 60));
+    }
+    let n: u64 = s.parse()?;
+    Ok(Duration::from_secs(n))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn include_samples_with_report_url_is_rejected() {
+        let cli = Cli::parse_from([
+            "redact-scan",
+            "--include-samples",
+            "--report-url",
+            "http://127.0.0.1:9/hook",
+            "--samples-out",
+            "/tmp/s.json",
+        ]);
+        let err = cli.validate_preflight().unwrap_err().to_string();
+        assert!(err.contains("--include-samples"));
+        assert!(err.contains("--report-url"));
+    }
+
+    #[test]
+    fn duration_parse() {
+        assert_eq!(parse_duration("30s").unwrap(), Duration::from_secs(30));
+        assert_eq!(parse_duration("500ms").unwrap(), Duration::from_millis(500));
+    }
+}

--- a/crates/redact-scan/src/cli.rs
+++ b/crates/redact-scan/src/cli.rs
@@ -4,78 +4,120 @@
 
 use anyhow::{anyhow, Result};
 use clap::{Parser, ValueEnum};
+use std::fmt;
 use std::path::PathBuf;
 use std::time::Duration;
 
 use crate::layers::{default_layers, parse_layers, ScanLayer};
+use crate::scrub::scrub;
 
-#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
+/// Report rendering format.
+#[derive(Clone, Copy, ValueEnum, PartialEq, Eq)]
 pub enum OutputFormat {
+    /// Pretty-printed `ScanReport` JSON.
     Json,
+    /// Human-readable table (no sample values).
     Table,
 }
 
-#[derive(Debug, Parser)]
-#[command(
-    name = "redact-scan",
-    about = "Read-only Postgres PII discovery scanner",
-    version
-)]
+/// Read-only Postgres PII discovery scanner.
+///
+/// Prefer a replica or staging database. Debug formatting redacts
+/// connection URLs and API keys.
+#[derive(Parser)]
+#[command(name = "redact-scan", version)]
 pub struct Cli {
-    /// Postgres connection URL (also reads DATABASE_URL)
+    /// Postgres connection URL (also reads `DATABASE_URL`).
     #[arg(long, env = "DATABASE_URL")]
     pub url: Option<String>,
 
-    /// Schema to scan
+    /// Schema to scan.
     #[arg(long, default_value = "public")]
     pub schema: String,
 
-    /// Comma-separated layers: 0,0.5,1,2
+    /// Comma-separated layers: `0,0.5,1,2`.
     #[arg(long, default_value = "0,0.5,1,2")]
     pub layers: String,
 
-    /// Maximum rows to sample per candidate column
+    /// Maximum rows to sample per candidate column.
     #[arg(long, default_value_t = 1000)]
     pub sample_rows: u32,
 
-    /// Statement timeout (e.g. 30s)
+    /// Statement timeout (for example `30s`).
     #[arg(long, default_value = "30s")]
     pub statement_timeout: String,
 
-    /// Output format
+    /// Output format.
     #[arg(long, value_enum, default_value_t = OutputFormat::Json)]
     pub format: OutputFormat,
 
-    /// Write the report to this path
+    /// Write the report JSON to this path.
     #[arg(long)]
     pub out: Option<PathBuf>,
 
-    /// Optional HTTP endpoint that receives the report JSON
+    /// Optional HTTP endpoint that receives the report JSON.
     #[arg(long)]
     pub report_url: Option<String>,
 
-    /// Bearer token for --report-url (also reads REDACT_SCAN_API_KEY)
+    /// Bearer token for `--report-url` (also reads `REDACT_SCAN_API_KEY`).
     #[arg(long, env = "REDACT_SCAN_API_KEY")]
     pub api_key: Option<String>,
 
-    /// Extra header for --report-url, repeatable (`Name: value`)
+    /// Extra header for `--report-url`, repeatable (`Name: value`).
     #[arg(long = "report-header")]
     pub report_headers: Vec<String>,
 
-    /// Exit 1 when findings match this entity type, or `any`
+    /// Exit 1 when findings match this entity type, or `any`.
     #[arg(long)]
     pub fail_on: Option<String>,
 
-    /// Write local debug samples (incompatible with --report-url)
+    /// Write local debug samples (incompatible with `--report-url`).
     #[arg(long)]
     pub include_samples: bool,
 
-    /// Path for local debug samples (required with --include-samples and --format json)
+    /// Path for local debug samples (required with `--include-samples` and `--format json`).
     #[arg(long)]
     pub samples_out: Option<PathBuf>,
 }
 
+impl fmt::Debug for Cli {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Cli")
+            .field("url", &self.url.as_deref().map(scrub))
+            .field("schema", &self.schema)
+            .field("layers", &self.layers)
+            .field("sample_rows", &self.sample_rows)
+            .field("statement_timeout", &self.statement_timeout)
+            .field("format", &self.format)
+            .field("out", &self.out)
+            .field("report_url", &self.report_url)
+            .field("api_key", &self.api_key.as_ref().map(|_| "***"))
+            .field(
+                "report_headers",
+                &self
+                    .report_headers
+                    .iter()
+                    .map(|h| scrub(h))
+                    .collect::<Vec<_>>(),
+            )
+            .field("fail_on", &self.fail_on)
+            .field("include_samples", &self.include_samples)
+            .field("samples_out", &self.samples_out)
+            .finish()
+    }
+}
+
+impl fmt::Debug for OutputFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OutputFormat::Json => f.write_str("Json"),
+            OutputFormat::Table => f.write_str("Table"),
+        }
+    }
+}
+
 impl Cli {
+    /// Parse `--layers` into unique [`ScanLayer`] values.
     pub fn parsed_layers(&self) -> Result<Vec<ScanLayer>> {
         if self.layers.trim().is_empty() {
             return Ok(default_layers());
@@ -83,6 +125,7 @@ impl Cli {
         parse_layers(&self.layers)
     }
 
+    /// Parse `--statement-timeout` (`30s`, `500ms`, `2m`, or bare seconds).
     pub fn statement_timeout(&self) -> Result<Duration> {
         parse_duration(&self.statement_timeout)
     }
@@ -99,14 +142,11 @@ impl Cli {
                 "--include-samples with --format json requires --samples-out"
             ));
         }
-        if self.url.is_none() && self.report_url.is_none() {
-            // Allow --include-samples + --report-url error path without --url.
-            // A real scan still needs --url; checked in run().
-        }
         Ok(())
     }
 }
 
+/// Parse a human duration used by `--statement-timeout`.
 pub fn parse_duration(s: &str) -> Result<Duration> {
     let s = s.trim();
     if let Some(ms) = s.strip_suffix("ms") {
@@ -148,5 +188,20 @@ mod tests {
     fn duration_parse() {
         assert_eq!(parse_duration("30s").unwrap(), Duration::from_secs(30));
         assert_eq!(parse_duration("500ms").unwrap(), Duration::from_millis(500));
+    }
+
+    #[test]
+    fn debug_redacts_url_and_api_key() {
+        let cli = Cli::parse_from([
+            "redact-scan",
+            "--url",
+            "postgres://alice:s3cret-pass@localhost/app",
+            "--api-key",
+            "tok_live_secret",
+        ]);
+        let shown = format!("{cli:?}");
+        assert!(!shown.contains("s3cret-pass"));
+        assert!(!shown.contains("tok_live_secret"));
+        assert!(shown.contains("***"));
     }
 }

--- a/crates/redact-scan/src/cli.rs
+++ b/crates/redact-scan/src/cli.rs
@@ -90,7 +90,7 @@ impl fmt::Debug for Cli {
             .field("statement_timeout", &self.statement_timeout)
             .field("format", &self.format)
             .field("out", &self.out)
-            .field("report_url", &self.report_url)
+            .field("report_url", &self.report_url.as_deref().map(scrub))
             .field("api_key", &self.api_key.as_ref().map(|_| "***"))
             .field(
                 "report_headers",
@@ -198,10 +198,13 @@ mod tests {
             "postgres://alice:s3cret-pass@localhost/app",
             "--api-key",
             "tok_live_secret",
+            "--report-url",
+            "https://hook:hook-pass@example.test/ingest",
         ]);
         let shown = format!("{cli:?}");
         assert!(!shown.contains("s3cret-pass"));
         assert!(!shown.contains("tok_live_secret"));
+        assert!(!shown.contains("hook-pass"));
         assert!(shown.contains("***"));
     }
 }

--- a/crates/redact-scan/src/cli.rs
+++ b/crates/redact-scan/src/cli.rs
@@ -142,6 +142,9 @@ impl Cli {
                 "--include-samples with --format json requires --samples-out"
             ));
         }
+        if let Some(spec) = &self.fail_on {
+            crate::detect::parse_fail_on(spec).map_err(|e| anyhow!("{e}"))?;
+        }
         Ok(())
     }
 }

--- a/crates/redact-scan/src/detect.rs
+++ b/crates/redact-scan/src/detect.rs
@@ -1,0 +1,92 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Pattern-engine wrapper that drops matched text immediately.
+
+use redact_core::recognizers::{pattern::PatternRecognizer, Recognizer};
+use redact_core::{AnalyzerEngine, EntityType};
+
+/// Entity types used for value-based layers (L0.5 / L1 / L2).
+///
+/// Excludes high-false-positive types (`DATE_TIME`, `GUID`, hashes, `URL`)
+/// unless a name heuristic already nominated them.
+pub fn precision_entities() -> &'static [EntityType] {
+    &[
+        EntityType::EmailAddress,
+        EntityType::PhoneNumber,
+        EntityType::IpAddress,
+        EntityType::CreditCard,
+        EntityType::IbanCode,
+        EntityType::Iban,
+        EntityType::UsSsn,
+        EntityType::UsBankNumber,
+        EntityType::UsPassport,
+        EntityType::UsDriverLicense,
+        EntityType::UkNhs,
+        EntityType::UkNino,
+        EntityType::PassportNumber,
+        EntityType::MedicalRecordNumber,
+        EntityType::MedicalLicense,
+        EntityType::PrivateKey,
+        EntityType::JwtToken,
+        EntityType::AwsAccessKey,
+        EntityType::GithubToken,
+        EntityType::GitlabToken,
+        EntityType::SlackToken,
+        EntityType::StripeApiKey,
+        EntityType::DatabaseConnectionString,
+    ]
+}
+
+/// Built-in pattern pack label (`builtin@<supported count>`).
+pub fn pattern_pack_label() -> String {
+    let rec = PatternRecognizer::new();
+    format!("builtin@{}", rec.supported_entities().len())
+}
+
+/// Run the pattern engine and drop matched text immediately.
+pub fn detect_types(text: &str) -> Vec<(EntityType, f32)> {
+    detect_types_filtered(text, precision_entities())
+}
+
+/// Detect only the listed entity types; never retain `RecognizerResult.text`.
+pub fn detect_types_filtered(text: &str, allowed: &[EntityType]) -> Vec<(EntityType, f32)> {
+    let engine = AnalyzerEngine::new();
+    let Ok(result) = engine.analyze_with_entities(text, allowed, Some("en")) else {
+        return Vec::new();
+    };
+    result
+        .detected_entities
+        .into_iter()
+        .map(|e| (e.entity_type, e.score))
+        .collect()
+}
+
+/// Parse a `--fail-on` entity token. `any` returns `None`.
+pub fn parse_entity_type(s: &str) -> Option<EntityType> {
+    let t = s.trim();
+    if t.eq_ignore_ascii_case("any") {
+        return None;
+    }
+    Some(EntityType::from(t.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn drops_text_and_finds_email() {
+        let hits = detect_types("contact me at user@example.com please");
+        assert!(hits.iter().any(|(t, _)| *t == EntityType::EmailAddress));
+    }
+
+    #[test]
+    fn pattern_pack_is_not_hardcoded() {
+        let label = pattern_pack_label();
+        assert!(label.starts_with("builtin@"));
+        let n: usize = label.rsplit('@').next().unwrap().parse().unwrap();
+        assert!(n > 0);
+    }
+}

--- a/crates/redact-scan/src/detect.rs
+++ b/crates/redact-scan/src/detect.rs
@@ -52,35 +52,44 @@ pub fn detect_types(text: &str) -> Vec<(EntityType, f32)> {
 
 /// Detect only the listed entity types; never retain `RecognizerResult.text`.
 pub fn detect_types_filtered(text: &str, allowed: &[EntityType]) -> Vec<(EntityType, f32)> {
-    let engine = AnalyzerEngine::new();
-    let Ok(result) = engine.analyze_with_entities(text, allowed, Some("en")) else {
-        return Vec::new();
-    };
-    result
-        .detected_entities
-        .into_iter()
-        .map(|e| (e.entity_type, e.score))
-        .collect()
+    thread_local! {
+        static ENGINE: AnalyzerEngine = AnalyzerEngine::new();
+    }
+    ENGINE.with(|engine| {
+        let Ok(result) = engine.analyze_with_entities(text, allowed, Some("en")) else {
+            return Vec::new();
+        };
+        result
+            .detected_entities
+            .into_iter()
+            .map(|e| (e.entity_type, e.score))
+            .collect()
+    })
 }
 
-/// Parse a `--fail-on` entity token. `any` returns `None`.
-pub fn parse_entity_type(s: &str) -> Option<EntityType> {
+/// Parse `--fail-on`. `any` is `Ok(None)`. Unknown names are errors.
+pub fn parse_fail_on(s: &str) -> Result<Option<EntityType>, crate::error::ScanError> {
     let t = s.trim();
     if t.eq_ignore_ascii_case("any") {
-        return None;
+        return Ok(None);
     }
-    Some(EntityType::from(t.to_string()))
+    let ty = EntityType::from(t.to_string());
+    if matches!(ty, EntityType::Custom(_)) {
+        return Err(crate::error::ScanError::new(format!(
+            "unknown --fail-on entity type {t}"
+        )));
+    }
+    Ok(Some(ty))
 }
 
 /// True when `--fail-on` should exit 1.
-pub fn fail_on_matches(spec: &str, findings: &[crate::report::Finding]) -> bool {
-    if spec.eq_ignore_ascii_case("any") {
-        return !findings.is_empty();
-    }
-    let wanted = parse_entity_type(spec);
-    match wanted {
-        None => !findings.is_empty(),
-        Some(ty) => findings.iter().any(|f| f.entity_type == ty),
+pub fn fail_on_matches(
+    spec: &str,
+    findings: &[crate::report::Finding],
+) -> Result<bool, crate::error::ScanError> {
+    match parse_fail_on(spec)? {
+        None => Ok(!findings.is_empty()),
+        Some(ty) => Ok(findings.iter().any(|f| f.entity_type == ty)),
     }
 }
 
@@ -117,9 +126,10 @@ mod tests {
             confidence: 0.9,
             evidence_class: EvidenceClass::TableSample,
         };
-        assert!(fail_on_matches("any", std::slice::from_ref(&f)));
-        assert!(fail_on_matches("EMAIL_ADDRESS", std::slice::from_ref(&f)));
-        assert!(!fail_on_matches("US_SSN", std::slice::from_ref(&f)));
-        assert!(!fail_on_matches("any", &[]));
+        assert!(fail_on_matches("any", std::slice::from_ref(&f)).unwrap());
+        assert!(fail_on_matches("EMAIL_ADDRESS", std::slice::from_ref(&f)).unwrap());
+        assert!(!fail_on_matches("US_SSN", std::slice::from_ref(&f)).unwrap());
+        assert!(!fail_on_matches("any", &[]).unwrap());
+        assert!(parse_fail_on("EMAIL").is_err());
     }
 }

--- a/crates/redact-scan/src/detect.rs
+++ b/crates/redact-scan/src/detect.rs
@@ -72,6 +72,18 @@ pub fn parse_entity_type(s: &str) -> Option<EntityType> {
     Some(EntityType::from(t.to_string()))
 }
 
+/// True when `--fail-on` should exit 1.
+pub fn fail_on_matches(spec: &str, findings: &[crate::report::Finding]) -> bool {
+    if spec.eq_ignore_ascii_case("any") {
+        return !findings.is_empty();
+    }
+    let wanted = parse_entity_type(spec);
+    match wanted {
+        None => !findings.is_empty(),
+        Some(ty) => findings.iter().any(|f| f.entity_type == ty),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -88,5 +100,26 @@ mod tests {
         assert!(label.starts_with("builtin@"));
         let n: usize = label.rsplit('@').next().unwrap().parse().unwrap();
         assert!(n > 0);
+    }
+
+    #[test]
+    fn fail_on_any_and_typed() {
+        use crate::layers::ScanLayer;
+        use crate::report::{EvidenceClass, Finding};
+        let f = Finding {
+            table: "public.t".into(),
+            column: "c".into(),
+            json_path: None,
+            entity_type: EntityType::EmailAddress,
+            layer: ScanLayer::Sample,
+            match_count: 1,
+            sampled_rows: 10,
+            confidence: 0.9,
+            evidence_class: EvidenceClass::TableSample,
+        };
+        assert!(fail_on_matches("any", std::slice::from_ref(&f)));
+        assert!(fail_on_matches("EMAIL_ADDRESS", std::slice::from_ref(&f)));
+        assert!(!fail_on_matches("US_SSN", std::slice::from_ref(&f)));
+        assert!(!fail_on_matches("any", &[]));
     }
 }

--- a/crates/redact-scan/src/error.rs
+++ b/crates/redact-scan/src/error.rs
@@ -5,19 +5,21 @@
 use crate::scrub::scrub_secret;
 use std::fmt;
 
-/// Scanner error. Display/Debug never include raw credentials.
+/// Scanner error. [`Display`](std::fmt::Display) and [`Debug`] never include raw credentials.
 #[derive(Debug)]
 pub struct ScanError {
     message: String,
 }
 
 impl ScanError {
+    /// Build an error after running the credential scrubber on `message`.
     pub fn new(message: impl std::fmt::Display) -> Self {
         Self {
             message: crate::scrub::scrub(&message.to_string()),
         }
     }
 
+    /// Build an error, also replacing every occurrence of `secret`.
     pub fn with_secret(message: impl std::fmt::Display, secret: &str) -> Self {
         Self {
             message: scrub_secret(&message.to_string(), secret),

--- a/crates/redact-scan/src/error.rs
+++ b/crates/redact-scan/src/error.rs
@@ -40,3 +40,9 @@ impl From<anyhow::Error> for ScanError {
         Self::new(err)
     }
 }
+
+impl From<sqlx::Error> for ScanError {
+    fn from(err: sqlx::Error) -> Self {
+        Self::new(err)
+    }
+}

--- a/crates/redact-scan/src/error.rs
+++ b/crates/redact-scan/src/error.rs
@@ -1,0 +1,40 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+use crate::scrub::scrub_secret;
+use std::fmt;
+
+/// Scanner error. Display/Debug never include raw credentials.
+#[derive(Debug)]
+pub struct ScanError {
+    message: String,
+}
+
+impl ScanError {
+    pub fn new(message: impl std::fmt::Display) -> Self {
+        Self {
+            message: crate::scrub::scrub(&message.to_string()),
+        }
+    }
+
+    pub fn with_secret(message: impl std::fmt::Display, secret: &str) -> Self {
+        Self {
+            message: scrub_secret(&message.to_string(), secret),
+        }
+    }
+}
+
+impl fmt::Display for ScanError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ScanError {}
+
+impl From<anyhow::Error> for ScanError {
+    fn from(err: anyhow::Error) -> Self {
+        Self::new(err)
+    }
+}

--- a/crates/redact-scan/src/format.rs
+++ b/crates/redact-scan/src/format.rs
@@ -4,7 +4,6 @@
 
 //! Human-readable table output. Never prints sample values.
 
-use crate::bound::rule_of_three_message;
 use crate::report::ScanReport;
 
 /// Render a tab-separated table of findings.
@@ -16,10 +15,6 @@ pub fn render_table(report: &ScanReport) -> String {
     ));
     if report.findings.is_empty() {
         out.push_str("No findings.\n");
-        out.push_str(&rule_of_three_message(u64::from(
-            report.sampling.rows_per_column,
-        )));
-        out.push('\n');
         return out;
     }
     out.push_str("table\tcolumn\tpath\tentity\tlayer\tmatches\tsampled\tconfidence\tevidence\n");
@@ -71,7 +66,8 @@ mod tests {
             content_hash: String::new(),
         };
         let s = render_table(&report);
-        assert!(s.contains("0.3%"));
+        assert!(s.contains("No findings."));
+        assert!(!s.contains("0.3%"));
         assert!(!s.contains("user@"));
     }
 }

--- a/crates/redact-scan/src/format.rs
+++ b/crates/redact-scan/src/format.rs
@@ -1,0 +1,77 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Human-readable table output. Never prints sample values.
+
+use crate::bound::rule_of_three_message;
+use crate::report::ScanReport;
+
+/// Render a tab-separated table of findings.
+pub fn render_table(report: &ScanReport) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "scan {}  {}  fingerprint={}  pack={}\n",
+        report.scan_id, report.scanned_at, report.target.fingerprint, report.scanner.pattern_pack
+    ));
+    if report.findings.is_empty() {
+        out.push_str("No findings.\n");
+        out.push_str(&rule_of_three_message(u64::from(
+            report.sampling.rows_per_column,
+        )));
+        out.push('\n');
+        return out;
+    }
+    out.push_str("table\tcolumn\tpath\tentity\tlayer\tmatches\tsampled\tconfidence\tevidence\n");
+    for f in &report.findings {
+        out.push_str(&format!(
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:.2}\t{:?}\n",
+            f.table,
+            f.column,
+            f.json_path.as_deref().unwrap_or("-"),
+            f.entity_type.as_str(),
+            f.layer,
+            f.match_count,
+            f.sampled_rows,
+            f.confidence,
+            f.evidence_class
+        ));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::layers::ScanLayer;
+    use crate::report::{Sampling, Scanner, Target};
+    use chrono::{TimeZone, Utc};
+    use uuid::Uuid;
+
+    #[test]
+    fn empty_report_mentions_rule_of_three() {
+        let report = ScanReport {
+            scan_id: Uuid::nil(),
+            scanned_at: Utc.with_ymd_and_hms(2026, 8, 15, 0, 0, 0).unwrap(),
+            target: Target {
+                fingerprint: "abc".into(),
+                engine: "postgres".into(),
+                version: "16".into(),
+            },
+            scanner: Scanner {
+                version: "0.9.1".into(),
+                pattern_pack: "builtin@1".into(),
+            },
+            sampling: Sampling {
+                layers: vec![ScanLayer::Sample],
+                rows_per_column: 1000,
+                method: "TABLESAMPLE SYSTEM".into(),
+            },
+            findings: vec![],
+            content_hash: String::new(),
+        };
+        let s = render_table(&report);
+        assert!(s.contains("0.3%"));
+        assert!(!s.contains("user@"));
+    }
+}

--- a/crates/redact-scan/src/ident.rs
+++ b/crates/redact-scan/src/ident.rs
@@ -2,16 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See the LICENSE file
 // in the project root for license information.
 
-//! Identifier quoting. Only `[A-Za-z0-9_]+` is accepted.
+//! Identifier quoting. Values are always double-quoted.
 
 use anyhow::{anyhow, Result};
 
-/// Quote a Postgres identifier after validating it is `[A-Za-z0-9_]+`.
+/// Quote a Postgres identifier. Embedded quotes are doubled.
 pub fn quote_ident(name: &str) -> Result<String> {
-    if name.is_empty() || !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+    if name.is_empty() || name.contains('\0') {
         return Err(anyhow!("unsafe identifier"));
     }
-    Ok(format!("\"{name}\""))
+    Ok(format!("\"{}\"", name.replace('"', "\"\"")))
 }
 
 /// `schema.table` with both parts quoted.
@@ -24,9 +24,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn rejects_injection() {
-        assert!(quote_ident("foo;drop").is_err());
-        assert!(quote_ident("ok_name").is_ok());
+    fn quotes_and_escapes() {
+        assert_eq!(quote_ident("ok_name").unwrap(), "\"ok_name\"");
+        assert_eq!(quote_ident("e-mail").unwrap(), "\"e-mail\"");
+        assert_eq!(quote_ident("foo;drop").unwrap(), "\"foo;drop\"");
+        assert_eq!(quote_ident("a\"b").unwrap(), "\"a\"\"b\"");
+        assert!(quote_ident("").is_err());
         assert_eq!(
             qualify_table("public", "users").unwrap(),
             "\"public\".\"users\""

--- a/crates/redact-scan/src/ident.rs
+++ b/crates/redact-scan/src/ident.rs
@@ -1,0 +1,35 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Identifier quoting. Only `[A-Za-z0-9_]+` is accepted.
+
+use anyhow::{anyhow, Result};
+
+/// Quote a Postgres identifier after validating it is `[A-Za-z0-9_]+`.
+pub fn quote_ident(name: &str) -> Result<String> {
+    if name.is_empty() || !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        return Err(anyhow!("unsafe identifier"));
+    }
+    Ok(format!("\"{name}\""))
+}
+
+/// `schema.table` with both parts quoted.
+pub fn qualify_table(schema: &str, table: &str) -> Result<String> {
+    Ok(format!("{}.{}", quote_ident(schema)?, quote_ident(table)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_injection() {
+        assert!(quote_ident("foo;drop").is_err());
+        assert!(quote_ident("ok_name").is_ok());
+        assert_eq!(
+            qualify_table("public", "users").unwrap(),
+            "\"public\".\"users\""
+        );
+    }
+}

--- a/crates/redact-scan/src/json_scan.rs
+++ b/crates/redact-scan/src/json_scan.rs
@@ -49,7 +49,7 @@ async fn scan_json_column(
         .await
         .map_err(ScanError::new)?;
 
-    let mut by_path: BTreeMap<String, (u64, u64, redact_core::EntityType, f32)> = BTreeMap::new();
+    let mut by_path: BTreeMap<String, (u64, redact_core::EntityType, f32)> = BTreeMap::new();
     let mut sampled_docs = 0u64;
     for raw in docs.into_iter().flatten() {
         sampled_docs += 1;
@@ -63,16 +63,21 @@ async fn scan_json_column(
             if hits.is_empty() {
                 continue;
             }
+            crate::report::record_sample(
+                &format!("{}.{}", col.schema, col.table),
+                &col.column,
+                Some(&path),
+                &text,
+            );
             let (ty, score) = hits
                 .into_iter()
                 .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
                 .expect("hits non-empty");
-            let entry = by_path.entry(path).or_insert((0, 0, ty.clone(), score));
+            let entry = by_path.entry(path).or_insert((0, ty.clone(), score));
             entry.0 += 1;
-            entry.1 = sampled_docs;
-            if score > entry.3 {
-                entry.2 = ty;
-                entry.3 = score;
+            if score > entry.2 {
+                entry.1 = ty;
+                entry.2 = score;
             }
         }
     }
@@ -80,19 +85,37 @@ async fn scan_json_column(
     Ok(by_path
         .into_iter()
         .map(
-            |(json_path, (match_count, sampled_rows, entity_type, confidence))| Finding {
+            |(json_path, (match_count, entity_type, confidence))| Finding {
                 table: format!("{}.{}", col.schema, col.table),
                 column: col.column.clone(),
                 json_path: Some(json_path),
                 entity_type,
                 layer: ScanLayer::Json,
                 match_count,
-                sampled_rows,
+                sampled_rows: sampled_docs,
                 confidence,
                 evidence_class: EvidenceClass::JsonPath,
             },
         )
         .collect())
+}
+
+/// Replace a JSON object key that looks like a value with a type placeholder.
+pub fn sanitize_path_key(key: &str) -> String {
+    let hits = detect_types(key);
+    if let Some((ty, _)) = hits
+        .into_iter()
+        .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+    {
+        return format!("{{{}}}", ty.as_str());
+    }
+    if key
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        return key.to_string();
+    }
+    "{key}".to_string()
 }
 
 fn walk(value: &Value, path: &str, out: &mut Vec<(String, String)>) {
@@ -101,7 +124,7 @@ fn walk(value: &Value, path: &str, out: &mut Vec<(String, String)>) {
         Value::Number(n) => out.push((path.to_string(), n.to_string())),
         Value::Object(map) => {
             for (k, v) in map {
-                let child = format!("{path}.{k}");
+                let child = format!("{path}.{}", sanitize_path_key(k));
                 walk(v, &child, out);
             }
         }
@@ -126,5 +149,20 @@ mod tests {
         walk(&v, "$", &mut paths);
         assert!(paths.iter().any(|(p, _)| p == "$.customer.email"));
         assert!(paths.iter().any(|(p, _)| p == "$.n"));
+    }
+
+    #[test]
+    fn sanitizes_email_object_keys() {
+        let v = serde_json::json!({"alice@example.test": "x"});
+        let mut paths = Vec::new();
+        walk(&v, "$", &mut paths);
+        assert!(
+            paths.iter().all(|(p, _)| !p.contains("alice@")),
+            "{paths:?}"
+        );
+        assert!(
+            paths.iter().any(|(p, _)| p.contains("EMAIL_ADDRESS")),
+            "{paths:?}"
+        );
     }
 }

--- a/crates/redact-scan/src/json_scan.rs
+++ b/crates/redact-scan/src/json_scan.rs
@@ -109,6 +109,10 @@ pub fn sanitize_path_key(key: &str) -> String {
     {
         return format!("{{{}}}", ty.as_str());
     }
+    let digits = key.chars().filter(|c| c.is_ascii_digit()).count();
+    if digits >= 7 {
+        return "{key}".to_string();
+    }
     if key
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')

--- a/crates/redact-scan/src/json_scan.rs
+++ b/crates/redact-scan/src/json_scan.rs
@@ -1,0 +1,130 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Layer 2: JSON/JSONB path sampling.
+
+use serde_json::Value;
+use sqlx::PgPool;
+use std::collections::BTreeMap;
+
+use crate::catalog::ColumnMeta;
+use crate::detect::detect_types;
+use crate::error::ScanError;
+use crate::ident::{qualify_table, quote_ident};
+use crate::layers::ScanLayer;
+use crate::report::{EvidenceClass, Finding};
+use crate::score::is_json_type;
+
+/// Sample JSON columns and emit path-level findings. Values are dropped.
+pub async fn l2_findings(
+    pool: &PgPool,
+    columns: &[&ColumnMeta],
+    sample_rows: u32,
+) -> Result<Vec<Finding>, ScanError> {
+    let mut out = Vec::new();
+    for col in columns {
+        if !is_json_type(&col.udt) {
+            continue;
+        }
+        if col.relkind != "r" && col.relkind != "p" {
+            continue;
+        }
+        out.extend(scan_json_column(pool, col, sample_rows).await?);
+    }
+    Ok(out)
+}
+
+async fn scan_json_column(
+    pool: &PgPool,
+    col: &ColumnMeta,
+    sample_rows: u32,
+) -> Result<Vec<Finding>, ScanError> {
+    let table = qualify_table(&col.schema, &col.table).map_err(ScanError::new)?;
+    let column = quote_ident(&col.column).map_err(ScanError::new)?;
+    let limit = i64::from(sample_rows.max(1));
+    let sql = format!("SELECT {column}::text FROM {table} LIMIT {limit}");
+    let docs: Vec<Option<String>> = sqlx::query_scalar(&sql)
+        .fetch_all(pool)
+        .await
+        .map_err(ScanError::new)?;
+
+    let mut by_path: BTreeMap<String, (u64, u64, redact_core::EntityType, f32)> = BTreeMap::new();
+    let mut sampled_docs = 0u64;
+    for raw in docs.into_iter().flatten() {
+        sampled_docs += 1;
+        let Ok(value) = serde_json::from_str::<Value>(&raw) else {
+            continue;
+        };
+        let mut paths = Vec::new();
+        walk(&value, "$", &mut paths);
+        for (path, text) in paths {
+            let hits = detect_types(&text);
+            if hits.is_empty() {
+                continue;
+            }
+            let (ty, score) = hits
+                .into_iter()
+                .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+                .expect("hits non-empty");
+            let entry = by_path.entry(path).or_insert((0, 0, ty.clone(), score));
+            entry.0 += 1;
+            entry.1 = sampled_docs;
+            if score > entry.3 {
+                entry.2 = ty;
+                entry.3 = score;
+            }
+        }
+    }
+
+    Ok(by_path
+        .into_iter()
+        .map(
+            |(json_path, (match_count, sampled_rows, entity_type, confidence))| Finding {
+                table: format!("{}.{}", col.schema, col.table),
+                column: col.column.clone(),
+                json_path: Some(json_path),
+                entity_type,
+                layer: ScanLayer::Json,
+                match_count,
+                sampled_rows,
+                confidence,
+                evidence_class: EvidenceClass::JsonPath,
+            },
+        )
+        .collect())
+}
+
+fn walk(value: &Value, path: &str, out: &mut Vec<(String, String)>) {
+    match value {
+        Value::String(s) => out.push((path.to_string(), s.clone())),
+        Value::Number(n) => out.push((path.to_string(), n.to_string())),
+        Value::Object(map) => {
+            for (k, v) in map {
+                let child = format!("{path}.{k}");
+                walk(v, &child, out);
+            }
+        }
+        Value::Array(items) => {
+            for (i, v) in items.iter().enumerate() {
+                let child = format!("{path}[{i}]");
+                walk(v, &child, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn walks_nested_paths() {
+        let v = serde_json::json!({"customer":{"email":"a@b.c"},"n":1});
+        let mut paths = Vec::new();
+        walk(&v, "$", &mut paths);
+        assert!(paths.iter().any(|(p, _)| p == "$.customer.email"));
+        assert!(paths.iter().any(|(p, _)| p == "$.n"));
+    }
+}

--- a/crates/redact-scan/src/layers.rs
+++ b/crates/redact-scan/src/layers.rs
@@ -1,0 +1,134 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+use std::str::FromStr;
+
+/// Discovery layer. Serialized as 0, 0.5, 1, or 2.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ScanLayer {
+    Metadata,
+    Stats,
+    Sample,
+    Json,
+}
+
+impl ScanLayer {
+    pub fn as_f64(self) -> f64 {
+        match self {
+            ScanLayer::Metadata => 0.0,
+            ScanLayer::Stats => 0.5,
+            ScanLayer::Sample => 1.0,
+            ScanLayer::Json => 2.0,
+        }
+    }
+
+    pub fn from_f64(v: f64) -> Result<Self> {
+        if (v - 0.0).abs() < f64::EPSILON {
+            Ok(ScanLayer::Metadata)
+        } else if (v - 0.5).abs() < f64::EPSILON {
+            Ok(ScanLayer::Stats)
+        } else if (v - 1.0).abs() < f64::EPSILON {
+            Ok(ScanLayer::Sample)
+        } else if (v - 2.0).abs() < f64::EPSILON {
+            Ok(ScanLayer::Json)
+        } else {
+            Err(anyhow!("invalid layer {v}; expected 0, 0.5, 1, or 2"))
+        }
+    }
+}
+
+impl fmt::Display for ScanLayer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ScanLayer::Metadata => write!(f, "0"),
+            ScanLayer::Stats => write!(f, "0.5"),
+            ScanLayer::Sample => write!(f, "1"),
+            ScanLayer::Json => write!(f, "2"),
+        }
+    }
+}
+
+impl FromStr for ScanLayer {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let t = s.trim();
+        match t {
+            "0" | "metadata" => Ok(ScanLayer::Metadata),
+            "0.5" | "stats" => Ok(ScanLayer::Stats),
+            "1" | "sample" => Ok(ScanLayer::Sample),
+            "2" | "json" => Ok(ScanLayer::Json),
+            other => {
+                let v: f64 = other
+                    .parse()
+                    .map_err(|_| anyhow!("invalid layer {other}; expected 0, 0.5, 1, or 2"))?;
+                ScanLayer::from_f64(v)
+            }
+        }
+    }
+}
+
+impl Serialize for ScanLayer {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_f64(self.as_f64())
+    }
+}
+
+impl<'de> Deserialize<'de> for ScanLayer {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let v = f64::deserialize(deserializer)?;
+        ScanLayer::from_f64(v).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Parse a comma-separated layer list (`0,0.5,1,2`).
+pub fn parse_layers(s: &str) -> Result<Vec<ScanLayer>> {
+    let mut out = Vec::new();
+    for part in s.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        let layer = ScanLayer::from_str(part)?;
+        if !out.contains(&layer) {
+            out.push(layer);
+        }
+    }
+    if out.is_empty() {
+        return Err(anyhow!("--layers must select at least one layer"));
+    }
+    Ok(out)
+}
+
+pub fn default_layers() -> Vec<ScanLayer> {
+    vec![
+        ScanLayer::Metadata,
+        ScanLayer::Stats,
+        ScanLayer::Sample,
+        ScanLayer::Json,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_default_list() {
+        let layers = parse_layers("0,0.5,1,2").unwrap();
+        assert_eq!(layers.len(), 4);
+        assert_eq!(layers[1], ScanLayer::Stats);
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let json = serde_json::to_string(&ScanLayer::Stats).unwrap();
+        assert_eq!(json, "0.5");
+        let back: ScanLayer = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, ScanLayer::Stats);
+    }
+}

--- a/crates/redact-scan/src/layers.rs
+++ b/crates/redact-scan/src/layers.rs
@@ -7,16 +7,21 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 use std::str::FromStr;
 
-/// Discovery layer. Serialized as 0, 0.5, 1, or 2.
+/// Discovery layer. Serialized as JSON numbers `0`, `0.5`, `1`, or `2`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ScanLayer {
+    /// Layer 0: catalog metadata only (no user-table reads).
     Metadata,
+    /// Layer 0.5: planner statistics (`pg_stats`).
     Stats,
+    /// Layer 1: bounded `TABLESAMPLE` of candidate columns.
     Sample,
+    /// Layer 2: JSON/JSONB path sampling.
     Json,
 }
 
 impl ScanLayer {
+    /// Numeric form used on the CLI and in report JSON.
     pub fn as_f64(self) -> f64 {
         match self {
             ScanLayer::Metadata => 0.0,
@@ -26,6 +31,7 @@ impl ScanLayer {
         }
     }
 
+    /// Parse the numeric layer token.
     pub fn from_f64(v: f64) -> Result<Self> {
         if (v - 0.0).abs() < f64::EPSILON {
             Ok(ScanLayer::Metadata)
@@ -104,6 +110,7 @@ pub fn parse_layers(s: &str) -> Result<Vec<ScanLayer>> {
     Ok(out)
 }
 
+/// Default layer set: `0,0.5,1,2`.
 pub fn default_layers() -> Vec<ScanLayer> {
     vec![
         ScanLayer::Metadata,

--- a/crates/redact-scan/src/lib.rs
+++ b/crates/redact-scan/src/lib.rs
@@ -9,19 +9,32 @@
 
 /// Canonical JSON hashing for [`ScanReport::content_hash`].
 pub mod canonical;
+/// Layer 0 catalog metadata.
+pub mod catalog;
 /// Command-line argument types.
 pub mod cli;
+/// Pattern-engine wrapper that drops matched text.
+pub mod detect;
 /// Scrubbed scanner errors.
 pub mod error;
 /// Discovery layer identifiers (`0`, `0.5`, `1`, `2`).
 pub mod layers;
 /// Value-free report types.
 pub mod report;
+/// Read-only session and privilege checks.
+pub mod safety;
+/// Scan orchestration.
+pub mod scan;
+/// Name and type heuristics.
+pub mod score;
 /// Credential redaction for logs and errors.
 pub mod scrub;
+/// Layer 0.5 planner statistics.
+pub mod stats;
 
 pub use error::ScanError;
 pub use report::{Finding, ScanReport};
+pub use scan::run_scan;
 
 /// Process exit code when the scan completed with no fail-on match.
 pub const EXIT_CLEAN: i32 = 0;

--- a/crates/redact-scan/src/lib.rs
+++ b/crates/redact-scan/src/lib.rs
@@ -7,16 +7,25 @@
 //! Prefer a replica or staging database. Reports list locations and counts
 //! only — never sample values.
 
+/// Canonical JSON hashing for [`ScanReport::content_hash`].
 pub mod canonical;
+/// Command-line argument types.
 pub mod cli;
+/// Scrubbed scanner errors.
 pub mod error;
+/// Discovery layer identifiers (`0`, `0.5`, `1`, `2`).
 pub mod layers;
+/// Value-free report types.
 pub mod report;
+/// Credential redaction for logs and errors.
 pub mod scrub;
 
 pub use error::ScanError;
 pub use report::{Finding, ScanReport};
 
+/// Process exit code when the scan completed with no fail-on match.
 pub const EXIT_CLEAN: i32 = 0;
+/// Process exit code when `--fail-on` matched at least one finding.
 pub const EXIT_FINDINGS: i32 = 1;
+/// Process exit code for usage errors, safety refusals, and I/O failures.
 pub const EXIT_ERROR: i32 = 2;

--- a/crates/redact-scan/src/lib.rs
+++ b/crates/redact-scan/src/lib.rs
@@ -7,6 +7,8 @@
 //! Prefer a replica or staging database. Reports list locations and counts
 //! only — never sample values.
 
+/// Rule-of-three helper for negative samples.
+pub mod bound;
 /// Canonical JSON hashing for [`ScanReport::content_hash`].
 pub mod canonical;
 /// Layer 0 catalog metadata.
@@ -17,12 +19,20 @@ pub mod cli;
 pub mod detect;
 /// Scrubbed scanner errors.
 pub mod error;
+/// Human-readable table output.
+pub mod format;
+/// Identifier quoting.
+pub mod ident;
+/// Layer 2 JSON path sampling.
+pub mod json_scan;
 /// Discovery layer identifiers (`0`, `0.5`, `1`, `2`).
 pub mod layers;
 /// Value-free report types.
 pub mod report;
 /// Read-only session and privilege checks.
 pub mod safety;
+/// Layer 1 table sampling.
+pub mod sample;
 /// Scan orchestration.
 pub mod scan;
 /// Name and type heuristics.
@@ -31,6 +41,8 @@ pub mod score;
 pub mod scrub;
 /// Layer 0.5 planner statistics.
 pub mod stats;
+/// Optional HTTP POST of the report JSON.
+pub mod upload;
 
 pub use error::ScanError;
 pub use report::{Finding, ScanReport};

--- a/crates/redact-scan/src/lib.rs
+++ b/crates/redact-scan/src/lib.rs
@@ -1,0 +1,22 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Read-only Postgres PII discovery scanner.
+//!
+//! Prefer a replica or staging database. Reports list locations and counts
+//! only — never sample values.
+
+pub mod canonical;
+pub mod cli;
+pub mod error;
+pub mod layers;
+pub mod report;
+pub mod scrub;
+
+pub use error::ScanError;
+pub use report::{Finding, ScanReport};
+
+pub const EXIT_CLEAN: i32 = 0;
+pub const EXIT_FINDINGS: i32 = 1;
+pub const EXIT_ERROR: i32 = 2;

--- a/crates/redact-scan/src/main.rs
+++ b/crates/redact-scan/src/main.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 use redact_scan::cli::Cli;
 use redact_scan::error::ScanError;
 use redact_scan::scrub::scrub;
-use redact_scan::EXIT_ERROR;
+use redact_scan::{run_scan, EXIT_CLEAN, EXIT_ERROR};
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
@@ -26,14 +26,27 @@ fn run() -> Result<i32, ScanError> {
     if cli.url.is_none() {
         return Err(ScanError::new("--url is required"));
     }
-    Err(ScanError::new(
-        "scan execution is not implemented in this revision",
-    ))
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("redact_scan=info")),
+        )
+        .init();
+
+    let rt = tokio::runtime::Runtime::new().map_err(ScanError::new)?;
+    let report = rt.block_on(run_scan(&cli))?;
+    let json = serde_json::to_string_pretty(&report).map_err(ScanError::new)?;
+    if let Some(path) = &cli.out {
+        std::fs::write(path, &json).map_err(ScanError::new)?;
+    } else {
+        println!("{json}");
+    }
+    Ok(EXIT_CLEAN)
 }
 
 fn install_panic_hook() {
     std::panic::set_hook(Box::new(move |info| {
-        // Do not invoke the default hook: it would print the original payload.
         eprintln!("panic: {}", scrub(&info.to_string()));
     }));
 }

--- a/crates/redact-scan/src/main.rs
+++ b/crates/redact-scan/src/main.rs
@@ -3,10 +3,13 @@
 // in the project root for license information.
 
 use clap::Parser;
-use redact_scan::cli::Cli;
+use redact_scan::cli::{Cli, OutputFormat};
+use redact_scan::detect::fail_on_matches;
 use redact_scan::error::ScanError;
+use redact_scan::report::DebugSamples;
 use redact_scan::scrub::scrub;
-use redact_scan::{run_scan, EXIT_CLEAN, EXIT_ERROR};
+use redact_scan::upload::post_report;
+use redact_scan::{run_scan, EXIT_CLEAN, EXIT_ERROR, EXIT_FINDINGS};
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
@@ -37,10 +40,44 @@ fn run() -> Result<i32, ScanError> {
     let rt = tokio::runtime::Runtime::new().map_err(ScanError::new)?;
     let report = rt.block_on(run_scan(&cli))?;
     let json = serde_json::to_string_pretty(&report).map_err(ScanError::new)?;
+    let rendered = match cli.format {
+        OutputFormat::Json => json.clone(),
+        OutputFormat::Table => redact_scan::format::render_table(&report),
+    };
+
     if let Some(path) = &cli.out {
         std::fs::write(path, &json).map_err(ScanError::new)?;
     } else {
-        println!("{json}");
+        println!("{rendered}");
+    }
+
+    if cli.include_samples {
+        let samples = DebugSamples {
+            scan_id: report.scan_id,
+            notes: "local debug only; ScanReport contains no values".into(),
+        };
+        if let Some(path) = &cli.samples_out {
+            std::fs::write(
+                path,
+                serde_json::to_vec_pretty(&samples).map_err(ScanError::new)?,
+            )
+            .map_err(ScanError::new)?;
+        }
+    }
+
+    if let Some(url) = &cli.report_url {
+        rt.block_on(post_report(
+            url,
+            cli.api_key.as_deref(),
+            &cli.report_headers,
+            &report,
+        ))?;
+    }
+
+    if let Some(spec) = &cli.fail_on {
+        if fail_on_matches(spec, &report.findings) {
+            return Ok(EXIT_FINDINGS);
+        }
     }
     Ok(EXIT_CLEAN)
 }

--- a/crates/redact-scan/src/main.rs
+++ b/crates/redact-scan/src/main.rs
@@ -38,6 +38,9 @@ fn run() -> Result<i32, ScanError> {
         .init();
 
     let rt = tokio::runtime::Runtime::new().map_err(ScanError::new)?;
+    if cli.include_samples {
+        redact_scan::report::enable_sample_sink();
+    }
     let report = rt.block_on(run_scan(&cli))?;
     let json = serde_json::to_string_pretty(&report).map_err(ScanError::new)?;
     let rendered = match cli.format {
@@ -55,6 +58,7 @@ fn run() -> Result<i32, ScanError> {
         let samples = DebugSamples {
             scan_id: report.scan_id,
             notes: "local debug only; ScanReport contains no values".into(),
+            samples: redact_scan::report::take_samples(),
         };
         if let Some(path) = &cli.samples_out {
             std::fs::write(
@@ -75,7 +79,7 @@ fn run() -> Result<i32, ScanError> {
     }
 
     if let Some(spec) = &cli.fail_on {
-        if fail_on_matches(spec, &report.findings) {
+        if fail_on_matches(spec, &report.findings)? {
             return Ok(EXIT_FINDINGS);
         }
     }

--- a/crates/redact-scan/src/main.rs
+++ b/crates/redact-scan/src/main.rs
@@ -1,0 +1,41 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+use clap::Parser;
+use redact_scan::cli::Cli;
+use redact_scan::error::ScanError;
+use redact_scan::scrub::scrub;
+use redact_scan::EXIT_ERROR;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    install_panic_hook();
+    match run() {
+        Ok(code) => ExitCode::from(code as u8),
+        Err(err) => {
+            eprintln!("Error: {err}");
+            ExitCode::from(EXIT_ERROR as u8)
+        }
+    }
+}
+
+fn run() -> Result<i32, ScanError> {
+    let cli = Cli::parse();
+    cli.validate_preflight().map_err(ScanError::new)?;
+    if cli.url.is_none() {
+        return Err(ScanError::new("--url is required"));
+    }
+    Err(ScanError::new(
+        "scan execution is not implemented in this revision",
+    ))
+}
+
+fn install_panic_hook() {
+    let default = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let msg = scrub(&info.to_string());
+        eprintln!("panic: {msg}");
+        default(info);
+    }));
+}

--- a/crates/redact-scan/src/main.rs
+++ b/crates/redact-scan/src/main.rs
@@ -32,10 +32,8 @@ fn run() -> Result<i32, ScanError> {
 }
 
 fn install_panic_hook() {
-    let default = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
-        let msg = scrub(&info.to_string());
-        eprintln!("panic: {msg}");
-        default(info);
+        // Do not invoke the default hook: it would print the original payload.
+        eprintln!("panic: {}", scrub(&info.to_string()));
     }));
 }

--- a/crates/redact-scan/src/report.rs
+++ b/crates/redact-scan/src/report.rs
@@ -155,8 +155,7 @@ pub fn record_sample(table: &str, column: &str, json_path: Option<&str>, preview
             if buf.len() >= 32 {
                 return;
             }
-            let mut preview = preview.to_string();
-            preview.truncate(64);
+            let preview: String = preview.chars().take(64).collect();
             buf.push(DebugSample {
                 table: table.into(),
                 column: column.into(),

--- a/crates/redact-scan/src/report.rs
+++ b/crates/redact-scan/src/report.rs
@@ -5,6 +5,7 @@
 use chrono::{DateTime, Utc};
 use redact_core::EntityType;
 use serde::{Deserialize, Serialize};
+use std::cell::RefCell;
 use uuid::Uuid;
 
 use crate::canonical::content_hash;
@@ -120,6 +121,55 @@ pub struct DebugSamples {
     pub scan_id: Uuid,
     /// Operator note. Must not be merged into [`ScanReport`].
     pub notes: String,
+    /// Local previews. Never copied into [`ScanReport`].
+    pub samples: Vec<DebugSample>,
+}
+
+/// One local debug preview. Sidecar only.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DebugSample {
+    /// Qualified table name.
+    pub table: String,
+    /// Column name.
+    pub column: String,
+    /// JSON path when the preview came from layer 2.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub json_path: Option<String>,
+    /// Truncated cell text. Sidecar only.
+    pub preview: String,
+}
+
+thread_local! {
+    static SAMPLE_SINK: RefCell<Option<Vec<DebugSample>>> = const { RefCell::new(None) };
+}
+
+/// Start collecting sidecar previews for `--include-samples`.
+pub fn enable_sample_sink() {
+    SAMPLE_SINK.with(|s| *s.borrow_mut() = Some(Vec::new()));
+}
+
+/// Record a sidecar preview. No-op unless [`enable_sample_sink`] was called.
+pub fn record_sample(table: &str, column: &str, json_path: Option<&str>, preview: &str) {
+    SAMPLE_SINK.with(|s| {
+        if let Some(buf) = s.borrow_mut().as_mut() {
+            if buf.len() >= 32 {
+                return;
+            }
+            let mut preview = preview.to_string();
+            preview.truncate(64);
+            buf.push(DebugSample {
+                table: table.into(),
+                column: column.into(),
+                json_path: json_path.map(str::to_string),
+                preview,
+            });
+        }
+    });
+}
+
+/// Take collected sidecar previews.
+pub fn take_samples() -> Vec<DebugSample> {
+    SAMPLE_SINK.with(|s| s.borrow_mut().take().unwrap_or_default())
 }
 
 #[cfg(test)]

--- a/crates/redact-scan/src/report.rs
+++ b/crates/redact-scan/src/report.rs
@@ -14,63 +14,98 @@ use crate::layers::ScanLayer;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum EvidenceClass {
+    /// Column or table name matched a known PII token.
     NameHeuristic,
+    /// Native column type (for example `inet`) implied an entity.
     TypeSignal,
+    /// Unique index on text-like data (candidate boost only).
     UniqueIndex,
+    /// Foreign key toward a subject-like table (candidate boost only).
     FkTopology,
+    /// Planner statistics (`most_common_vals` / `histogram_bounds`).
     PgStats,
+    /// Bounded table sample.
     TableSample,
+    /// JSON document path sample.
     JsonPath,
 }
 
 /// A PII location. This type must not grow a field that can hold a sample value.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Finding {
+    /// Qualified table name (`schema.table`).
     pub table: String,
+    /// Column name.
     pub column: String,
+    /// JSON path for layer 2 findings (`$.customer.email`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub json_path: Option<String>,
+    /// Detected entity type (SCREAMING_SNAKE_CASE in JSON).
     pub entity_type: EntityType,
+    /// Layer that produced the finding.
     pub layer: ScanLayer,
+    /// How many sampled cells matched. Zero for metadata-only findings.
     pub match_count: u64,
+    /// How many cells were examined. Zero for metadata-only findings.
     pub sampled_rows: u64,
+    /// Detector or heuristic confidence in `0.0..=1.0`.
     pub confidence: f32,
+    /// Why this location was reported.
     pub evidence_class: EvidenceClass,
 }
 
+/// Hashed scan target. Never a connection string or hostname.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Target {
+    /// `sha256(host|database|schema)` hex digest.
     pub fingerprint: String,
+    /// Database engine (`postgres`).
     pub engine: String,
+    /// Server version string from the engine.
     pub version: String,
 }
 
+/// Scanner identity recorded in the report.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Scanner {
+    /// `CARGO_PKG_VERSION` of `redact-scan`.
     pub version: String,
+    /// Built-in pattern pack label (`builtin@<count>`).
     pub pattern_pack: String,
 }
 
+/// Sampling configuration used for the run.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Sampling {
+    /// Layers that were selected.
     pub layers: Vec<ScanLayer>,
+    /// `--sample-rows` limit.
     pub rows_per_column: u32,
+    /// Sampling method (`TABLESAMPLE SYSTEM`).
     pub method: String,
 }
 
 /// Value-free scan report. `content_hash` is computed after the other fields.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ScanReport {
+    /// Random identifier for this run.
     pub scan_id: Uuid,
+    /// UTC timestamp when the report was assembled.
     pub scanned_at: DateTime<Utc>,
+    /// Hashed target identity.
     pub target: Target,
+    /// Scanner version and pattern pack.
     pub scanner: Scanner,
+    /// Selected layers and sample size.
     pub sampling: Sampling,
+    /// Locations only — never values.
     pub findings: Vec<Finding>,
+    /// SHA-256 of canonical JSON with this field omitted.
     pub content_hash: String,
 }
 
 impl ScanReport {
+    /// Fill [`ScanReport::content_hash`] from the other fields.
     pub fn finalize(mut self) -> Result<Self, anyhow::Error> {
         self.content_hash.clear();
         self.content_hash = content_hash(&self)?;
@@ -81,7 +116,9 @@ impl ScanReport {
 /// Local debug samples. Never serialized into [`ScanReport`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DebugSamples {
+    /// Scan that produced the sidecar file.
     pub scan_id: Uuid,
+    /// Operator note. Must not be merged into [`ScanReport`].
     pub notes: String,
 }
 

--- a/crates/redact-scan/src/report.rs
+++ b/crates/redact-scan/src/report.rs
@@ -1,0 +1,129 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+use chrono::{DateTime, Utc};
+use redact_core::EntityType;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::canonical::content_hash;
+use crate::layers::ScanLayer;
+
+/// How a finding was produced. Never carries a matched value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceClass {
+    NameHeuristic,
+    TypeSignal,
+    UniqueIndex,
+    FkTopology,
+    PgStats,
+    TableSample,
+    JsonPath,
+}
+
+/// A PII location. This type must not grow a field that can hold a sample value.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Finding {
+    pub table: String,
+    pub column: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub json_path: Option<String>,
+    pub entity_type: EntityType,
+    pub layer: ScanLayer,
+    pub match_count: u64,
+    pub sampled_rows: u64,
+    pub confidence: f32,
+    pub evidence_class: EvidenceClass,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Target {
+    pub fingerprint: String,
+    pub engine: String,
+    pub version: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Scanner {
+    pub version: String,
+    pub pattern_pack: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Sampling {
+    pub layers: Vec<ScanLayer>,
+    pub rows_per_column: u32,
+    pub method: String,
+}
+
+/// Value-free scan report. `content_hash` is computed after the other fields.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScanReport {
+    pub scan_id: Uuid,
+    pub scanned_at: DateTime<Utc>,
+    pub target: Target,
+    pub scanner: Scanner,
+    pub sampling: Sampling,
+    pub findings: Vec<Finding>,
+    pub content_hash: String,
+}
+
+impl ScanReport {
+    pub fn finalize(mut self) -> Result<Self, anyhow::Error> {
+        self.content_hash.clear();
+        self.content_hash = content_hash(&self)?;
+        Ok(self)
+    }
+}
+
+/// Local debug samples. Never serialized into [`ScanReport`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DebugSamples {
+    pub scan_id: Uuid,
+    pub notes: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finding_json_has_no_value_keys() {
+        let f = Finding {
+            table: "public.t".into(),
+            column: "c".into(),
+            json_path: None,
+            entity_type: EntityType::EmailAddress,
+            layer: ScanLayer::Sample,
+            match_count: 1,
+            sampled_rows: 10,
+            confidence: 0.9,
+            evidence_class: EvidenceClass::TableSample,
+        };
+        let s = serde_json::to_string(&f).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&s).unwrap();
+        let keys = object_keys(&value);
+        for banned in ["value", "sample", "text", "most_common"] {
+            assert!(
+                !keys.iter().any(|k| k == banned),
+                "finding JSON unexpectedly contains key {banned}: {s}"
+            );
+        }
+    }
+
+    fn object_keys(value: &serde_json::Value) -> Vec<String> {
+        match value {
+            serde_json::Value::Object(map) => {
+                let mut keys: Vec<String> = map.keys().cloned().collect();
+                for v in map.values() {
+                    keys.extend(object_keys(v));
+                }
+                keys
+            }
+            serde_json::Value::Array(items) => items.iter().flat_map(object_keys).collect(),
+            _ => Vec::new(),
+        }
+    }
+}

--- a/crates/redact-scan/src/safety.rs
+++ b/crates/redact-scan/src/safety.rs
@@ -103,6 +103,22 @@ async fn verify_readonly(safe: &SafePool, schema: &str) -> Result<(), ScanError>
         ));
     }
 
+    let column_writes: Vec<String> = sqlx::query_scalar(
+        r#"
+        SELECT privilege_type
+        FROM information_schema.column_privileges
+        WHERE grantee = current_user
+        "#,
+    )
+    .fetch_all(&safe.pool)
+    .await
+    .map_err(|e| safe.scrub(e))?;
+    if has_write_grants(column_writes.iter().map(String::as_str)) {
+        return Err(ScanError::new(
+            "refusing to run: role holds column write grants (INSERT/UPDATE)",
+        ));
+    }
+
     let acl_writes: i64 = sqlx::query_scalar(
         r#"
         SELECT COUNT(*)::bigint

--- a/crates/redact-scan/src/safety.rs
+++ b/crates/redact-scan/src/safety.rs
@@ -1,0 +1,178 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Read-only session setup and privilege refusal.
+
+use sqlx::{postgres::PgConnectOptions, postgres::PgPoolOptions, PgPool};
+use std::str::FromStr;
+use std::time::Duration;
+
+use crate::error::ScanError;
+
+/// Privilege names that must not be present on a scan role.
+pub const WRITE_PRIVILEGES: &[&str] = &["INSERT", "UPDATE", "DELETE", "TRUNCATE"];
+
+/// Open a single-connection pool, force read-only, and refuse write roles.
+pub struct SafePool {
+    /// sqlx pool (`max_connections = 1`).
+    pub pool: PgPool,
+    secret: String,
+}
+
+impl SafePool {
+    /// Wrap an error with this connection's password scrubbed.
+    pub fn scrub(&self, msg: impl std::fmt::Display) -> ScanError {
+        ScanError::with_secret(msg, &self.secret)
+    }
+}
+
+/// Connect and enforce the safety session.
+pub async fn connect_readonly(
+    url: &str,
+    statement_timeout: Duration,
+    schema: &str,
+) -> Result<SafePool, ScanError> {
+    let secret = password_from_url(url).unwrap_or_default();
+    let timeout_ms = statement_timeout.as_millis().max(1);
+    let options = PgConnectOptions::from_str(url)
+        .map_err(|e| ScanError::with_secret(e, &secret))?
+        .application_name("redact-scan");
+
+    let pool = PgPoolOptions::new()
+        .max_connections(1)
+        .after_connect(move |conn, _| {
+            Box::pin(async move {
+                sqlx::query("SET default_transaction_read_only = on")
+                    .execute(&mut *conn)
+                    .await?;
+                sqlx::query(&format!("SET statement_timeout = '{timeout_ms}ms'"))
+                    .execute(&mut *conn)
+                    .await?;
+                sqlx::query("SET lock_timeout = '5s'")
+                    .execute(&mut *conn)
+                    .await?;
+                Ok(())
+            })
+        })
+        .connect_with(options)
+        .await
+        .map_err(|e| ScanError::with_secret(e, &secret))?;
+
+    let safe = SafePool { pool, secret };
+    verify_readonly(&safe, schema).await?;
+    Ok(safe)
+}
+
+async fn verify_readonly(safe: &SafePool, schema: &str) -> Result<(), ScanError> {
+    let ro: String = sqlx::query_scalar("SHOW default_transaction_read_only")
+        .fetch_one(&safe.pool)
+        .await
+        .map_err(|e| safe.scrub(e))?;
+    if !ro.eq_ignore_ascii_case("on") {
+        return Err(ScanError::new(
+            "refusing to run: default_transaction_read_only is not on",
+        ));
+    }
+
+    let is_super: bool = sqlx::query_scalar(
+        "SELECT COALESCE((SELECT rolsuper FROM pg_roles WHERE rolname = current_user), false)",
+    )
+    .fetch_one(&safe.pool)
+    .await
+    .map_err(|e| safe.scrub(e))?;
+    if is_super {
+        return Err(ScanError::new(
+            "refusing to run: role is superuser; use a SELECT-only role",
+        ));
+    }
+
+    let info_writes: Vec<String> = sqlx::query_scalar(
+        r#"
+        SELECT privilege_type
+        FROM information_schema.role_table_grants
+        WHERE grantee = current_user
+        "#,
+    )
+    .fetch_all(&safe.pool)
+    .await
+    .map_err(|e| safe.scrub(e))?;
+    if has_write_grants(info_writes.iter().map(String::as_str)) {
+        return Err(ScanError::new(
+            "refusing to run: role holds write grants (INSERT/UPDATE/DELETE/TRUNCATE)",
+        ));
+    }
+
+    let acl_writes: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)::bigint
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = $1
+          AND c.relkind IN ('r', 'p', 'v', 'm')
+          AND (
+            has_table_privilege(current_user, c.oid, 'INSERT')
+            OR has_table_privilege(current_user, c.oid, 'UPDATE')
+            OR has_table_privilege(current_user, c.oid, 'DELETE')
+            OR has_table_privilege(current_user, c.oid, 'TRUNCATE')
+          )
+        "#,
+    )
+    .bind(schema)
+    .fetch_one(&safe.pool)
+    .await
+    .map_err(|e| safe.scrub(e))?;
+    if acl_writes > 0 {
+        return Err(ScanError::new(
+            "refusing to run: role holds write grants (INSERT/UPDATE/DELETE/TRUNCATE)",
+        ));
+    }
+    Ok(())
+}
+
+/// True when any privilege is a table write grant.
+pub fn has_write_grants<'a>(privileges: impl IntoIterator<Item = &'a str>) -> bool {
+    privileges
+        .into_iter()
+        .any(|p| WRITE_PRIVILEGES.iter().any(|w| p.eq_ignore_ascii_case(w)))
+}
+
+/// Extract the password from a Postgres URL, percent-decoded.
+pub fn password_from_url(url: &str) -> Option<String> {
+    let rest = url.split("://").nth(1)?;
+    let creds = rest.split('@').next()?;
+    let pass = creds.split_once(':')?.1;
+    if pass.is_empty() {
+        return None;
+    }
+    Some(crate::scrub::percent_decode(pass))
+}
+
+/// Host and database name from a connection URL. The host is hashed later.
+pub fn host_db_from_url(url: &str) -> Result<(String, String), ScanError> {
+    let opts = PgConnectOptions::from_str(url).map_err(ScanError::new)?;
+    let host = opts.get_host().to_string();
+    let db = opts
+        .get_database()
+        .ok_or_else(|| ScanError::new("connection URL is missing a database name"))?
+        .to_string();
+    Ok((host, db))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_percent_decoded_password() {
+        let p = password_from_url("postgres://u:p%40ss@localhost/db").unwrap();
+        assert_eq!(p, "p@ss");
+    }
+
+    #[test]
+    fn write_grant_rows_are_refused() {
+        assert!(has_write_grants(["SELECT", "INSERT"]));
+        assert!(has_write_grants(["truncate"]));
+        assert!(!has_write_grants(["SELECT", "USAGE"]));
+    }
+}

--- a/crates/redact-scan/src/safety.rs
+++ b/crates/redact-scan/src/safety.rs
@@ -103,17 +103,27 @@ async fn verify_readonly(safe: &SafePool, schema: &str) -> Result<(), ScanError>
         ));
     }
 
-    let column_writes: Vec<String> = sqlx::query_scalar(
+    let column_writes: i64 = sqlx::query_scalar(
         r#"
-        SELECT privilege_type
-        FROM information_schema.column_privileges
-        WHERE grantee = current_user
+        SELECT COUNT(*)::bigint
+        FROM pg_attribute a
+        JOIN pg_class c ON c.oid = a.attrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = $1
+          AND a.attnum > 0
+          AND NOT a.attisdropped
+          AND c.relkind IN ('r', 'p', 'v', 'm')
+          AND (
+            has_column_privilege(current_user, c.oid, a.attname, 'INSERT')
+            OR has_column_privilege(current_user, c.oid, a.attname, 'UPDATE')
+          )
         "#,
     )
-    .fetch_all(&safe.pool)
+    .bind(schema)
+    .fetch_one(&safe.pool)
     .await
     .map_err(|e| safe.scrub(e))?;
-    if has_write_grants(column_writes.iter().map(String::as_str)) {
+    if column_writes > 0 {
         return Err(ScanError::new(
             "refusing to run: role holds column write grants (INSERT/UPDATE)",
         ));

--- a/crates/redact-scan/src/sample.rs
+++ b/crates/redact-scan/src/sample.rs
@@ -51,6 +51,9 @@ async fn sample_column(
     let column = quote_ident(&col.column).map_err(ScanError::new)?;
     let n = col.n_live_tup.max(0) as u64;
     let limit = i64::from(sample_rows.max(1));
+    // When the table is no larger than the sample budget, LIMIT is enough.
+    // TABLESAMPLE on a tiny relation still reads the same rows and can
+    // return zero pages; a full-table random scan is not used either way.
     let sql = if n > 0 && n <= u64::from(sample_rows) {
         format!("SELECT {column}::text FROM {table} LIMIT {limit}")
     } else {

--- a/crates/redact-scan/src/sample.rs
+++ b/crates/redact-scan/src/sample.rs
@@ -42,6 +42,11 @@ pub fn tablesample_percent(n_live_tup: u64, sample_rows: u32) -> f64 {
     (200.0 * f64::from(sample_rows) / n_live_tup as f64).clamp(1.0, 100.0)
 }
 
+/// Percent token written into `TABLESAMPLE SYSTEM (…)` (two decimal places).
+pub fn sql_tablesample_percent(n_live_tup: u64, sample_rows: u32) -> f64 {
+    (tablesample_percent(n_live_tup, sample_rows) * 100.0).round() / 100.0
+}
+
 async fn sample_column(
     pool: &PgPool,
     col: &ColumnMeta,
@@ -54,17 +59,25 @@ async fn sample_column(
     // When the table is no larger than the sample budget, LIMIT is enough.
     // TABLESAMPLE on a tiny relation still reads the same rows and can
     // return zero pages; a full-table random scan is not used either way.
-    let sql = if n > 0 && n <= u64::from(sample_rows) {
+    // Stale n_live_tup=0 (fresh replica) must not use TABLESAMPLE 1%.
+    let sql = if n <= u64::from(sample_rows) {
         format!("SELECT {column}::text FROM {table} LIMIT {limit}")
     } else {
-        let pct = (tablesample_percent(n, sample_rows) * 100.0).round() / 100.0;
+        let pct = sql_tablesample_percent(n, sample_rows);
         format!("SELECT {column}::text FROM {table} TABLESAMPLE SYSTEM ({pct}) LIMIT {limit}")
     };
 
-    let values: Vec<Option<String>> = sqlx::query_scalar(&sql)
+    let mut values: Vec<Option<String>> = sqlx::query_scalar(&sql)
         .fetch_all(pool)
         .await
         .map_err(ScanError::new)?;
+    if values.is_empty() && n > u64::from(sample_rows) {
+        let fallback = format!("SELECT {column}::text FROM {table} LIMIT {limit}");
+        values = sqlx::query_scalar(&fallback)
+            .fetch_all(pool)
+            .await
+            .map_err(ScanError::new)?;
+    }
     let sampled = values.len() as u64;
     if sampled == 0 {
         return Ok(None);
@@ -78,6 +91,12 @@ async fn sample_column(
             continue;
         }
         match_count += 1;
+        crate::report::record_sample(
+            &format!("{}.{}", col.schema, col.table),
+            &col.column,
+            None,
+            &v,
+        );
         for (ty, score) in hits {
             match &best {
                 Some((_, s)) if *s >= score => {}
@@ -110,5 +129,7 @@ mod tests {
         assert_eq!(tablesample_percent(0, 1000), 1.0);
         assert!((tablesample_percent(10_000, 1000) - 20.0).abs() < 1e-9);
         assert_eq!(tablesample_percent(100, 1000), 100.0);
+        assert!((sql_tablesample_percent(10_000, 1000) - 20.0).abs() < 1e-9);
+        assert!(sql_tablesample_percent(10_000, 1000) < 100.0);
     }
 }

--- a/crates/redact-scan/src/sample.rs
+++ b/crates/redact-scan/src/sample.rs
@@ -1,0 +1,111 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Layer 1: bounded `TABLESAMPLE SYSTEM` of candidate columns.
+
+use sqlx::PgPool;
+
+use crate::catalog::ColumnMeta;
+use crate::detect::detect_types;
+use crate::error::ScanError;
+use crate::ident::{qualify_table, quote_ident};
+use crate::layers::ScanLayer;
+use crate::report::{EvidenceClass, Finding};
+
+/// Sample ordinary tables only (`relkind` `r`/`p`). Views are skipped.
+pub async fn l1_findings(
+    pool: &PgPool,
+    columns: &[&ColumnMeta],
+    sample_rows: u32,
+) -> Result<Vec<Finding>, ScanError> {
+    let mut out = Vec::new();
+    for col in columns {
+        if col.relkind != "r" && col.relkind != "p" {
+            continue;
+        }
+        if crate::score::is_json_type(&col.udt) {
+            continue;
+        }
+        if let Some(finding) = sample_column(pool, col, sample_rows).await? {
+            out.push(finding);
+        }
+    }
+    Ok(out)
+}
+
+/// `TABLESAMPLE` percent: `clamp(1, 100, 200 * sample_rows / n_live_tup)`.
+pub fn tablesample_percent(n_live_tup: u64, sample_rows: u32) -> f64 {
+    if n_live_tup == 0 {
+        return 1.0;
+    }
+    (200.0 * f64::from(sample_rows) / n_live_tup as f64).clamp(1.0, 100.0)
+}
+
+async fn sample_column(
+    pool: &PgPool,
+    col: &ColumnMeta,
+    sample_rows: u32,
+) -> Result<Option<Finding>, ScanError> {
+    let table = qualify_table(&col.schema, &col.table).map_err(ScanError::new)?;
+    let column = quote_ident(&col.column).map_err(ScanError::new)?;
+    let n = col.n_live_tup.max(0) as u64;
+    let limit = i64::from(sample_rows.max(1));
+    let sql = if n > 0 && n <= u64::from(sample_rows) {
+        format!("SELECT {column}::text FROM {table} LIMIT {limit}")
+    } else {
+        let pct = (tablesample_percent(n, sample_rows) * 100.0).round() / 100.0;
+        format!("SELECT {column}::text FROM {table} TABLESAMPLE SYSTEM ({pct}) LIMIT {limit}")
+    };
+
+    let values: Vec<Option<String>> = sqlx::query_scalar(&sql)
+        .fetch_all(pool)
+        .await
+        .map_err(ScanError::new)?;
+    let sampled = values.len() as u64;
+    if sampled == 0 {
+        return Ok(None);
+    }
+
+    let mut match_count = 0u64;
+    let mut best: Option<(redact_core::EntityType, f32)> = None;
+    for v in values.into_iter().flatten() {
+        let hits = detect_types(&v);
+        if hits.is_empty() {
+            continue;
+        }
+        match_count += 1;
+        for (ty, score) in hits {
+            match &best {
+                Some((_, s)) if *s >= score => {}
+                _ => best = Some((ty, score)),
+            }
+        }
+    }
+    let Some((entity_type, confidence)) = best else {
+        return Ok(None);
+    };
+    Ok(Some(Finding {
+        table: format!("{}.{}", col.schema, col.table),
+        column: col.column.clone(),
+        json_path: None,
+        entity_type,
+        layer: ScanLayer::Sample,
+        match_count,
+        sampled_rows: sampled,
+        confidence,
+        evidence_class: EvidenceClass::TableSample,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn percent_clamps_and_never_uses_full_random_order() {
+        assert_eq!(tablesample_percent(0, 1000), 1.0);
+        assert!((tablesample_percent(10_000, 1000) - 20.0).abs() < 1e-9);
+        assert_eq!(tablesample_percent(100, 1000), 100.0);
+    }
+}

--- a/crates/redact-scan/src/scan.rs
+++ b/crates/redact-scan/src/scan.rs
@@ -92,6 +92,13 @@ fn dedup_findings(mut findings: Vec<Finding>) -> Vec<Finding> {
             .then(a.column.cmp(&b.column))
             .then(a.json_path.cmp(&b.json_path))
             .then(a.entity_type.as_str().cmp(b.entity_type.as_str()))
+            .then(
+                b.layer
+                    .as_f64()
+                    .partial_cmp(&a.layer.as_f64())
+                    .unwrap_or(std::cmp::Ordering::Equal),
+            )
+            .then(b.match_count.cmp(&a.match_count))
     });
     findings.dedup_by(|a, b| {
         a.table == b.table
@@ -131,7 +138,14 @@ mod tests {
             confidence: 0.8,
             evidence_class: EvidenceClass::NameHeuristic,
         };
-        let out = dedup_findings(vec![f.clone(), f]);
+        let mut stronger = f.clone();
+        stronger.layer = ScanLayer::Sample;
+        stronger.match_count = 4;
+        stronger.sampled_rows = 10;
+        stronger.evidence_class = EvidenceClass::TableSample;
+        let out = dedup_findings(vec![f, stronger.clone()]);
         assert_eq!(out.len(), 1);
+        assert_eq!(out[0].layer, ScanLayer::Sample);
+        assert_eq!(out[0].match_count, 4);
     }
 }

--- a/crates/redact-scan/src/scan.rs
+++ b/crates/redact-scan/src/scan.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See the LICENSE file
 // in the project root for license information.
 
-//! Scan orchestration for layers 0 and 0.5.
+//! Scan orchestration for layers 0, 0.5, 1, and 2.
 
 use chrono::Utc;
 use uuid::Uuid;
@@ -12,9 +12,11 @@ use crate::catalog::{candidates, l0_findings, load_columns};
 use crate::cli::Cli;
 use crate::detect::pattern_pack_label;
 use crate::error::ScanError;
+use crate::json_scan::l2_findings;
 use crate::layers::ScanLayer;
 use crate::report::{Finding, Sampling, ScanReport, Scanner, Target};
 use crate::safety::{connect_readonly, host_db_from_url};
+use crate::sample::l1_findings;
 use crate::stats::l05_findings;
 
 /// Run the selected layers and return a finalized report.
@@ -47,8 +49,11 @@ pub async fn run_scan(cli: &Cli) -> Result<ScanReport, ScanError> {
     if layers.contains(&ScanLayer::Stats) {
         findings.extend(l05_findings(&safe.pool, &cli.schema, &cand).await?);
     }
-    if layers.contains(&ScanLayer::Sample) || layers.contains(&ScanLayer::Json) {
-        tracing::warn!("layers 1 and 2 are not implemented in this revision");
+    if layers.contains(&ScanLayer::Sample) {
+        findings.extend(l1_findings(&safe.pool, &cand, cli.sample_rows).await?);
+    }
+    if layers.contains(&ScanLayer::Json) {
+        findings.extend(l2_findings(&safe.pool, &cand, cli.sample_rows).await?);
     }
 
     findings = dedup_findings(findings);

--- a/crates/redact-scan/src/scan.rs
+++ b/crates/redact-scan/src/scan.rs
@@ -1,0 +1,132 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Scan orchestration for layers 0 and 0.5.
+
+use chrono::Utc;
+use uuid::Uuid;
+
+use crate::canonical::hex_sha256;
+use crate::catalog::{candidates, l0_findings, load_columns};
+use crate::cli::Cli;
+use crate::detect::pattern_pack_label;
+use crate::error::ScanError;
+use crate::layers::ScanLayer;
+use crate::report::{Finding, Sampling, ScanReport, Scanner, Target};
+use crate::safety::{connect_readonly, host_db_from_url};
+use crate::stats::l05_findings;
+
+/// Run the selected layers and return a finalized report.
+pub async fn run_scan(cli: &Cli) -> Result<ScanReport, ScanError> {
+    let url = cli
+        .url
+        .as_deref()
+        .ok_or_else(|| ScanError::new("--url is required to scan"))?;
+    let layers = cli.parsed_layers().map_err(ScanError::new)?;
+    let timeout = cli.statement_timeout().map_err(ScanError::new)?;
+    let (host, database) = host_db_from_url(url)?;
+    let fingerprint = fingerprint(&host, &database, &cli.schema);
+    drop(host);
+
+    let safe = connect_readonly(url, timeout, &cli.schema).await?;
+    let version: String = sqlx::query_scalar("SHOW server_version")
+        .fetch_one(&safe.pool)
+        .await
+        .map_err(|e| safe.scrub(e))?;
+
+    let columns = load_columns(&safe.pool, &cli.schema)
+        .await
+        .map_err(|e| safe.scrub(e))?;
+
+    let mut findings: Vec<Finding> = Vec::new();
+    if layers.contains(&ScanLayer::Metadata) {
+        findings.extend(l0_findings(&columns));
+    }
+    let cand = candidates(&columns, &findings);
+    if layers.contains(&ScanLayer::Stats) {
+        findings.extend(l05_findings(&safe.pool, &cli.schema, &cand).await?);
+    }
+    if layers.contains(&ScanLayer::Sample) || layers.contains(&ScanLayer::Json) {
+        tracing::warn!("layers 1 and 2 are not implemented in this revision");
+    }
+
+    findings = dedup_findings(findings);
+
+    let report = ScanReport {
+        scan_id: Uuid::new_v4(),
+        scanned_at: Utc::now(),
+        target: Target {
+            fingerprint,
+            engine: "postgres".into(),
+            version,
+        },
+        scanner: Scanner {
+            version: env!("CARGO_PKG_VERSION").into(),
+            pattern_pack: pattern_pack_label(),
+        },
+        sampling: Sampling {
+            layers,
+            rows_per_column: cli.sample_rows,
+            method: "TABLESAMPLE SYSTEM".into(),
+        },
+        findings,
+        content_hash: String::new(),
+    };
+    report.finalize().map_err(ScanError::new)
+}
+
+fn fingerprint(host: &str, database: &str, schema: &str) -> String {
+    hex_sha256(format!("{host}|{database}|{schema}").as_bytes())
+}
+
+fn dedup_findings(mut findings: Vec<Finding>) -> Vec<Finding> {
+    findings.sort_by(|a, b| {
+        a.table
+            .cmp(&b.table)
+            .then(a.column.cmp(&b.column))
+            .then(a.json_path.cmp(&b.json_path))
+            .then(a.entity_type.as_str().cmp(b.entity_type.as_str()))
+    });
+    findings.dedup_by(|a, b| {
+        a.table == b.table
+            && a.column == b.column
+            && a.json_path == b.json_path
+            && a.entity_type == b.entity_type
+    });
+    findings
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::report::EvidenceClass;
+    use redact_core::EntityType;
+
+    #[test]
+    fn fingerprint_is_hex_and_stable() {
+        let a = fingerprint("db.example", "app", "public");
+        let b = fingerprint("db.example", "app", "public");
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 64);
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_ne!(a, fingerprint("other", "app", "public"));
+    }
+
+    #[test]
+    fn dedup_keeps_one_row_per_location_type() {
+        let f = Finding {
+            table: "public.t".into(),
+            column: "c".into(),
+            json_path: None,
+            entity_type: EntityType::EmailAddress,
+            layer: ScanLayer::Metadata,
+            match_count: 0,
+            sampled_rows: 0,
+            confidence: 0.8,
+            evidence_class: EvidenceClass::NameHeuristic,
+        };
+        let out = dedup_findings(vec![f.clone(), f]);
+        assert_eq!(out.len(), 1);
+    }
+}

--- a/crates/redact-scan/src/score.rs
+++ b/crates/redact-scan/src/score.rs
@@ -1,0 +1,94 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Name and type heuristics for layer 0.
+
+use redact_core::EntityType;
+
+/// Map a column name token to an entity type and confidence.
+pub fn name_entity(column: &str) -> Option<(EntityType, f32)> {
+    let n = normalize(column);
+    let rules: &[(&str, EntityType, f32)] = &[
+        ("email", EntityType::EmailAddress, 0.85),
+        ("e_mail", EntityType::EmailAddress, 0.85),
+        ("ssn", EntityType::UsSsn, 0.9),
+        ("social_security", EntityType::UsSsn, 0.9),
+        ("dob", EntityType::DateTime, 0.7),
+        ("date_of_birth", EntityType::DateTime, 0.75),
+        ("birth_date", EntityType::DateTime, 0.75),
+        ("phone", EntityType::PhoneNumber, 0.8),
+        ("mobile", EntityType::PhoneNumber, 0.7),
+        ("addr", EntityType::Location, 0.55),
+        ("address", EntityType::Location, 0.6),
+        ("tax_id", EntityType::UsSsn, 0.65),
+        ("iban", EntityType::IbanCode, 0.9),
+        ("passport", EntityType::PassportNumber, 0.8),
+        ("mrn", EntityType::MedicalRecordNumber, 0.8),
+        ("medical_record", EntityType::MedicalRecordNumber, 0.8),
+        ("first_name", EntityType::Person, 0.7),
+        ("last_name", EntityType::Person, 0.7),
+        ("full_name", EntityType::Person, 0.7),
+        ("credit_card", EntityType::CreditCard, 0.9),
+        ("card_number", EntityType::CreditCard, 0.85),
+        ("ip_address", EntityType::IpAddress, 0.8),
+        ("ipv4", EntityType::IpAddress, 0.8),
+        ("ipv6", EntityType::IpAddress, 0.8),
+    ];
+    for (needle, ty, conf) in rules {
+        if n == *needle || n.contains(needle) {
+            return Some((ty.clone(), *conf));
+        }
+    }
+    None
+}
+
+/// True for `json` / `jsonb` (candidates only, not L0 findings).
+pub fn is_json_type(udt: &str) -> bool {
+    matches!(udt, "json" | "jsonb")
+}
+
+/// True for `inet` / `cidr`.
+pub fn is_inet_type(udt: &str) -> bool {
+    matches!(udt, "inet" | "cidr")
+}
+
+/// True for date/timestamp types.
+pub fn is_date_type(udt: &str) -> bool {
+    matches!(udt, "date" | "timestamp" | "timestamptz")
+}
+
+/// True for text-like types that may hold identifiers.
+pub fn is_textish(udt: &str) -> bool {
+    matches!(udt, "text" | "varchar" | "bpchar" | "citext")
+}
+
+fn normalize(name: &str) -> String {
+    name.to_ascii_lowercase()
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn email_name() {
+        let (ty, _) = name_entity("user_email").unwrap();
+        assert_eq!(ty, EntityType::EmailAddress);
+    }
+
+    #[test]
+    fn dob_name() {
+        let (ty, _) = name_entity("date_of_birth").unwrap();
+        assert_eq!(ty, EntityType::DateTime);
+    }
+
+    #[test]
+    fn status_is_not_pii() {
+        assert!(name_entity("status").is_none());
+        assert!(name_entity("active").is_none());
+    }
+}

--- a/crates/redact-scan/src/score.rs
+++ b/crates/redact-scan/src/score.rs
@@ -35,7 +35,9 @@ pub fn name_entity(column: &str) -> Option<(EntityType, f32)> {
         ("ipv4", EntityType::IpAddress, 0.8),
         ("ipv6", EntityType::IpAddress, 0.8),
     ];
-    for (needle, ty, conf) in rules {
+    let mut ranked: Vec<_> = rules.iter().collect();
+    ranked.sort_by_key(|(needle, _, _)| std::cmp::Reverse(needle.len()));
+    for (needle, ty, conf) in ranked {
         if n == *needle || n.contains(needle) {
             return Some((ty.clone(), *conf));
         }
@@ -90,5 +92,13 @@ mod tests {
     fn status_is_not_pii() {
         assert!(name_entity("status").is_none());
         assert!(name_entity("active").is_none());
+    }
+
+    #[test]
+    fn ip_address_is_not_location() {
+        let (ty, _) = name_entity("ip_address").unwrap();
+        assert_eq!(ty, EntityType::IpAddress);
+        let (ty, _) = name_entity("client_ipv4").unwrap();
+        assert_eq!(ty, EntityType::IpAddress);
     }
 }

--- a/crates/redact-scan/src/score.rs
+++ b/crates/redact-scan/src/score.rs
@@ -35,14 +35,22 @@ pub fn name_entity(column: &str) -> Option<(EntityType, f32)> {
         ("ipv4", EntityType::IpAddress, 0.8),
         ("ipv6", EntityType::IpAddress, 0.8),
     ];
-    let mut ranked: Vec<_> = rules.iter().collect();
-    ranked.sort_by_key(|(needle, _, _)| std::cmp::Reverse(needle.len()));
-    for (needle, ty, conf) in ranked {
+    let mut best: Option<(EntityType, f32, usize)> = None;
+    for (needle, ty, conf) in rules {
         if n == *needle || n.contains(needle) {
-            return Some((ty.clone(), *conf));
+            let cand = (ty.clone(), *conf, needle.len());
+            let take = match &best {
+                None => true,
+                Some((_, bconf, blen)) => {
+                    *conf > *bconf || (*conf == *bconf && needle.len() > *blen)
+                }
+            };
+            if take {
+                best = Some(cand);
+            }
         }
     }
-    None
+    best.map(|(ty, conf, _)| (ty, conf))
 }
 
 /// True for `json` / `jsonb` (candidates only, not L0 findings).
@@ -100,5 +108,13 @@ mod tests {
         assert_eq!(ty, EntityType::IpAddress);
         let (ty, _) = name_entity("client_ipv4").unwrap();
         assert_eq!(ty, EntityType::IpAddress);
+    }
+
+    #[test]
+    fn email_address_is_email_not_location() {
+        let (ty, _) = name_entity("email_address").unwrap();
+        assert_eq!(ty, EntityType::EmailAddress);
+        let (ty, _) = name_entity("contact_email_addr").unwrap();
+        assert_eq!(ty, EntityType::EmailAddress);
     }
 }

--- a/crates/redact-scan/src/scrub.rs
+++ b/crates/redact-scan/src/scrub.rs
@@ -1,0 +1,63 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+use regex::Regex;
+use std::sync::OnceLock;
+
+fn url_userinfo() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)([a-z][a-z0-9+.-]*://)([^:/?#]+):([^@/?#]+)@").expect("url userinfo regex")
+    })
+}
+
+fn password_query() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)(password|passwd|pwd|secret)=([^&\s]+)").expect("password query regex")
+    })
+}
+
+/// Redact credentials from any string that may appear in logs or errors.
+pub fn scrub(input: &str) -> String {
+    let mut out = url_userinfo()
+        .replace_all(input, |caps: &regex::Captures| {
+            format!("{}{}:***@", &caps[1], &caps[2])
+        })
+        .into_owned();
+    out = password_query()
+        .replace_all(&out, |caps: &regex::Captures| format!("{}=***", &caps[1]))
+        .into_owned();
+    // Percent-encoded userinfo (`user%3Apass@` is uncommon; cover `pass%40word` leftovers
+    // by also stripping raw password tokens when explicitly provided.
+    out
+}
+
+/// If `secret` is non-empty and appears in `input`, replace every occurrence.
+pub fn scrub_secret(input: &str, secret: &str) -> String {
+    let mut out = scrub(input);
+    if !secret.is_empty() && out.contains(secret) {
+        out = out.replace(secret, "***");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scrubs_url_password() {
+        let s = scrub("postgres://alice:s3cret-pass@db.example/app");
+        assert!(!s.contains("s3cret-pass"));
+        assert!(s.contains("alice:***@"));
+    }
+
+    #[test]
+    fn scrubs_query_password() {
+        let s = scrub("error password=hunter2 extra");
+        assert!(!s.contains("hunter2"));
+        assert!(s.contains("password=***"));
+    }
+}

--- a/crates/redact-scan/src/scrub.rs
+++ b/crates/redact-scan/src/scrub.rs
@@ -19,26 +19,69 @@ fn password_query() -> &'static Regex {
     })
 }
 
-/// Redact credentials from any string that may appear in logs or errors.
-pub fn scrub(input: &str) -> String {
-    let mut out = url_userinfo()
+/// Percent-decode `%XX` sequences. Invalid sequences are left unchanged.
+pub fn percent_decode(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let Ok(v) = u8::from_str_radix(&input[i + 1..i + 3], 16) {
+                out.push(v);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn fully_percent_decode(input: &str) -> String {
+    let mut current = input.to_string();
+    for _ in 0..3 {
+        let next = percent_decode(&current);
+        if next == current {
+            break;
+        }
+        current = next;
+    }
+    current
+}
+
+fn scrub_patterns(input: &str) -> String {
+    let out = url_userinfo()
         .replace_all(input, |caps: &regex::Captures| {
             format!("{}{}:***@", &caps[1], &caps[2])
         })
         .into_owned();
-    out = password_query()
+    password_query()
         .replace_all(&out, |caps: &regex::Captures| format!("{}=***", &caps[1]))
-        .into_owned();
-    // Percent-encoded userinfo (`user%3Apass@` is uncommon; cover `pass%40word` leftovers
-    // by also stripping raw password tokens when explicitly provided.
-    out
+        .into_owned()
+}
+
+/// Redact credentials from any string that may appear in logs or errors.
+///
+/// Handles `user:pass@`, `password=`, and percent-encoded variants
+/// (`user%3Apass`, `password%3D…`, `%40` in passwords) by decoding first.
+pub fn scrub(input: &str) -> String {
+    let decoded = fully_percent_decode(input);
+    scrub_patterns(&decoded)
 }
 
 /// If `secret` is non-empty and appears in `input`, replace every occurrence.
 pub fn scrub_secret(input: &str, secret: &str) -> String {
     let mut out = scrub(input);
-    if !secret.is_empty() && out.contains(secret) {
+    if secret.is_empty() {
+        return out;
+    }
+    if out.contains(secret) {
         out = out.replace(secret, "***");
+    }
+    let decoded_secret = fully_percent_decode(secret);
+    if decoded_secret != secret && out.contains(&decoded_secret) {
+        out = out.replace(&decoded_secret, "***");
     }
     out
 }
@@ -57,6 +100,28 @@ mod tests {
     #[test]
     fn scrubs_query_password() {
         let s = scrub("error password=hunter2 extra");
+        assert!(!s.contains("hunter2"));
+        assert!(s.contains("password=***"));
+    }
+
+    #[test]
+    fn scrubs_percent_encoded_password_in_url() {
+        let s = scrub("postgres://alice:p%40ssword@db.example/app");
+        assert!(!s.contains("p%40ssword"));
+        assert!(!s.contains("p@ssword"));
+        assert!(s.contains("alice:***@"));
+    }
+
+    #[test]
+    fn scrubs_percent_encoded_userinfo_delimiter() {
+        let s = scrub("postgres://alice%3As3cret-pass@db.example/app");
+        assert!(!s.contains("s3cret-pass"));
+        assert!(s.contains("alice:***@"));
+    }
+
+    #[test]
+    fn scrubs_percent_encoded_password_query() {
+        let s = scrub("login failed password%3Dhunter2");
         assert!(!s.contains("hunter2"));
         assert!(s.contains("password=***"));
     }

--- a/crates/redact-scan/src/scrub.rs
+++ b/crates/redact-scan/src/scrub.rs
@@ -47,6 +47,18 @@ fn fully_percent_decode(input: &str) -> String {
     current
 }
 
+fn scrub_decode_rounds(input: &str) -> String {
+    let mut current = scrub_patterns(input);
+    for _ in 0..3 {
+        let next = percent_decode(&current);
+        if next == current {
+            break;
+        }
+        current = scrub_patterns(&next);
+    }
+    current
+}
+
 /// Redact `user:password@` using the last `@` in the URL authority.
 ///
 /// That last `@` is the host delimiter (RFC 3986). Encoded `@` / `:` inside
@@ -106,15 +118,10 @@ fn scrub_patterns(input: &str) -> String {
 /// Handles `user:pass@`, `password=`, and percent-encoded variants
 /// (`user%3Apass`, `password%3D…`, `%40` / `%26` inside passwords).
 /// Patterns run on the raw string first so encoded reserved bytes stay
-/// inside the credential; then the result is decoded and scrubbed again.
+/// inside the credential; then each percent-decode pass is scrubbed again
+/// (nested `%25` encodings included).
 pub fn scrub(input: &str) -> String {
-    let raw = scrub_patterns(input);
-    let decoded = fully_percent_decode(&raw);
-    if decoded == raw {
-        raw
-    } else {
-        scrub_patterns(&decoded)
-    }
+    scrub_decode_rounds(input)
 }
 
 /// If `secret` is non-empty and appears in `input`, replace every occurrence.
@@ -195,6 +202,14 @@ mod tests {
     fn leaves_username_only_url() {
         let s = scrub("postgres://alice@db.example/app");
         assert_eq!(s, "postgres://alice@db.example/app");
+    }
+
+    #[test]
+    fn scrubs_double_encoded_query_password() {
+        let s = scrub("login failed password%253Dpa%2526ss");
+        assert!(!s.contains("pa%26ss"), "{s}");
+        assert!(!s.contains("pa&ss"), "{s}");
+        assert!(s.contains("password=***"), "{s}");
     }
 
     #[test]

--- a/crates/redact-scan/src/scrub.rs
+++ b/crates/redact-scan/src/scrub.rs
@@ -8,8 +8,10 @@ use std::sync::OnceLock;
 fn password_query() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
-        Regex::new(r"(?i)(password|passwd|pwd|secret)(?:=|%3[Dd])([^&\s]+)")
-            .expect("password query regex")
+        Regex::new(
+            r#"(?i)(password|passwd|pwd|secret)(?:=|%3[Dd])(?:'([^']*)'|"([^"]*)"|([^&\s]+))"#,
+        )
+        .expect("password query regex")
     })
 }
 
@@ -156,6 +158,16 @@ mod tests {
         let s = scrub("error password=hunter2 extra");
         assert!(!s.contains("hunter2"));
         assert!(s.contains("password=***"));
+    }
+
+    #[test]
+    fn scrubs_quoted_libpq_password() {
+        let s = scrub("libpq connect failed: host=db user=app password='pa ss' dbname=prod");
+        assert!(!s.contains("pa ss"), "{s}");
+        assert!(s.contains("password=***"), "{s}");
+        let d = scrub(r#"libpq connect failed password="pa ss" dbname=prod"#);
+        assert!(!d.contains("pa ss"), "{d}");
+        assert!(d.contains("password=***"), "{d}");
     }
 
     #[test]

--- a/crates/redact-scan/src/scrub.rs
+++ b/crates/redact-scan/src/scrub.rs
@@ -5,17 +5,11 @@
 use regex::Regex;
 use std::sync::OnceLock;
 
-fn url_userinfo() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| {
-        Regex::new(r"(?i)([a-z][a-z0-9+.-]*://)([^:/?#]+):([^@/?#]+)@").expect("url userinfo regex")
-    })
-}
-
 fn password_query() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
-        Regex::new(r"(?i)(password|passwd|pwd|secret)=([^&\s]+)").expect("password query regex")
+        Regex::new(r"(?i)(password|passwd|pwd|secret)(?:=|%3[Dd])([^&\s]+)")
+            .expect("password query regex")
     })
 }
 
@@ -53,23 +47,66 @@ fn fully_percent_decode(input: &str) -> String {
     current
 }
 
-fn scrub_patterns(input: &str) -> String {
-    let out = url_userinfo()
-        .replace_all(input, |caps: &regex::Captures| {
-            format!("{}{}:***@", &caps[1], &caps[2])
-        })
-        .into_owned();
+/// Redact `user:password@` using the last `@` in the URL authority.
+///
+/// That last `@` is the host delimiter (RFC 3986). Encoded `@` / `:` inside
+/// the password therefore cannot split the credential.
+fn scrub_url_userinfo(input: &str) -> String {
+    let lower = input.to_ascii_lowercase();
+    let mut out = String::with_capacity(input.len());
+    let mut i = 0;
+    while i < input.len() {
+        let Some(rel) = lower[i..].find("://") else {
+            out.push_str(&input[i..]);
+            break;
+        };
+        let scheme_end = i + rel + 3;
+        out.push_str(&input[i..scheme_end]);
+        let rest = &input[scheme_end..];
+        let auth_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+        let authority = &rest[..auth_end];
+        if let Some(at) = authority.rfind('@') {
+            let userinfo = &authority[..at];
+            let hostport = &authority[at + 1..];
+            if let Some(user) = userinfo_user(userinfo) {
+                out.push_str(user);
+                out.push_str(":***@");
+                out.push_str(hostport);
+            } else {
+                out.push_str(authority);
+            }
+        } else {
+            out.push_str(authority);
+        }
+        i = scheme_end + auth_end;
+    }
+    out
+}
+
+fn userinfo_user(userinfo: &str) -> Option<&str> {
+    if let Some((user, _)) = userinfo.split_once(':') {
+        return Some(user);
+    }
+    let lower = userinfo.to_ascii_lowercase();
+    lower.find("%3a").map(|idx| &userinfo[..idx])
+}
+
+fn scrub_password_params(input: &str) -> String {
     password_query()
-        .replace_all(&out, |caps: &regex::Captures| format!("{}=***", &caps[1]))
+        .replace_all(input, |caps: &regex::Captures| format!("{}=***", &caps[1]))
         .into_owned()
+}
+
+fn scrub_patterns(input: &str) -> String {
+    scrub_password_params(&scrub_url_userinfo(input))
 }
 
 /// Redact credentials from any string that may appear in logs or errors.
 ///
 /// Handles `user:pass@`, `password=`, and percent-encoded variants
-/// (`user%3Apass`, `password%3D…`, `%40` in passwords). Patterns run on the
-/// raw string first so an encoded `@` inside a password cannot split userinfo
-/// after decode; then the result is decoded and scrubbed again.
+/// (`user%3Apass`, `password%3D…`, `%40` / `%26` inside passwords).
+/// Patterns run on the raw string first so encoded reserved bytes stay
+/// inside the credential; then the result is decoded and scrubbed again.
 pub fn scrub(input: &str) -> String {
     let raw = scrub_patterns(input);
     let decoded = fully_percent_decode(&raw);
@@ -124,6 +161,21 @@ mod tests {
     }
 
     #[test]
+    fn scrubs_percent_encoded_userinfo_delimiter() {
+        let s = scrub("postgres://alice%3As3cret-pass@db.example/app");
+        assert!(!s.contains("s3cret-pass"));
+        assert!(s.contains("alice:***@"));
+    }
+
+    #[test]
+    fn scrubs_combined_encoded_separator_and_at() {
+        let s = scrub("postgres://alice%3As3cret%40pass@db.example/app");
+        assert!(!s.contains("s3cret"), "{s}");
+        assert!(!s.contains("pass@"), "{s}");
+        assert!(s.contains("alice:***@"), "{s}");
+    }
+
+    #[test]
     fn scrubs_password_with_encoded_reserved_bytes() {
         let s = scrub("postgres://alice:a%26b%2Fc%3Fd@db.example/app");
         assert!(!s.contains("a%26b"), "{s}");
@@ -132,23 +184,23 @@ mod tests {
     }
 
     #[test]
+    fn scrubs_encoded_query_password_with_encoded_ampersand() {
+        let s = scrub("login failed password%3Dpa%26ss");
+        assert!(!s.contains("pa%26ss"), "{s}");
+        assert!(!s.contains("pa&ss"), "{s}");
+        assert!(s.contains("password=***"), "{s}");
+    }
+
+    #[test]
+    fn leaves_username_only_url() {
+        let s = scrub("postgres://alice@db.example/app");
+        assert_eq!(s, "postgres://alice@db.example/app");
+    }
+
+    #[test]
     fn percent_decode_leaves_invalid_and_unicode_sequences() {
         assert_eq!(percent_decode("%€"), "%€");
         assert_eq!(percent_decode("%ZZ"), "%ZZ");
         assert_eq!(percent_decode("ok%20x"), "ok x");
-    }
-
-    #[test]
-    fn scrubs_percent_encoded_userinfo_delimiter() {
-        let s = scrub("postgres://alice%3As3cret-pass@db.example/app");
-        assert!(!s.contains("s3cret-pass"));
-        assert!(s.contains("alice:***@"));
-    }
-
-    #[test]
-    fn scrubs_percent_encoded_password_query() {
-        let s = scrub("login failed password%3Dhunter2");
-        assert!(!s.contains("hunter2"));
-        assert!(s.contains("password=***"));
     }
 }

--- a/crates/redact-scan/src/scrub.rs
+++ b/crates/redact-scan/src/scrub.rs
@@ -26,8 +26,11 @@ pub fn percent_decode(input: &str) -> String {
     let mut i = 0;
     while i < bytes.len() {
         if bytes[i] == b'%' && i + 2 < bytes.len() {
-            if let Ok(v) = u8::from_str_radix(&input[i + 1..i + 3], 16) {
-                out.push(v);
+            let h1 = bytes[i + 1];
+            let h2 = bytes[i + 2];
+            if h1.is_ascii_hexdigit() && h2.is_ascii_hexdigit() {
+                let hex = std::str::from_utf8(&bytes[i + 1..i + 3]).expect("ascii hex");
+                out.push(u8::from_str_radix(hex, 16).expect("ascii hex"));
                 i += 3;
                 continue;
             }
@@ -64,10 +67,17 @@ fn scrub_patterns(input: &str) -> String {
 /// Redact credentials from any string that may appear in logs or errors.
 ///
 /// Handles `user:pass@`, `password=`, and percent-encoded variants
-/// (`user%3Apass`, `password%3D…`, `%40` in passwords) by decoding first.
+/// (`user%3Apass`, `password%3D…`, `%40` in passwords). Patterns run on the
+/// raw string first so an encoded `@` inside a password cannot split userinfo
+/// after decode; then the result is decoded and scrubbed again.
 pub fn scrub(input: &str) -> String {
-    let decoded = fully_percent_decode(input);
-    scrub_patterns(&decoded)
+    let raw = scrub_patterns(input);
+    let decoded = fully_percent_decode(&raw);
+    if decoded == raw {
+        raw
+    } else {
+        scrub_patterns(&decoded)
+    }
 }
 
 /// If `secret` is non-empty and appears in `input`, replace every occurrence.
@@ -107,9 +117,25 @@ mod tests {
     #[test]
     fn scrubs_percent_encoded_password_in_url() {
         let s = scrub("postgres://alice:p%40ssword@db.example/app");
-        assert!(!s.contains("p%40ssword"));
-        assert!(!s.contains("p@ssword"));
-        assert!(s.contains("alice:***@"));
+        assert!(!s.contains("p%40ssword"), "{s}");
+        assert!(!s.contains("p@ssword"), "{s}");
+        assert!(!s.contains("ssword"), "{s}");
+        assert!(s.contains("alice:***@"), "{s}");
+    }
+
+    #[test]
+    fn scrubs_password_with_encoded_reserved_bytes() {
+        let s = scrub("postgres://alice:a%26b%2Fc%3Fd@db.example/app");
+        assert!(!s.contains("a%26b"), "{s}");
+        assert!(!s.contains("a&b"), "{s}");
+        assert!(s.contains("alice:***@"), "{s}");
+    }
+
+    #[test]
+    fn percent_decode_leaves_invalid_and_unicode_sequences() {
+        assert_eq!(percent_decode("%€"), "%€");
+        assert_eq!(percent_decode("%ZZ"), "%ZZ");
+        assert_eq!(percent_decode("ok%20x"), "ok x");
     }
 
     #[test]

--- a/crates/redact-scan/src/scrub.rs
+++ b/crates/redact-scan/src/scrub.rs
@@ -9,7 +9,7 @@ fn password_query() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
         Regex::new(
-            r#"(?i)(password|passwd|pwd|secret)(?:=|%3[Dd])(?:'([^']*)'|"([^"]*)"|([^&\s]+))"#,
+            r#"(?i)(password|passwd|pwd|secret)(?:=|%3[Dd])(?:'((?:\\.|[^'\\])*)'|"((?:\\.|[^"\\])*)"|([^&\s]+))"#,
         )
         .expect("password query regex")
     })
@@ -168,6 +168,9 @@ mod tests {
         let d = scrub(r#"libpq connect failed password="pa ss" dbname=prod"#);
         assert!(!d.contains("pa ss"), "{d}");
         assert!(d.contains("password=***"), "{d}");
+        let e = scrub(r"libpq connect failed: password='pa\' ss' dbname=prod");
+        assert!(!e.contains("ss'"), "{e}");
+        assert!(e.contains("password=***"), "{e}");
     }
 
     #[test]

--- a/crates/redact-scan/src/stats.rs
+++ b/crates/redact-scan/src/stats.rs
@@ -1,0 +1,87 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Layer 0.5: `pg_stats` most-common values and histogram bounds.
+
+use sqlx::PgPool;
+
+use crate::catalog::ColumnMeta;
+use crate::detect::detect_types;
+use crate::error::ScanError;
+use crate::layers::ScanLayer;
+use crate::report::{EvidenceClass, Finding};
+
+/// Scan planner statistics. Never echoes MCV / histogram values into findings.
+pub async fn l05_findings(
+    pool: &PgPool,
+    schema: &str,
+    candidates: &[&ColumnMeta],
+) -> Result<Vec<Finding>, ScanError> {
+    let rows = sqlx::query_as::<_, (String, String, Option<String>, Option<String>, Option<f32>)>(
+        r#"
+        SELECT tablename, attname,
+               most_common_vals::text,
+               histogram_bounds::text,
+               n_distinct
+        FROM pg_stats
+        WHERE schemaname = $1
+        "#,
+    )
+    .bind(schema)
+    .fetch_all(pool)
+    .await;
+    let rows = match rows {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!("layer 0.5 skipped (pg_stats unavailable): {e}");
+            return Ok(Vec::new());
+        }
+    };
+
+    let wanted: std::collections::HashSet<(&str, &str)> = candidates
+        .iter()
+        .map(|c| (c.table.as_str(), c.column.as_str()))
+        .collect();
+
+    let mut out = Vec::new();
+    for (table, column, mcv, hist, _n_distinct) in rows {
+        if !wanted.contains(&(table.as_str(), column.as_str())) {
+            continue;
+        }
+        let mut texts = Vec::new();
+        if let Some(v) = mcv {
+            texts.push(v);
+        }
+        if let Some(v) = hist {
+            texts.push(v);
+        }
+        if texts.is_empty() {
+            continue;
+        }
+        let blob = texts.join(" ");
+        let hits = detect_types(&blob);
+        drop(blob);
+        drop(texts);
+        if hits.is_empty() {
+            continue;
+        }
+        let sampled = hits.len() as u64;
+        let (entity_type, confidence) = hits
+            .into_iter()
+            .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+            .expect("hits non-empty");
+        out.push(Finding {
+            table: format!("{schema}.{table}"),
+            column,
+            json_path: None,
+            entity_type,
+            layer: ScanLayer::Stats,
+            match_count: sampled,
+            sampled_rows: sampled,
+            confidence,
+            evidence_class: EvidenceClass::PgStats,
+        });
+    }
+    Ok(out)
+}

--- a/crates/redact-scan/src/stats.rs
+++ b/crates/redact-scan/src/stats.rs
@@ -66,7 +66,7 @@ pub async fn l05_findings(
         if hits.is_empty() {
             continue;
         }
-        let sampled = hits.len() as u64;
+        let match_count = hits.len() as u64;
         let (entity_type, confidence) = hits
             .into_iter()
             .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
@@ -77,8 +77,8 @@ pub async fn l05_findings(
             json_path: None,
             entity_type,
             layer: ScanLayer::Stats,
-            match_count: sampled,
-            sampled_rows: sampled,
+            match_count,
+            sampled_rows: 0,
             confidence,
             evidence_class: EvidenceClass::PgStats,
         });

--- a/crates/redact-scan/src/upload.rs
+++ b/crates/redact-scan/src/upload.rs
@@ -1,0 +1,60 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Optional HTTP POST of the report JSON.
+
+use crate::error::ScanError;
+use crate::report::ScanReport;
+
+/// POST `report` to `url`. 2xx required. Optional Bearer key and extra headers.
+pub async fn post_report(
+    url: &str,
+    api_key: Option<&str>,
+    headers: &[String],
+    report: &ScanReport,
+) -> Result<(), ScanError> {
+    let client = reqwest::Client::new();
+    let mut req = client
+        .post(url)
+        .header("content-type", "application/json")
+        .json(report);
+    if let Some(key) = api_key {
+        if !key.is_empty() {
+            req = req.bearer_auth(key);
+        }
+    }
+    for h in headers {
+        let (name, value) = parse_header(h)?;
+        req = req.header(name, value);
+    }
+    let resp = req.send().await.map_err(ScanError::new)?;
+    if !resp.status().is_success() {
+        return Err(ScanError::new(format!(
+            "report POST failed with HTTP {}",
+            resp.status()
+        )));
+    }
+    Ok(())
+}
+
+/// Split `Name: value`.
+pub fn parse_header(h: &str) -> Result<(&str, &str), ScanError> {
+    let (name, value) = h
+        .split_once(':')
+        .ok_or_else(|| ScanError::new("invalid --report-header; expected Name: value"))?;
+    Ok((name.trim(), value.trim()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_split() {
+        let (n, v) = parse_header("X-Run: abc").unwrap();
+        assert_eq!(n, "X-Run");
+        assert_eq!(v, "abc");
+        assert!(parse_header("nope").is_err());
+    }
+}

--- a/crates/redact-scan/tests/cli_safety.rs
+++ b/crates/redact-scan/tests/cli_safety.rs
@@ -1,0 +1,56 @@
+//! CLI safety: flag combinations that must fail before any database connect.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::net::TcpListener;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+fn cli() -> Command {
+    Command::cargo_bin("redact-scan").unwrap()
+}
+
+#[test]
+fn include_samples_with_report_url_exits_error_without_connect() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let mut accepted = 0u32;
+        let start = std::time::Instant::now();
+        while start.elapsed() < Duration::from_millis(400) {
+            if listener.accept().is_ok() {
+                accepted += 1;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        let _ = tx.send(accepted);
+    });
+
+    cli()
+        .arg("--include-samples")
+        .arg("--samples-out")
+        .arg("/tmp/redact-scan-samples.json")
+        .arg("--report-url")
+        .arg(format!("http://{addr}/hook"))
+        .arg("--url")
+        .arg("postgres://nobody:should-not-connect@127.0.0.1:1/db")
+        .assert()
+        .failure()
+        .code(2)
+        .stderr(predicate::str::contains("--include-samples"));
+
+    let accepted = rx.recv_timeout(Duration::from_secs(1)).unwrap_or(0);
+    assert_eq!(accepted, 0, "must not open a TCP connection");
+}
+
+#[test]
+fn help_mentions_read_only_scanner() {
+    cli()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Read-only Postgres"));
+}

--- a/crates/redact-scan/tests/postgres.rs
+++ b/crates/redact-scan/tests/postgres.rs
@@ -1,0 +1,269 @@
+//! Postgres acceptance tests. Skipped unless `REDACT_SCAN_INTEGRATION=1`.
+
+mod support;
+
+use clap::Parser;
+use redact_scan::cli::Cli;
+use redact_scan::layers::ScanLayer;
+use redact_scan::run_scan;
+use redact_scan::safety::connect_readonly;
+use sqlx::postgres::PgPoolOptions;
+use std::time::{Duration, Instant};
+use support::fixture::{self, Fixture};
+use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+use testcontainers_modules::testcontainers::ImageExt;
+
+fn enabled() -> bool {
+    std::env::var("REDACT_SCAN_INTEGRATION").ok().as_deref() == Some("1")
+}
+
+fn seed() -> u64 {
+    std::env::var("REDACT_SCAN_FIXTURE_SEED")
+        .ok()
+        .and_then(|s| {
+            s.strip_prefix("0x")
+                .and_then(|h| u64::from_str_radix(h, 16).ok())
+                .or_else(|| s.parse().ok())
+        })
+        .unwrap_or_else(rand::random)
+}
+
+async fn start_postgres() -> (
+    testcontainers_modules::testcontainers::ContainerAsync<Postgres>,
+    String,
+    String,
+) {
+    let container = Postgres::default()
+        .with_tag("16-alpine")
+        .with_cmd([
+            "postgres",
+            "-c",
+            "shared_preload_libraries=pg_stat_statements",
+        ])
+        .start()
+        .await
+        .expect("start postgres");
+    let host = container.get_host().await.expect("host").to_string();
+    let port = container.get_host_port_ipv4(5432).await.expect("port");
+    let admin = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    let scanner = format!("postgres://scanner:scan-pass-not-super@{host}:{port}/postgres");
+    (container, admin, scanner)
+}
+
+async fn admin_pool(url: &str) -> sqlx::PgPool {
+    PgPoolOptions::new()
+        .max_connections(2)
+        .connect(url)
+        .await
+        .expect("admin connect")
+}
+
+async fn prepare_roles(admin: &sqlx::PgPool) {
+    sqlx::query("CREATE EXTENSION IF NOT EXISTS pg_stat_statements")
+        .execute(admin)
+        .await
+        .expect("pg_stat_statements");
+    sqlx::query(
+        "CREATE ROLE scanner LOGIN PASSWORD 'scan-pass-not-super' NOSUPERUSER NOCREATEDB NOCREATEROLE",
+    )
+    .execute(admin)
+    .await
+    .expect("create scanner");
+    sqlx::query("GRANT USAGE ON SCHEMA public TO scanner")
+        .execute(admin)
+        .await
+        .expect("grant usage");
+    sqlx::query("GRANT pg_read_all_stats TO scanner")
+        .execute(admin)
+        .await
+        .ok();
+}
+
+async fn grant_select(admin: &sqlx::PgPool) {
+    sqlx::query("GRANT SELECT ON ALL TABLES IN SCHEMA public TO scanner")
+        .execute(admin)
+        .await
+        .expect("grant select");
+}
+
+fn scan_cli(url: &str, layers: &str) -> Cli {
+    Cli::parse_from([
+        "redact-scan",
+        "--url",
+        url,
+        "--schema",
+        "public",
+        "--layers",
+        layers,
+        "--sample-rows",
+        "200",
+    ])
+}
+
+#[tokio::test]
+async fn acceptance_randomized_fixture() {
+    if !enabled() {
+        eprintln!("skipping: set REDACT_SCAN_INTEGRATION=1");
+        return;
+    }
+    let seed = seed();
+    eprintln!("redact-scan fixture seed={seed:#x}");
+    let (_c, admin_url, scanner_url) = start_postgres().await;
+    let admin = admin_pool(&admin_url).await;
+    prepare_roles(&admin).await;
+
+    let (fx, stmts) = Fixture::generate(seed);
+    fixture::apply(&admin, &stmts).await.expect("apply fixture");
+    sqlx::query("ANALYZE")
+        .execute(&admin)
+        .await
+        .expect("analyze");
+    grant_select(&admin).await;
+    sqlx::query("SELECT pg_stat_statements_reset()")
+        .execute(&admin)
+        .await
+        .ok();
+
+    let super_err = run_scan(&scan_cli(&admin_url, "0,0.5"))
+        .await
+        .expect_err("superuser must be refused");
+    assert!(
+        super_err
+            .to_string()
+            .to_ascii_lowercase()
+            .contains("superuser"),
+        "{super_err}"
+    );
+
+    let l05 = run_scan(&scan_cli(&scanner_url, "0,0.5"))
+        .await
+        .expect("l0+l0.5");
+    let found: Vec<(String, String)> = l05
+        .findings
+        .iter()
+        .map(|f| {
+            let table = f.table.rsplit('.').next().unwrap_or(&f.table).to_string();
+            (table, f.column.clone())
+        })
+        .collect();
+    let pii_hits = fx
+        .pii
+        .iter()
+        .filter(|p| found.iter().any(|f| f == *p))
+        .count();
+    assert!(
+        pii_hits * 5 >= fx.pii.len() * 4,
+        "L0+L0.5 found {pii_hits}/{} PII columns: {found:?}",
+        fx.pii.len()
+    );
+    for c in &fx.clean {
+        assert!(
+            !found.iter().any(|f| f == c),
+            "clean column {}.{} appeared in L0+L0.5",
+            c.0,
+            c.1
+        );
+    }
+
+    let queries: Vec<String> = sqlx::query_scalar("SELECT query FROM pg_stat_statements")
+        .fetch_all(&admin)
+        .await
+        .unwrap_or_default();
+    for (table, _) in fx.pii.iter().chain(fx.clean.iter()) {
+        for q in &queries {
+            let lower = q.to_ascii_lowercase();
+            if lower.contains(&format!("from {table}"))
+                || lower.contains(&format!("from public.{table}"))
+                || lower.contains(&format!("from \"{table}\""))
+            {
+                panic!("L0+L0.5 issued user-table SELECT: {q}");
+            }
+        }
+    }
+
+    let full = run_scan(&scan_cli(&scanner_url, "0,0.5,1,2"))
+        .await
+        .expect("full scan");
+    let full_found: Vec<(String, String)> = full
+        .findings
+        .iter()
+        .map(|f| {
+            let table = f.table.rsplit('.').next().unwrap_or(&f.table).to_string();
+            (table, f.column.clone())
+        })
+        .collect();
+    for p in &fx.pii {
+        assert!(
+            full_found.iter().any(|f| f == p),
+            "missing PII column {}.{}",
+            p.0,
+            p.1
+        );
+    }
+    for c in &fx.clean {
+        assert!(
+            !full_found.iter().any(|f| f == c),
+            "clean column {}.{} produced a finding",
+            c.0,
+            c.1
+        );
+    }
+
+    let json = serde_json::to_string(&full).expect("json");
+    for secret in &fx.secret_values {
+        assert!(
+            !json.contains(secret),
+            "report leaked fixture value {secret}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn bad_password_is_scrubbed() {
+    if !enabled() {
+        eprintln!("skipping: set REDACT_SCAN_INTEGRATION=1");
+        return;
+    }
+    let (_c, admin_url, _) = start_postgres().await;
+    let secret = "super-secret-db-pass";
+    let bad = admin_url.replace("postgres:postgres", &format!("postgres:{secret}"));
+    let err = match connect_readonly(&bad, Duration::from_secs(5), "public").await {
+        Ok(_) => panic!("auth should fail"),
+        Err(e) => e,
+    };
+    let shown = format!("{err}");
+    let debug = format!("{err:?}");
+    assert!(!shown.contains(secret), "{shown}");
+    assert!(!debug.contains(secret), "{debug}");
+}
+
+#[tokio::test]
+async fn five_hundred_tables_l0_l05_under_ten_seconds() {
+    if !enabled() {
+        eprintln!("skipping: set REDACT_SCAN_INTEGRATION=1");
+        return;
+    }
+    let (_c, admin_url, scanner_url) = start_postgres().await;
+    let admin = admin_pool(&admin_url).await;
+    prepare_roles(&admin).await;
+    for i in 0..500 {
+        sqlx::query(&format!(
+            "CREATE TABLE t_bulk_{i} (id int, note text, email text)"
+        ))
+        .execute(&admin)
+        .await
+        .expect("create");
+    }
+    grant_select(&admin).await;
+    let start = Instant::now();
+    let report = run_scan(&scan_cli(&scanner_url, "0,0.5"))
+        .await
+        .expect("bulk scan");
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "L0+L0.5 on 500 tables took {elapsed:?}"
+    );
+    assert!(report.sampling.layers.contains(&ScanLayer::Metadata));
+}

--- a/crates/redact-scan/tests/report_invariants.rs
+++ b/crates/redact-scan/tests/report_invariants.rs
@@ -1,0 +1,67 @@
+use chrono::{TimeZone, Utc};
+use redact_core::EntityType;
+use redact_scan::layers::ScanLayer;
+use redact_scan::report::{EvidenceClass, Finding, Sampling, ScanReport, Scanner, Target};
+use uuid::Uuid;
+
+#[test]
+fn report_json_omits_value_bearing_keys() {
+    let report = ScanReport {
+        scan_id: Uuid::nil(),
+        scanned_at: Utc.with_ymd_and_hms(2026, 8, 15, 0, 0, 0).unwrap(),
+        target: Target {
+            fingerprint: "abc".into(),
+            engine: "postgres".into(),
+            version: "16".into(),
+        },
+        scanner: Scanner {
+            version: "0.9.1".into(),
+            pattern_pack: "builtin@54".into(),
+        },
+        sampling: Sampling {
+            layers: vec![ScanLayer::Metadata],
+            rows_per_column: 1000,
+            method: "TABLESAMPLE SYSTEM".into(),
+        },
+        findings: vec![Finding {
+            table: "public.t".into(),
+            column: "c".into(),
+            json_path: None,
+            entity_type: EntityType::EmailAddress,
+            layer: ScanLayer::Sample,
+            match_count: 3,
+            sampled_rows: 10,
+            confidence: 0.9,
+            evidence_class: EvidenceClass::TableSample,
+        }],
+        content_hash: String::new(),
+    }
+    .finalize()
+    .unwrap();
+
+    let json = serde_json::to_string(&report).unwrap();
+    let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let keys = object_keys(&value);
+    for banned in ["value", "sample", "text", "most_common"] {
+        assert!(
+            !keys.iter().any(|k| k == banned),
+            "report JSON contains banned key {banned}: {json}"
+        );
+    }
+    assert!(!report.content_hash.is_empty());
+    assert!(!json.contains("postgres://"));
+}
+
+fn object_keys(value: &serde_json::Value) -> Vec<String> {
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut keys: Vec<String> = map.keys().cloned().collect();
+            for v in map.values() {
+                keys.extend(object_keys(v));
+            }
+            keys
+        }
+        serde_json::Value::Array(items) => items.iter().flat_map(object_keys).collect(),
+        _ => Vec::new(),
+    }
+}

--- a/crates/redact-scan/tests/scrub.rs
+++ b/crates/redact-scan/tests/scrub.rs
@@ -2,6 +2,28 @@ use redact_scan::error::ScanError;
 use redact_scan::scrub::{scrub, scrub_secret};
 
 #[test]
+fn new_scrubs_url_password_from_display_and_debug() {
+    let secret = "super-secret-db-pass";
+    let raw = format!("password authentication failed for postgres://app:{secret}@db/prod");
+    let err = ScanError::new(raw);
+    let shown = format!("{err}");
+    let debug = format!("{err:?}");
+    assert!(!shown.contains(secret));
+    assert!(!debug.contains(secret));
+    assert!(shown.contains("app:***@"));
+}
+
+#[test]
+fn new_scrubs_percent_encoded_password() {
+    let err = ScanError::new("connect postgres://app:p%40ssword@db/prod failed");
+    let shown = format!("{err}");
+    let debug = format!("{err:?}");
+    assert!(!shown.contains("p%40ssword"));
+    assert!(!shown.contains("p@ssword"));
+    assert!(!debug.contains("p@ssword"));
+}
+
+#[test]
 fn password_absent_from_formatted_error() {
     let secret = "super-secret-db-pass";
     let raw = format!("password authentication failed for postgres://app:{secret}@db/prod");

--- a/crates/redact-scan/tests/scrub.rs
+++ b/crates/redact-scan/tests/scrub.rs
@@ -20,6 +20,7 @@ fn new_scrubs_percent_encoded_password() {
     let debug = format!("{err:?}");
     assert!(!shown.contains("p%40ssword"));
     assert!(!shown.contains("p@ssword"));
+    assert!(!shown.contains("ssword"));
     assert!(!debug.contains("p@ssword"));
 }
 

--- a/crates/redact-scan/tests/scrub.rs
+++ b/crates/redact-scan/tests/scrub.rs
@@ -1,0 +1,21 @@
+use redact_scan::error::ScanError;
+use redact_scan::scrub::{scrub, scrub_secret};
+
+#[test]
+fn password_absent_from_formatted_error() {
+    let secret = "super-secret-db-pass";
+    let raw = format!("password authentication failed for postgres://app:{secret}@db/prod");
+    let err = ScanError::with_secret(raw, secret);
+    let shown = format!("{err}");
+    let debug = format!("{err:?}");
+    assert!(!shown.contains(secret));
+    assert!(!debug.contains(secret));
+    assert!(!scrub(&shown).contains(secret));
+}
+
+#[test]
+fn scrub_secret_replaces_raw_token() {
+    let out = scrub_secret("boom hunter2 boom", "hunter2");
+    assert!(!out.contains("hunter2"));
+    assert!(out.contains("***"));
+}

--- a/crates/redact-scan/tests/support/fixture.rs
+++ b/crates/redact-scan/tests/support/fixture.rs
@@ -44,7 +44,7 @@ impl Fixture {
         let iban = "GB82WEST12345698765432";
         let cc = "4111111111111111";
         let ip = "203.0.113.10";
-        let json = format!(r#"{{"customer":{{"email":"{email}"}}}}"#);
+        let json = format!(r#"{{"customer":{{"email":"{email}"}},"{email}":"note"}}"#);
         secret_values.extend([email.clone(), ssn.into(), iban.into(), cc.into(), ip.into()]);
 
         // Repeat a subset so ANALYZE fills most_common_vals.

--- a/crates/redact-scan/tests/support/fixture.rs
+++ b/crates/redact-scan/tests/support/fixture.rs
@@ -1,0 +1,123 @@
+//! Randomized scan fixture. Seed is printed first.
+
+use rand::{Rng, RngExt, SeedableRng};
+use sqlx::PgPool;
+
+/// Known PII and clean columns created for a run.
+pub struct Fixture {
+    pub pii: Vec<(String, String)>,
+    pub clean: Vec<(String, String)>,
+    pub secret_values: Vec<String>,
+}
+
+impl Fixture {
+    pub fn generate(seed: u64) -> (Self, Vec<String>) {
+        eprintln!("redact-scan fixture seed={seed:#x}");
+        let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+        let mut sql = Vec::new();
+        let mut pii = Vec::new();
+        let mut clean = Vec::new();
+        let mut secret_values = Vec::new();
+
+        let t_pii = ident(&mut rng, "t");
+        let t_clean = ident(&mut rng, "t");
+        let c_email = ident(&mut rng, "c");
+        let c_ssn = ident(&mut rng, "c");
+        let c_iban = ident(&mut rng, "c");
+        let c_cc = ident(&mut rng, "c");
+        let c_ip = ident(&mut rng, "c");
+        let c_json = ident(&mut rng, "c");
+        let c_status = ident(&mut rng, "c");
+        let c_qty = ident(&mut rng, "c");
+        let c_note = ident(&mut rng, "c");
+        let c_flag = ident(&mut rng, "c");
+
+        sql.push(format!(
+            r#"
+            CREATE TABLE {t_pii} (
+              {c_email} text,
+              {c_ssn} text,
+              {c_iban} text,
+              {c_cc} text,
+              {c_ip} inet,
+              {c_json} jsonb
+            );
+            CREATE TABLE {t_clean} (
+              {c_status} text,
+              {c_qty} int,
+              {c_note} text,
+              {c_flag} boolean
+            );
+            "#
+        ));
+
+        let email = format!("user{seed}@example.test");
+        let ssn = "856-45-6789";
+        let iban = "GB82WEST12345698765432";
+        let cc = "4111111111111111";
+        let ip = "203.0.113.10";
+        let json = format!(r#"{{"customer":{{"email":"{email}"}}}}"#);
+        secret_values.extend([email.clone(), ssn.into(), iban.into(), cc.into(), ip.into()]);
+
+        // Repeat a subset so ANALYZE fills most_common_vals.
+        for _ in 0..40 {
+            sql.push(format!(
+                "INSERT INTO {t_pii} ({c_email},{c_ssn},{c_iban},{c_cc},{c_ip},{c_json}) VALUES ('{email}','{ssn}','{iban}','{cc}','{ip}','{json}');"
+            ));
+        }
+        // Unique emails so histogram_bounds also holds values.
+        for i in 0..20 {
+            let unique = format!("uniq{seed}{i}@example.test");
+            secret_values.push(unique.clone());
+            sql.push(format!(
+                "INSERT INTO {t_pii} ({c_email},{c_ssn},{c_iban},{c_cc},{c_ip},{c_json}) VALUES ('{unique}','{ssn}','{iban}','{cc}','{ip}','{json}');"
+            ));
+        }
+        for _ in 0..30 {
+            let status = if rng.random_bool(0.5) {
+                "active"
+            } else {
+                "pending"
+            };
+            sql.push(format!(
+                "INSERT INTO {t_clean} ({c_status},{c_qty},{c_note},{c_flag}) VALUES ('{status}',{},'lorem ipsum dolor sit amet',true);",
+                rng.random_range(1..100)
+            ));
+        }
+
+        pii.extend([
+            (t_pii.clone(), c_email),
+            (t_pii.clone(), c_ssn),
+            (t_pii.clone(), c_iban),
+            (t_pii.clone(), c_cc),
+            (t_pii.clone(), c_ip),
+            (t_pii, c_json),
+        ]);
+        clean.extend([
+            (t_clean.clone(), c_status),
+            (t_clean.clone(), c_qty),
+            (t_clean.clone(), c_note),
+            (t_clean, c_flag),
+        ]);
+
+        (
+            Self {
+                pii,
+                clean,
+                secret_values,
+            },
+            sql,
+        )
+    }
+}
+
+fn ident<R: Rng>(rng: &mut R, prefix: &str) -> String {
+    format!("{prefix}_{:08x}", rng.random::<u32>())
+}
+
+pub async fn apply(pool: &PgPool, statements: &[String]) -> sqlx::Result<()> {
+    for s in statements {
+        sqlx::query(s).execute(pool).await?;
+    }
+    Ok(())
+}

--- a/crates/redact-scan/tests/support/fixture.rs
+++ b/crates/redact-scan/tests/support/fixture.rs
@@ -33,22 +33,10 @@ impl Fixture {
         let c_flag = ident(&mut rng, "c");
 
         sql.push(format!(
-            r#"
-            CREATE TABLE {t_pii} (
-              {c_email} text,
-              {c_ssn} text,
-              {c_iban} text,
-              {c_cc} text,
-              {c_ip} inet,
-              {c_json} jsonb
-            );
-            CREATE TABLE {t_clean} (
-              {c_status} text,
-              {c_qty} int,
-              {c_note} text,
-              {c_flag} boolean
-            );
-            "#
+            "CREATE TABLE {t_pii} ({c_email} text, {c_ssn} text, {c_iban} text, {c_cc} text, {c_ip} inet, {c_json} jsonb)"
+        ));
+        sql.push(format!(
+            "CREATE TABLE {t_clean} ({c_status} text, {c_qty} int, {c_note} text, {c_flag} boolean)"
         ));
 
         let email = format!("user{seed}@example.test");
@@ -62,7 +50,7 @@ impl Fixture {
         // Repeat a subset so ANALYZE fills most_common_vals.
         for _ in 0..40 {
             sql.push(format!(
-                "INSERT INTO {t_pii} ({c_email},{c_ssn},{c_iban},{c_cc},{c_ip},{c_json}) VALUES ('{email}','{ssn}','{iban}','{cc}','{ip}','{json}');"
+                "INSERT INTO {t_pii} ({c_email},{c_ssn},{c_iban},{c_cc},{c_ip},{c_json}) VALUES ('{email}','{ssn}','{iban}','{cc}','{ip}','{json}')"
             ));
         }
         // Unique emails so histogram_bounds also holds values.
@@ -70,7 +58,7 @@ impl Fixture {
             let unique = format!("uniq{seed}{i}@example.test");
             secret_values.push(unique.clone());
             sql.push(format!(
-                "INSERT INTO {t_pii} ({c_email},{c_ssn},{c_iban},{c_cc},{c_ip},{c_json}) VALUES ('{unique}','{ssn}','{iban}','{cc}','{ip}','{json}');"
+                "INSERT INTO {t_pii} ({c_email},{c_ssn},{c_iban},{c_cc},{c_ip},{c_json}) VALUES ('{unique}','{ssn}','{iban}','{cc}','{ip}','{json}')"
             ));
         }
         for _ in 0..30 {
@@ -80,7 +68,7 @@ impl Fixture {
                 "pending"
             };
             sql.push(format!(
-                "INSERT INTO {t_clean} ({c_status},{c_qty},{c_note},{c_flag}) VALUES ('{status}',{},'lorem ipsum dolor sit amet',true);",
+                "INSERT INTO {t_clean} ({c_status},{c_qty},{c_note},{c_flag}) VALUES ('{status}',{},'lorem ipsum dolor sit amet',true)",
                 rng.random_range(1..100)
             ));
         }
@@ -117,6 +105,10 @@ fn ident<R: Rng>(rng: &mut R, prefix: &str) -> String {
 
 pub async fn apply(pool: &PgPool, statements: &[String]) -> sqlx::Result<()> {
     for s in statements {
+        let s = s.trim().trim_end_matches(';');
+        if s.is_empty() {
+            continue;
+        }
         sqlx::query(s).execute(pool).await?;
     }
     Ok(())

--- a/crates/redact-scan/tests/support/fixture.rs
+++ b/crates/redact-scan/tests/support/fixture.rs
@@ -44,7 +44,7 @@ impl Fixture {
         let iban = "GB82WEST12345698765432";
         let cc = "4111111111111111";
         let ip = "203.0.113.10";
-        let json = format!(r#"{{"customer":{{"email":"{email}"}},"{email}":"note"}}"#);
+        let json = format!(r#"{{"customer":{{"email":"{email}"}},"{email}":"{iban}"}}"#);
         secret_values.extend([email.clone(), ssn.into(), iban.into(), cc.into(), ip.into()]);
 
         // Repeat a subset so ANALYZE fills most_common_vals.

--- a/crates/redact-scan/tests/support/mod.rs
+++ b/crates/redact-scan/tests/support/mod.rs
@@ -1,0 +1,1 @@
+pub mod fixture;

--- a/docs/PROJECT_SCOPE.md
+++ b/docs/PROJECT_SCOPE.md
@@ -18,6 +18,7 @@ This Apache-2.0 repository accepts contributions to:
 | `redact-cli` | Command-line interface |
 | `redact-wasm` | WebAssembly bindings |
 | `redact-gateway` | Self-hosted OpenAI-compatible privacy gateway |
+| `redact-scan` | Read-only Postgres PII discovery scanner |
 
 Also in scope: documentation, tests, examples, packaging, and CI for those
 crates.

--- a/docs/scanning-model.md
+++ b/docs/scanning-model.md
@@ -58,9 +58,8 @@ nominated that type from the column name.
 findings. `content_hash` is SHA-256 of canonical JSON with that field
 omitted.
 
-`--out` always writes `ScanReport` JSON. `--format table` is for terminals
-and includes a rule-of-three note when a sample found nothing:
-“0 matches in 1,000 rows; prevalence above 0.3% is unlikely.”
+`--out` always writes `ScanReport` JSON. `--format table` is for terminals.
+A rule-of-three note is only appropriate when rows were actually sampled.
 
 `--report-url` optionally POSTs the same JSON to a caller-supplied
 endpoint (`Authorization: Bearer` when `--api-key` is set;

--- a/docs/scanning-model.md
+++ b/docs/scanning-model.md
@@ -1,0 +1,69 @@
+# Scanning model
+
+`redact-scan` is a **read-only** Postgres PII discovery scanner. Prefer a
+replica or staging database. The report lists locations and counts — never
+sample values.
+
+## Safety
+
+Before any catalog work the scanner:
+
+1. Opens a pool with `max_connections = 1`
+2. Sets `default_transaction_read_only = on`, `statement_timeout`, and
+   `lock_timeout = 5s`
+3. Refuses superuser roles
+4. Refuses `INSERT` / `UPDATE` / `DELETE` / `TRUNCATE` (table and column)
+5. Quotes enumerated identifiers only — never `SELECT *`
+6. Scrubs connection passwords from errors, logs, and the panic hook
+
+`--include-samples` cannot be combined with `--report-url`. Samples are a
+local sidecar file and are never merged into `ScanReport`.
+
+## Layers
+
+Select layers independently with `--layers`. Default: `0,0.5,1,2`.
+
+| Layer | Source | User-table reads |
+| --- | --- | --- |
+| `0` | `pg_catalog` / `information_schema` names, types, comments, unique indexes, FK topology | No |
+| `0.5` | `pg_stats` `most_common_vals` and `histogram_bounds` | No |
+| `1` | `TABLESAMPLE SYSTEM` + `LIMIT` on ordinary tables (`relkind = r`) | Yes, bounded |
+| `2` | JSON/JSONB documents, path-level detections | Yes, bounded |
+
+Layer 0 emits findings for name tokens (`email`, `ssn`, `iban`, …) and for
+`inet` / `cidr` types. `json` / unconstrained `text` without a name match
+are **candidates only**.
+
+Layer 0.5 runs the built-in pattern pack on planner statistics and drops
+the matched text immediately. If `pg_stats` is unreadable the layer is
+skipped and other selected layers continue.
+
+Layer 1 samples candidate columns. Percent is
+`clamp(1, 100, 200 * sample_rows / n_live_tup)`. When the table is no
+larger than `--sample-rows`, `LIMIT` without a full-table random scan is
+used. Views are not sampled.
+
+Layer 2 walks sampled JSON documents and reports paths such as
+`$.customer.email`. Values are discarded.
+
+Value-based layers use a precision entity set (email, phone, SSN, payment
+cards, IBAN, IP, passport, MRN, secrets, …) and exclude high-false-positive
+types such as `DATE_TIME`, `GUID`, and hashes unless layer 0 already
+nominated that type from the column name.
+
+## Report
+
+`ScanReport` includes `scan_id`, `scanned_at`, a hashed target fingerprint
+(`sha256(host|database|schema)`), scanner version, selected layers, and
+findings. `content_hash` is SHA-256 of canonical JSON with that field
+omitted.
+
+`--out` always writes `ScanReport` JSON. `--format table` is for terminals
+and includes a rule-of-three note when a sample found nothing:
+“0 matches in 1,000 rows; prevalence above 0.3% is unlikely.”
+
+`--report-url` optionally POSTs the same JSON to a caller-supplied
+endpoint (`Authorization: Bearer` when `--api-key` is set;
+`--report-header` may be repeated). There is no default host.
+
+Exit codes: `0` clean, `1` when `--fail-on` matches, `2` on error.

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -38,6 +38,7 @@ show_usage() {
     echo "  - crates/redact-api/Cargo.toml (redact-core, redact-ner dependencies)"
     echo "  - crates/redact-cli/Cargo.toml (redact-core, redact-ner dependencies)"
     echo "  - crates/redact-gateway/Cargo.toml (redact-core dependency)"
+    echo "  - crates/redact-scan/Cargo.toml (redact-core dependency)"
     echo "  - README.md (library Cargo.toml example versions)"
     echo "  - docs/benchmarks/README.md (current release link)"
     echo "  - CHANGELOG.md (adds new version entry)"
@@ -271,6 +272,7 @@ main() {
     update_crate_dependency "crates/redact-cli/Cargo.toml" "redact-core" "$new_version" "$dry_run"
     update_crate_dependency "crates/redact-cli/Cargo.toml" "redact-ner" "$new_version" "$dry_run"
     update_crate_dependency "crates/redact-gateway/Cargo.toml" "redact-core" "$new_version" "$dry_run"
+    update_crate_dependency "crates/redact-scan/Cargo.toml" "redact-core" "$new_version" "$dry_run"
     update_doc_versions "$new_version" "$dry_run"
     update_changelog "$new_version" "$dry_run"
     


### PR DESCRIPTION
Thank you for contributing to Redact. These checkboxes are acknowledgements;
the CLA bot enforces the Individual CLA signature.

- [x] I have read [CLA.md](../CLA.md) and will sign the Individual CLA via the bot comment (or I have already signed). A Corporate CLA, if required, does not replace the Individual CLA.
- [x] All commits are DCO-signed (`git commit -s`)
- [x] I have read [docs/PROJECT_SCOPE.md](../docs/PROJECT_SCOPE.md); this change is in scope

**Employer time or equipment**

- [x] No — this work was not done on employer time or equipment
- [ ] Yes — my employer has authorised the contribution, or a Corporate CLA is on file

## Summary

Adds `redact-scan`, a new workspace crate and binary for **read-only** Postgres PII discovery.

- Depends on `redact-core` only (sqlx never enters `redact-core` / wasm)
- Safety session: read-only transaction, timeouts, pool max 1, refuse superuser and write grants
- Four layers: catalog metadata (0), `pg_stats` (0.5), `TABLESAMPLE SYSTEM` (1), JSON paths (2)
- `ScanReport` / `Finding` have no value-bearing fields; `content_hash` is canonical SHA-256
- Credential scrubber on errors, logs, and the panic hook
- `--include-samples` cannot be combined with `--report-url`
- Optional `--report-url` POSTs the report JSON to a caller-supplied endpoint
- `--fail-on any|<ENTITY_TYPE>` exits 1
- Docs: `docs/scanning-model.md`, crate README, `PROJECT_SCOPE`, CI `coder*` filters + Ubuntu integration job

Stacked reviews already merged into this branch: #127 (types), #128 (L0), #129 (L1/L2), #130 (tests).

Rebased onto current `main` via merge: workspace now includes both `redact-scan` and `redact-verify`; `Cargo.lock` is main's dep bump plus scan test deps; Security Audit ignore for unused optional `sqlx-mysql` / `rsa` remains.

## Test plan

- [x] `cargo test -p redact-scan`
- [x] `cargo clippy -p redact-scan --all-targets -- -D warnings`
- [x] rustdoc `-D missing_docs`
- [x] `REDACT_SCAN_INTEGRATION=1 cargo test -p redact-scan --test postgres -- --nocapture` (3 passed)
- [x] CLI `--include-samples --report-url` exits 2 with zero TCP accepts
- [x] `cargo audit` exits 0 after the testcontainers upgrade + rsa ignore
- [x] Merge `main` (conflicts in `Cargo.toml`, `Cargo.lock`, `AGENTS.md`) and re-run scan + verify tests
