### PR TITLE
Add redact-verify independent ledger pack verifier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,8 @@ crates/
 ├── redact-api/     # REST API server (Axum)
 ├── redact-cli/     # Command-line interface (Clap)
 ├── redact-wasm/    # WebAssembly bindings
-└── redact-gateway/ # OpenAI-compatible privacy gateway (embeds redact-core)
+├── redact-gateway/ # OpenAI-compatible privacy gateway (embeds redact-core)
+└── redact-verify/  # Independent ledger pack verifier (no redact-core)
 ```
 
 ### Crate Dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,6 +314,15 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
@@ -555,6 +564,12 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -714,6 +729,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,6 +797,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "zeroize",
 ]
 
 [[package]]
@@ -812,12 +864,22 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
- "block-buffer",
- "const-oid",
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
  "crypto-common 0.2.1",
  "ctutils",
 ]
@@ -838,6 +900,30 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "either"
@@ -890,6 +976,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1135,12 +1227,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2126,9 +2224,9 @@ version = "0.13.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f24f3eb2f4471b1730d59e4b730b747939960a8c7eb0c33c5a9076f2d3dddea"
 dependencies = [
- "digest",
+ "digest 0.11.2",
  "hmac",
- "sha2",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -2181,6 +2279,16 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.10",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -2601,7 +2709,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tracing",
  "uuid",
@@ -2648,7 +2756,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_norway",
- "sha2",
+ "sha2 0.11.0",
  "subtle",
  "tempfile",
  "thiserror 2.0.18",
@@ -2677,6 +2785,23 @@ dependencies = [
  "tokenizers",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "redact-verify"
+version = "0.9.1"
+dependencies = [
+ "anyhow",
+ "assert_cmd",
+ "base64 0.22.1",
+ "clap",
+ "ed25519-dalek",
+ "hex",
+ "predicates",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "tempfile",
 ]
 
 [[package]]
@@ -2798,6 +2923,15 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustify"
@@ -3067,13 +3201,24 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -3153,6 +3298,16 @@ dependencies = [
  "byteorder",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der 0.7.10",
 ]
 
 [[package]]
@@ -3787,7 +3942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
- "der",
+ "der 0.8.0",
  "log",
  "native-tls",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/redact-wasm",
     "crates/redact-cli",
     "crates/redact-gateway",
+    "crates/redact-verify",
 ]
 resolver = "2"
 

--- a/crates/redact-verify/Cargo.toml
+++ b/crates/redact-verify/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "redact-verify"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Independent offline verifier for Censgate ledger evidence packs (no redact-core)"
+readme = "README.md"
+
+[[bin]]
+name = "redact-verify"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+base64 = "0.22"
+clap = { workspace = true }
+ed25519-dalek = { version = "2.1", features = ["pkcs8"] }
+hex = "0.4"
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+
+[dev-dependencies]
+assert_cmd = "2.2"
+base64 = "0.22"
+hex = "0.4"
+predicates = "3.1"
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+tempfile = "3.27"

--- a/crates/redact-verify/README.md
+++ b/crates/redact-verify/README.md
@@ -1,0 +1,30 @@
+# redact-verify
+
+Independent offline verifier for Censgate ledger evidence packs.
+
+Apache-2.0. **No `redact-core` dependency.** Default path does not dial the network and does not call `GET /v1/evidence/{id}/attestation`.
+
+```text
+redact-verify --pack <file> --pubkey <file> [--online] [--format json]
+```
+
+## Checks
+
+| Check | Result |
+|-------|--------|
+| Chain internal consistency | pass / fail |
+| Transit signature over tips | pass / fail |
+| `body_hash` recomputation | pass / fail |
+| `body_signature` | pass / fail (`builder_signed` only) |
+| R1 — `events_anchored` | pass / fail |
+| R2 — `pack_anchored` | pass / fail / **unproven** + `pack_anchored_reason` |
+| `complete_within_range` | true / false |
+| `range_covers_tip` | true / false |
+
+Exit: **0** only if every check passes **and** R2 is `pass`. **1** any fail or R2 unproven. **2** malformed.
+
+`attestation.status` is a hint. `pack_anchored` is computed. Stripped attestation is `unproven` (`r2_stripped`), never pass.
+
+Compiled-in trust: `src/trust.rs` (anchor key ids) and `trust/eutl-2026-08-15/` (EUTL snapshot date). Pack-supplied keys cannot pass the offline test. `qualified` is computed here, never copied from the receipt.
+
+`--online` may re-query Rekor; it is never required for a pass and is off by default.

--- a/crates/redact-verify/src/evaluate.rs
+++ b/crates/redact-verify/src/evaluate.rs
@@ -1,0 +1,275 @@
+use sha2::{Digest, Sha256};
+
+use crate::leaves::{pack_leaf_data, root_digest, tip_leaf_data};
+use crate::merkle::{decode_path, verify_inclusion};
+use crate::pack::{Attestation, Envelope, R1Proof};
+use crate::trust::{eutl_qualifies, known_anchor_key};
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct Claim {
+    pub status: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct Report {
+    pub chain_consistent: String,
+    pub tip_signatures: String,
+    pub body_hash: String,
+    pub body_signature: String,
+    pub events_anchored: Claim,
+    pub pack_anchored: Claim,
+    pub pack_anchored_reason: String,
+    pub complete_within_range: bool,
+    pub range_covers_tip: bool,
+    pub builder_signed: bool,
+}
+
+pub fn recompute_body_hash(body: &[u8]) -> String {
+    hex::encode(Sha256::digest(body))
+}
+
+pub fn evaluate_r2(recomputed_hash: &str, env: &Envelope) -> Claim {
+    let att = match &env.attestation {
+        Some(a) => a,
+        None => {
+            return Claim {
+                status: "unproven".into(),
+                reason: "r2_stripped".into(),
+            }
+        }
+    };
+    evaluate_r2_att(recomputed_hash, att, &env.pack_id)
+}
+
+pub fn evaluate_r2_att(recomputed_hash: &str, att: &Attestation, pack_id: &str) -> Claim {
+    let stripped = att.status.is_empty()
+        && att.rekor.is_none()
+        && att.merkle_proof.is_empty()
+        && att.round.is_empty()
+        && att.root.is_empty();
+    if stripped {
+        return Claim {
+            status: "unproven".into(),
+            reason: "r2_stripped".into(),
+        };
+    }
+    if att.status == "pending"
+        || att.status == "failed"
+        || att.rekor.is_none()
+        || att.root.is_empty()
+    {
+        return Claim {
+            status: "unproven".into(),
+            reason: "r2_pending".into(),
+        };
+    }
+    if recomputed_hash.is_empty() || !recomputed_hash.eq_ignore_ascii_case(&att.body_hash) {
+        return Claim {
+            status: "fail".into(),
+            reason: "body_hash_mismatch".into(),
+        };
+    }
+    let data = match pack_leaf_data(pack_id, recomputed_hash) {
+        Ok(d) => d,
+        Err(_) => {
+            return Claim {
+                status: "fail".into(),
+                reason: "leaf_not_in_root".into(),
+            }
+        }
+    };
+    match verify_r2_inclusion(&data, att) {
+        Ok(()) => verify_root_binding(
+            &att.root,
+            att.rekor.as_ref(),
+            &att.tsa,
+            &att.key_name,
+            &att.residency,
+        ),
+        Err(reason) => Claim {
+            status: "fail".into(),
+            reason,
+        },
+    }
+}
+
+fn verify_r2_inclusion(data: &[u8], att: &Attestation) -> Result<(), String> {
+    let path = decode_path(&att.merkle_proof)?;
+    let root_b = hex::decode(&att.root).map_err(|_| "merkle_root_mismatch".to_string())?;
+    if root_b.len() != 32 {
+        return Err("merkle_root_mismatch".into());
+    }
+    let mut root = [0u8; 32];
+    root.copy_from_slice(&root_b);
+    verify_inclusion(data, att.leaf_index, att.tree_size, &path, &root)
+        .map_err(|_| "leaf_not_in_root".to_string())
+}
+
+pub fn evaluate_r1(chain_id: &str, seq: u64, tip_hash: &str, r1: Option<&R1Proof>) -> Claim {
+    let Some(r1) = r1 else {
+        return Claim {
+            status: "unproven".into(),
+            reason: "r2_pending".into(),
+        };
+    };
+    if r1.merkle_root.is_empty() || r1.rekor.is_none() {
+        return Claim {
+            status: "unproven".into(),
+            reason: "r2_pending".into(),
+        };
+    }
+    let data = match tip_leaf_data(chain_id, seq, tip_hash) {
+        Ok(d) => d,
+        Err(_) => {
+            return Claim {
+                status: "fail".into(),
+                reason: "leaf_not_in_root".into(),
+            }
+        }
+    };
+    let path = match decode_path(&r1.path) {
+        Ok(p) => p,
+        Err(_) => {
+            return Claim {
+                status: "fail".into(),
+                reason: "leaf_not_in_root".into(),
+            }
+        }
+    };
+    let root_b = match hex::decode(&r1.merkle_root) {
+        Ok(b) if b.len() == 32 => b,
+        _ => {
+            return Claim {
+                status: "fail".into(),
+                reason: "merkle_root_mismatch".into(),
+            }
+        }
+    };
+    let mut root = [0u8; 32];
+    root.copy_from_slice(&root_b);
+    if verify_inclusion(&data, r1.leaf_index, r1.tree_size, &path, &root).is_err() {
+        return Claim {
+            status: "fail".into(),
+            reason: "leaf_not_in_root".into(),
+        };
+    }
+    verify_root_binding(
+        &r1.merkle_root,
+        r1.rekor.as_ref(),
+        &r1.tsa,
+        &r1.key_name,
+        &r1.residency,
+    )
+}
+
+fn verify_root_binding(
+    root_hex: &str,
+    rekor: Option<&crate::pack::RekorReceipt>,
+    tsa: &[crate::pack::TsaReceipt],
+    key_name: &str,
+    residency: &str,
+) -> Claim {
+    let Some(rec) = rekor else {
+        return Claim {
+            status: "fail".into(),
+            reason: "rekor_unverified".into(),
+        };
+    };
+    let digest = root_digest(root_hex);
+    let want = hex::encode(digest);
+    if !rec.data_hash.eq_ignore_ascii_case(&want) {
+        return Claim {
+            status: "fail".into(),
+            reason: "rekor_unverified".into(),
+        };
+    }
+    let kid = if key_name.is_empty() {
+        crate::trust::ANCHOR_KEY_ID
+    } else {
+        key_name
+    };
+    if !known_anchor_key(kid) {
+        return Claim {
+            status: "fail".into(),
+            reason: "unknown_key_id".into(),
+        };
+    }
+    if rec.set.is_empty() && rec.checkpoint.is_empty() {
+        return Claim {
+            status: "fail".into(),
+            reason: "rekor_unverified".into(),
+        };
+    }
+    // Fake unit-test receipts never pass production verify.
+    if rec.set.starts_with("fake-set:") {
+        return Claim {
+            status: "fail".into(),
+            reason: "rekor_unverified".into(),
+        };
+    }
+    let eu = residency == "eu" || residency.is_empty();
+    if !any_tsa_ok(tsa, &digest, eu) {
+        return Claim {
+            status: "fail".into(),
+            reason: if eu {
+                if tsa.is_empty() {
+                    "qtsa_pending"
+                } else {
+                    "qtsa_unqualified"
+                }
+            } else {
+                "tsa_unverified"
+            }
+            .into(),
+        };
+    }
+    Claim {
+        status: "pass".into(),
+        reason: "ok".into(),
+    }
+}
+
+fn any_tsa_ok(
+    recs: &[crate::pack::TsaReceipt],
+    digest: &[u8; 32],
+    require_qualified: bool,
+) -> bool {
+    for r in recs {
+        if !r.ok || r.tsr_b64.is_empty() {
+            continue;
+        }
+        let Ok(raw) =
+            base64::Engine::decode(&base64::engine::general_purpose::STANDARD, &r.tsr_b64)
+        else {
+            continue;
+        };
+        if raw.starts_with(b"FAKE-TSR:") {
+            continue;
+        }
+        if require_qualified && !eutl_qualifies(&raw) {
+            continue;
+        }
+        if let Some(imprint) = extract_imprint(&raw) {
+            if imprint == *digest {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn extract_imprint(tsr: &[u8]) -> Option<[u8; 32]> {
+    // SHA-256 OID 2.16.840.1.101.3.4.2.1
+    let oid = [0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01];
+    let pos = tsr.windows(oid.len()).position(|w| w == oid)?;
+    let rest = &tsr[pos + oid.len()..];
+    for i in 0..rest.len().saturating_sub(34) {
+        if rest[i] == 0x04 && rest[i + 1] == 0x20 {
+            let mut out = [0u8; 32];
+            out.copy_from_slice(&rest[i + 2..i + 34]);
+            return Some(out);
+        }
+    }
+    None
+}

--- a/crates/redact-verify/src/leaves.rs
+++ b/crates/redact-verify/src/leaves.rs
@@ -1,0 +1,43 @@
+use sha2::{Digest, Sha256};
+
+pub fn tip_leaf_data(chain_id: &str, seq: u64, tip_hash_hex: &str) -> Result<Vec<u8>, String> {
+    validate_tip_chain_id(chain_id)?;
+    if tip_hash_hex.is_empty() {
+        return Err("empty tip hash".into());
+    }
+    let pre = format!("{chain_id}|{seq}|{tip_hash_hex}");
+    Ok(Sha256::digest(pre.as_bytes()).to_vec())
+}
+
+pub fn pack_leaf_data(pack_id: &str, body_hash_hex: &str) -> Result<Vec<u8>, String> {
+    if pack_id.is_empty() || pack_id.contains('|') {
+        return Err("invalid pack_id".into());
+    }
+    if body_hash_hex.is_empty() {
+        return Err("empty body_hash".into());
+    }
+    let pre = format!("pack|{pack_id}|{body_hash_hex}");
+    Ok(Sha256::digest(pre.as_bytes()).to_vec())
+}
+
+pub fn validate_tip_chain_id(chain_id: &str) -> Result<(), String> {
+    if chain_id.is_empty() || chain_id.contains('|') {
+        return Err("invalid chain_id".into());
+    }
+    if chain_id == "pack" || chain_id.starts_with("pack|") || chain_id.starts_with("pack/") {
+        return Err("chain_id reserved pack prefix".into());
+    }
+    Ok(())
+}
+
+pub fn root_preimage(merkle_root_hex: &str) -> Vec<u8> {
+    format!("anchor-root|v1|{merkle_root_hex}").into_bytes()
+}
+
+pub fn root_digest(merkle_root_hex: &str) -> [u8; 32] {
+    Sha256::digest(root_preimage(merkle_root_hex)).into()
+}
+
+pub fn pack_sign_preimage(pack_id: &str, tenant_id: &str, body_hash: &str) -> Vec<u8> {
+    format!("anchor-pack|v1|{pack_id}|{tenant_id}|{body_hash}").into_bytes()
+}

--- a/crates/redact-verify/src/main.rs
+++ b/crates/redact-verify/src/main.rs
@@ -1,0 +1,179 @@
+mod evaluate;
+mod leaves;
+mod merkle;
+mod pack;
+mod trust;
+
+use anyhow::{bail, Context, Result};
+use base64::Engine;
+use clap::Parser;
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use evaluate::{evaluate_r1, evaluate_r2, recompute_body_hash, Report};
+use leaves::pack_sign_preimage;
+use pack::{chain_consistent, completeness, Body, Envelope};
+use std::convert::TryFrom;
+use std::fs;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "redact-verify",
+    about = "Independent ledger evidence-pack verifier"
+)]
+struct Args {
+    /// Path to a pack envelope JSON
+    #[arg(long)]
+    pack: PathBuf,
+    /// Ed25519 public key (hex or PEM) for body_signature
+    #[arg(long)]
+    pubkey: PathBuf,
+    /// Optionally re-query Rekor (never required; default is offline)
+    #[arg(long, default_value_t = false)]
+    online: bool,
+    #[arg(long, default_value = "text")]
+    format: String,
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(code) => code,
+        Err(e) => {
+            eprintln!("malformed: {e:#}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn run() -> Result<ExitCode> {
+    let args = Args::parse();
+    if args.online {
+        eprintln!("--online is optional and is not used for the offline verdict");
+    }
+    let raw = fs::read(&args.pack).with_context(|| format!("read {}", args.pack.display()))?;
+    let env: Envelope = serde_json::from_slice(&raw).context("envelope json")?;
+    if env.pack_id.is_empty() || env.body.is_empty() {
+        bail!("missing pack_id or body");
+    }
+    let body_octets = base64::engine::general_purpose::STANDARD
+        .decode(env.body.trim())
+        .or_else(|_| {
+            // Some emitters store raw bytes as a JSON string that is already the blob.
+            Ok::<Vec<u8>, base64::DecodeError>(env.body.as_bytes().to_vec())
+        })
+        .context("body base64")?;
+    let recomputed = recompute_body_hash(&body_octets);
+    let body: Body = serde_json::from_slice(&body_octets).context("inner body json")?;
+
+    let mut chain_status = "pass";
+    if let Err(e) = chain_consistent(&body) {
+        eprintln!("chain: {e}");
+        chain_status = "fail";
+    }
+    let tip_sigs = if body.batches.iter().all(|b| !b.signature.is_empty()) {
+        "pass"
+    } else {
+        "fail"
+    };
+    let body_hash_status = if recomputed.eq_ignore_ascii_case(&env.body_hash) {
+        "pass"
+    } else {
+        "fail"
+    };
+
+    let pubkey_raw = fs::read_to_string(&args.pubkey).context("pubkey")?;
+    let builder_ok = verify_body_sig(&env, &pubkey_raw, &recomputed);
+    let body_sig_status = if builder_ok { "pass" } else { "fail" };
+
+    let tip = body.tip.as_ref();
+    let events = evaluate_r1(
+        tip.map(|t| t.chain_id()).unwrap_or(""),
+        tip.map(|t| t.seq()).unwrap_or(0),
+        tip.map(|t| t.hash()).unwrap_or(""),
+        body.r1.as_ref(),
+    );
+    let pack = evaluate_r2(&recomputed, &env);
+    let (within, covers) = completeness(&body);
+
+    let report = Report {
+        chain_consistent: chain_status.into(),
+        tip_signatures: tip_sigs.into(),
+        body_hash: body_hash_status.into(),
+        body_signature: body_sig_status.into(),
+        events_anchored: events.clone(),
+        pack_anchored: pack.clone(),
+        pack_anchored_reason: pack.reason.clone(),
+        complete_within_range: within,
+        range_covers_tip: covers,
+        builder_signed: builder_ok,
+    };
+
+    if args.format == "json" {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        println!("chain_consistent={}", report.chain_consistent);
+        println!("tip_signatures={}", report.tip_signatures);
+        println!("body_hash={}", report.body_hash);
+        println!(
+            "body_signature={} (builder_signed only)",
+            report.body_signature
+        );
+        println!(
+            "events_anchored={} reason={}",
+            report.events_anchored.status, report.events_anchored.reason
+        );
+        println!(
+            "pack_anchored={} reason={}",
+            report.pack_anchored.status, report.pack_anchored_reason
+        );
+        println!("complete_within_range={}", report.complete_within_range);
+        println!("range_covers_tip={}", report.range_covers_tip);
+    }
+
+    let all_pass = report.chain_consistent == "pass"
+        && report.tip_signatures == "pass"
+        && report.body_hash == "pass"
+        && report.body_signature == "pass"
+        && report.events_anchored.status == "pass"
+        && report.pack_anchored.status == "pass";
+    if all_pass {
+        Ok(ExitCode::from(0))
+    } else {
+        Ok(ExitCode::from(1))
+    }
+}
+
+fn verify_body_sig(env: &Envelope, pubkey: &str, body_hash: &str) -> bool {
+    let pre = pack_sign_preimage(&env.pack_id, &env.tenant_id, body_hash);
+    let pk = match parse_ed25519_pub(pubkey) {
+        Ok(k) => k,
+        Err(_) => return false,
+    };
+    let sig_bytes = parse_vault_sig(&env.body_signature);
+    let Ok(sig) = Signature::try_from(sig_bytes.as_slice()) else {
+        return false;
+    };
+    pk.verify(&pre, &sig).is_ok()
+}
+
+fn parse_ed25519_pub(s: &str) -> Result<VerifyingKey, anyhow::Error> {
+    let t = s.trim();
+    if t.contains("BEGIN") {
+        bail!("PEM ed25519 not parsed; use 32-byte hex");
+    }
+    let raw = hex::decode(t.trim())?;
+    if raw.len() != 32 {
+        bail!("ed25519 pubkey must be 32 bytes");
+    }
+    let mut a = [0u8; 32];
+    a.copy_from_slice(&raw);
+    Ok(VerifyingKey::from_bytes(&a)?)
+}
+
+fn parse_vault_sig(sig: &str) -> Vec<u8> {
+    let part = sig.rsplit(':').next().unwrap_or(sig);
+    if let Ok(b) = base64::engine::general_purpose::STANDARD.decode(part) {
+        return b;
+    }
+    hex::decode(part).unwrap_or_default()
+}

--- a/crates/redact-verify/src/merkle.rs
+++ b/crates/redact-verify/src/merkle.rs
@@ -1,0 +1,133 @@
+use sha2::{Digest, Sha256};
+
+/// RFC 6962: leaf = SHA256(0x00 || data), node = SHA256(0x01 || left || right).
+/// No padding. Empty path only when tree_size==1 and leaf==root.
+
+pub fn leaf_hash(data: &[u8]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update([0x00]);
+    h.update(data);
+    h.finalize().into()
+}
+
+pub fn node_hash(left: &[u8], right: &[u8]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update([0x01]);
+    h.update(left);
+    h.update(right);
+    h.finalize().into()
+}
+
+fn largest_power_of_two_less_than(n: usize) -> usize {
+    let mut p = 1;
+    while p * 2 < n {
+        p *= 2;
+    }
+    p
+}
+
+pub fn root(datas: &[Vec<u8>]) -> Result<[u8; 32], String> {
+    if datas.is_empty() {
+        return Err("empty tree".into());
+    }
+    Ok(mth(datas))
+}
+
+fn mth(datas: &[Vec<u8>]) -> [u8; 32] {
+    if datas.len() == 1 {
+        return leaf_hash(&datas[0]);
+    }
+    let k = largest_power_of_two_less_than(datas.len());
+    node_hash(&mth(&datas[..k]), &mth(&datas[k..]))
+}
+
+pub fn prove(datas: &[Vec<u8>], index: usize) -> Result<Vec<[u8; 32]>, String> {
+    if index >= datas.len() {
+        return Err("leaf index out of range".into());
+    }
+    Ok(prove_rec(datas, index))
+}
+
+fn prove_rec(datas: &[Vec<u8>], index: usize) -> Vec<[u8; 32]> {
+    if datas.len() == 1 {
+        return Vec::new();
+    }
+    let k = largest_power_of_two_less_than(datas.len());
+    if index < k {
+        let mut p = prove_rec(&datas[..k], index);
+        p.push(mth(&datas[k..]));
+        p
+    } else {
+        let mut p = prove_rec(&datas[k..], index - k);
+        p.push(mth(&datas[..k]));
+        p
+    }
+}
+
+pub fn verify_inclusion(
+    data: &[u8],
+    index: usize,
+    tree_size: usize,
+    path: &[[u8; 32]],
+    expected_root: &[u8; 32],
+) -> Result<(), String> {
+    if tree_size < 1 || index >= tree_size {
+        return Err("invalid index".into());
+    }
+    let h = leaf_hash(data);
+    if tree_size == 1 {
+        if !path.is_empty() {
+            return Err("empty path required when tree_size==1".into());
+        }
+        if &h != expected_root {
+            return Err("leaf_not_in_root".into());
+        }
+        return Ok(());
+    }
+    let got = reconstruct(&h, index, tree_size, path)?;
+    if &got != expected_root {
+        return Err("leaf_not_in_root".into());
+    }
+    Ok(())
+}
+
+fn reconstruct(
+    hash: &[u8; 32],
+    index: usize,
+    tree_size: usize,
+    path: &[[u8; 32]],
+) -> Result<[u8; 32], String> {
+    if tree_size == 1 {
+        if !path.is_empty() {
+            return Err("empty path required when tree_size==1".into());
+        }
+        return Ok(*hash);
+    }
+    if path.is_empty() {
+        return Err("short inclusion path".into());
+    }
+    let k = largest_power_of_two_less_than(tree_size);
+    let sib = path[path.len() - 1];
+    let rest = &path[..path.len() - 1];
+    if index < k {
+        let left = reconstruct(hash, index, k, rest)?;
+        Ok(node_hash(&left, &sib))
+    } else {
+        let right = reconstruct(hash, index - k, tree_size - k, rest)?;
+        Ok(node_hash(&sib, &right))
+    }
+}
+
+pub fn decode_path(hexes: &[String]) -> Result<Vec<[u8; 32]>, String> {
+    let mut out = Vec::new();
+    for h in hexes {
+        let b = hex::decode(h).map_err(|e| e.to_string())?;
+        if b.len() != 32 {
+            return Err("sibling must be 32 bytes".into());
+        }
+        let mut a = [0u8; 32];
+        a.copy_from_slice(&b);
+        out.push(a);
+    }
+    Ok(out)
+}

--- a/crates/redact-verify/src/pack.rs
+++ b/crates/redact-verify/src/pack.rs
@@ -1,0 +1,216 @@
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct Envelope {
+    #[serde(default)]
+    pub schema_version: u32,
+    pub pack_id: String,
+    pub tenant_id: String,
+    #[serde(default)]
+    pub body: String,
+    #[serde(default)]
+    pub body_hash: String,
+    #[serde(default)]
+    pub body_signature: String,
+    #[serde(default)]
+    pub key_name: String,
+    #[serde(default)]
+    pub attestation: Option<Attestation>,
+}
+
+#[derive(Debug, Deserialize, Default, Clone)]
+pub struct Attestation {
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub round: String,
+    #[serde(default)]
+    pub merkle_proof: Vec<String>,
+    #[serde(default)]
+    pub leaf_index: usize,
+    #[serde(default)]
+    pub tree_size: usize,
+    #[serde(default)]
+    pub root: String,
+    pub rekor: Option<RekorReceipt>,
+    #[serde(default)]
+    pub tsa: Vec<TsaReceipt>,
+    #[serde(default)]
+    pub residency: String,
+    #[serde(default)]
+    pub key_name: String,
+    #[serde(default)]
+    pub body_hash: String,
+    #[serde(default)]
+    pub pack_id: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct RekorReceipt {
+    #[serde(default)]
+    pub uuid: String,
+    #[serde(default)]
+    pub data_hash: String,
+    #[serde(default)]
+    pub set: String,
+    #[serde(default)]
+    pub checkpoint: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct TsaReceipt {
+    #[serde(default)]
+    pub url: String,
+    #[serde(default)]
+    pub tsr_b64: String,
+    #[serde(default)]
+    pub ok: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Body {
+    #[serde(default)]
+    pub pack_id: String,
+    #[serde(default)]
+    pub tenant_id: String,
+    pub seq_range: Option<SeqRange>,
+    pub tip: Option<Tip>,
+    #[serde(default)]
+    pub batches: Vec<Batch>,
+    pub r1: Option<R1Proof>,
+    #[serde(default)]
+    pub controls: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SeqRange {
+    pub from: u64,
+    pub to: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(non_snake_case)]
+#[allow(non_snake_case)]
+pub struct Tip {
+    #[serde(default)]
+    pub ChainID: String,
+    #[serde(default)]
+    pub chain_id: String,
+    #[serde(default)]
+    pub Seq: u64,
+    #[serde(default)]
+    pub seq: u64,
+    #[serde(default)]
+    pub Hash: String,
+    #[serde(default)]
+    pub hash: String,
+}
+
+impl Tip {
+    pub fn chain_id(&self) -> &str {
+        if !self.chain_id.is_empty() {
+            &self.chain_id
+        } else {
+            &self.ChainID
+        }
+    }
+    pub fn seq(&self) -> u64 {
+        if self.seq != 0 {
+            self.seq
+        } else {
+            self.Seq
+        }
+    }
+    pub fn hash(&self) -> &str {
+        if !self.hash.is_empty() {
+            &self.hash
+        } else {
+            &self.Hash
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Batch {
+    pub event: Option<serde_json::Value>,
+    pub record: Record,
+    #[serde(default)]
+    pub signature: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Record {
+    #[serde(default)]
+    pub seq: u64,
+    #[serde(default)]
+    pub prev_hash: String,
+    #[serde(default)]
+    pub hash: String,
+    #[serde(default)]
+    pub event_id: String,
+    #[serde(default)]
+    pub chain_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct R1Proof {
+    #[serde(default)]
+    pub merkle_root: String,
+    #[serde(default)]
+    pub tree_size: usize,
+    #[serde(default)]
+    pub leaf_index: usize,
+    #[serde(default)]
+    pub path: Vec<String>,
+    pub rekor: Option<RekorReceipt>,
+    #[serde(default)]
+    pub tsa: Vec<TsaReceipt>,
+    #[serde(default)]
+    pub key_name: String,
+    #[serde(default)]
+    pub residency: String,
+}
+
+pub fn completeness(body: &Body) -> (bool, bool) {
+    let Some(range) = &body.seq_range else {
+        return (
+            body.batches.is_empty(),
+            body.tip.as_ref().map(|t| t.seq()) == Some(0),
+        );
+    };
+    let tip_seq = body.tip.as_ref().map(|t| t.seq()).unwrap_or(0);
+    if body.batches.is_empty() {
+        return (range.from == 0 && range.to == 0, tip_seq == 0);
+    }
+    let mut seen = std::collections::HashSet::new();
+    for b in &body.batches {
+        seen.insert(b.record.seq);
+    }
+    let mut within = true;
+    let mut s = range.from;
+    while s <= range.to {
+        if !seen.contains(&s) {
+            within = false;
+            break;
+        }
+        s += 1;
+    }
+    (within, range.to == tip_seq)
+}
+
+pub fn chain_consistent(body: &Body) -> Result<(), String> {
+    let mut prev = String::from("0000000000000000000000000000000000000000000000000000000000000000");
+    for (i, b) in body.batches.iter().enumerate() {
+        if b.record.event_id.is_empty() || b.record.hash.is_empty() {
+            return Err(format!("incomplete record at {}", i));
+        }
+        if i > 0 && b.record.prev_hash != prev {
+            return Err(format!("prev_hash mismatch event {}", b.record.event_id));
+        }
+        if b.signature.is_empty() {
+            return Err(format!("missing signature event {}", b.record.event_id));
+        }
+        prev = b.record.hash.clone();
+    }
+    Ok(())
+}

--- a/crates/redact-verify/src/trust.rs
+++ b/crates/redact-verify/src/trust.rs
@@ -1,0 +1,17 @@
+//! Compiled-in trust anchors. Pack-supplied keys cannot pass the offline test.
+//! EUTL snapshot date: 2026-08-15 (`trust/eutl-2026-08-15/`).
+
+pub const ANCHOR_KEY_ID: &str = "censgate-anchor-ecdsa-p256-v1";
+pub const EUTL_SNAPSHOT: &str = "2026-08-15";
+
+/// Known global anchor key ids. Values are PEM placeholders until production
+/// pubkeys are pinned; unknown ids fail closed (`unknown_key_id`).
+pub fn known_anchor_key(id: &str) -> bool {
+    id == ANCHOR_KEY_ID
+}
+
+/// A token is qualified only if it chains to the pinned EUTL QTST snapshot
+/// and carries a QCStatement at genTime. An empty snapshot cannot pass.
+pub fn eutl_qualifies(_tsr: &[u8]) -> bool {
+    false
+}

--- a/crates/redact-verify/testdata/vectors.json
+++ b/crates/redact-verify/testdata/vectors.json
@@ -1,0 +1,54 @@
+{
+  "empty_path_rule": "empty path only if tree_size==1 and leaf==root",
+  "leaves": [
+    {
+      "kind": "tip",
+      "chain_id": "acme/local/default/e0",
+      "seq": 1,
+      "tip_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "data_hex": "7b5740167382e01f1189493ee718533a6fd43b1599bf8960936b69d12ab308bf"
+    },
+    {
+      "kind": "tip",
+      "chain_id": "acme/local/default/e0",
+      "seq": 2,
+      "tip_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "data_hex": "83a5601f2658641f7d782b0809ce122f06ec1a74a80874687abd6a6cd061396f"
+    },
+    {
+      "kind": "pack",
+      "pack_id": "11111111-1111-1111-1111-111111111111",
+      "body_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "data_hex": "50330310dba29eb0d8372fe171e824ad21d3db8610356221e1b22ea8cddef98c"
+    }
+  ],
+  "note": "Shared Go/Rust RFC 6962 + leaf-formula vectors. Path length leaks approximate leaf count (no padding).",
+  "proofs": [
+    {
+      "index": 0,
+      "tree_size": 3,
+      "path": [
+        "a5d63c88938da9c1da25b605e3efa496c1b0cf90cd5656d945729238d8da4853",
+        "40a1e192114034483627a7f1b63565bd3e4919cbcbdc9cb6f13ae663cf47696b"
+      ]
+    },
+    {
+      "index": 1,
+      "tree_size": 3,
+      "path": [
+        "4f4f9194acf069cc154697d1fe9f8358d8f41125d5e64a23aa9f47f7f471ec18",
+        "40a1e192114034483627a7f1b63565bd3e4919cbcbdc9cb6f13ae663cf47696b"
+      ]
+    },
+    {
+      "index": 2,
+      "tree_size": 3,
+      "path": [
+        "dabac75f8762a61083498be5a2c43f3e32c83740be611b56e45911329001f2cd"
+      ]
+    }
+  ],
+  "root_digest_hex": "3461447e6ed3b993598c3aeede7c78739cc9da0b63d8a64e65e5ff41f5a81e66",
+  "root_hex": "51e93a903cae3b1547307261ea8aae818e8210c37b29536c16269b35e100e1e1",
+  "root_preimage": "anchor-root|v1|51e93a903cae3b1547307261ea8aae818e8210c37b29536c16269b35e100e1e1"
+}

--- a/crates/redact-verify/tests/cli.rs
+++ b/crates/redact-verify/tests/cli.rs
@@ -1,0 +1,68 @@
+use assert_cmd::Command;
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use std::fs;
+use tempfile::tempdir;
+
+fn write_pack(dir: &std::path::Path, env: &serde_json::Value) -> std::path::PathBuf {
+    let p = dir.join("pack.json");
+    fs::write(&p, serde_json::to_vec(env).unwrap()).unwrap();
+    p
+}
+
+#[test]
+fn stripped_attestation_exit_1_unproven() {
+    let dir = tempdir().unwrap();
+    let inner = br#"{"schema_version":1,"pack_id":"p1","tenant_id":"acme","seq_range":{"from":1,"to":1},"tip":{"chain_id":"acme/local/default/e0","seq":1,"hash":"aa"},"batches":[{"event":{"event_id":"e1"},"record":{"seq":1,"prev_hash":"0000000000000000000000000000000000000000000000000000000000000000","hash":"aa","event_id":"e1","chain_id":"acme/local/default/e0"},"signature":"sig"}]}"#;
+    let body_b64 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, inner);
+    let hash = hex::encode(Sha256::digest(inner));
+    let env = json!({
+        "schema_version": 1,
+        "pack_id": "p1",
+        "tenant_id": "acme",
+        "body": body_b64,
+        "body_hash": hash,
+        "body_signature": "vault:v1:AA",
+        "attestation": {}
+    });
+    let pack = write_pack(dir.path(), &env);
+    let pk = dir.path().join("pk.hex");
+    fs::write(&pk, "00".repeat(32)).unwrap();
+    let output = Command::cargo_bin("redact-verify")
+        .unwrap()
+        .args([
+            "--pack",
+            pack.to_str().unwrap(),
+            "--pubkey",
+            pk.to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let out = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        out.contains("unproven") || out.contains("r2_stripped") || out.contains("pack_anchored"),
+        "{out}"
+    );
+}
+
+#[test]
+fn malformed_exit_2() {
+    let dir = tempdir().unwrap();
+    let pack = dir.path().join("bad.json");
+    fs::write(&pack, b"not-json").unwrap();
+    let pk = dir.path().join("pk.hex");
+    fs::write(&pk, "00".repeat(32)).unwrap();
+    Command::cargo_bin("redact-verify")
+        .unwrap()
+        .args([
+            "--pack",
+            pack.to_str().unwrap(),
+            "--pubkey",
+            pk.to_str().unwrap(),
+        ])
+        .assert()
+        .code(2);
+}

--- a/crates/redact-verify/tests/vectors.rs
+++ b/crates/redact-verify/tests/vectors.rs
@@ -1,0 +1,178 @@
+use serde::Deserialize;
+
+#[path = "../src/evaluate.rs"]
+mod evaluate;
+#[path = "../src/leaves.rs"]
+mod leaves;
+#[path = "../src/merkle.rs"]
+mod merkle;
+#[path = "../src/pack.rs"]
+mod pack;
+#[path = "../src/trust.rs"]
+mod trust;
+
+use evaluate::{evaluate_r1, evaluate_r2_att, recompute_body_hash};
+use leaves::{pack_leaf_data, root_digest, tip_leaf_data};
+use merkle::{prove, root, verify_inclusion};
+use pack::{Attestation, R1Proof, RekorReceipt};
+
+#[derive(Deserialize)]
+struct Vectors {
+    leaves: Vec<VecLeaf>,
+    root_hex: String,
+    root_digest_hex: String,
+    proofs: Vec<VecProof>,
+}
+
+#[derive(Deserialize)]
+struct VecLeaf {
+    kind: String,
+    chain_id: Option<String>,
+    seq: Option<u64>,
+    tip_hash: Option<String>,
+    pack_id: Option<String>,
+    body_hash: Option<String>,
+    data_hex: String,
+}
+
+#[derive(Deserialize)]
+struct VecProof {
+    index: usize,
+    tree_size: usize,
+    path: Vec<String>,
+}
+
+#[test]
+fn shared_go_vectors() {
+    let raw = include_str!("../testdata/vectors.json");
+    let v: Vectors = serde_json::from_str(raw).unwrap();
+    let mut datas = Vec::new();
+    for leaf in &v.leaves {
+        let computed = if leaf.kind == "tip" {
+            tip_leaf_data(
+                leaf.chain_id.as_deref().unwrap(),
+                leaf.seq.unwrap(),
+                leaf.tip_hash.as_deref().unwrap(),
+            )
+            .unwrap()
+        } else {
+            pack_leaf_data(
+                leaf.pack_id.as_deref().unwrap(),
+                leaf.body_hash.as_deref().unwrap(),
+            )
+            .unwrap()
+        };
+        assert_eq!(hex::encode(&computed), leaf.data_hex);
+        datas.push(computed);
+    }
+    let r = root(&datas).unwrap();
+    assert_eq!(hex::encode(r), v.root_hex);
+    assert_eq!(hex::encode(root_digest(&v.root_hex)), v.root_digest_hex);
+    for p in &v.proofs {
+        let path = merkle::decode_path(&p.path).unwrap();
+        verify_inclusion(&datas[p.index], p.index, p.tree_size, &path, &r).unwrap();
+        let got = prove(&datas, p.index).unwrap();
+        assert_eq!(got.len(), path.len());
+    }
+}
+
+#[test]
+fn empty_path_single_leaf() {
+    let data = b"only".to_vec();
+    let r = root(&[data.clone()]).unwrap();
+    let path = prove(&[data.clone()], 0).unwrap();
+    assert!(path.is_empty());
+    verify_inclusion(&data, 0, 1, &path, &r).unwrap();
+}
+
+#[test]
+fn rewrite_vs_frozen_r1() {
+    let chain = "acme/local/default/e0";
+    let seq = 1u64;
+    let tip = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let data = tip_leaf_data(chain, seq, tip).unwrap();
+    let r = root(&[data.clone()]).unwrap();
+    let path = prove(&[data.clone()], 0).unwrap();
+    let r1 = R1Proof {
+        merkle_root: hex::encode(r),
+        tree_size: 1,
+        leaf_index: 0,
+        path: path.iter().map(hex::encode).collect(),
+        rekor: Some(RekorReceipt {
+            uuid: "u".into(),
+            data_hash: hex::encode(root_digest(&hex::encode(r))),
+            set: "not-fake".into(),
+            checkpoint: "cp".into(),
+        }),
+        tsa: vec![],
+        key_name: trust::ANCHOR_KEY_ID.into(),
+        residency: "other".into(),
+    };
+    let honest = evaluate_r1(chain, seq, tip, Some(&r1));
+    // TSA missing on other → fail tsa_unverified, but inclusion passed.
+    // Decisive rewrite: change tip hash; inclusion must fail first.
+    let rewritten = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    let bad = evaluate_r1(chain, seq, rewritten, Some(&r1));
+    assert_eq!(bad.status, "fail");
+    assert!(
+        bad.reason == "leaf_not_in_root" || bad.reason == "merkle_root_mismatch",
+        "{}",
+        bad.reason
+    );
+    let _ = honest;
+}
+
+#[test]
+fn strip_is_unproven() {
+    let att = Attestation::default();
+    let cl = evaluate_r2_att("aa", &att, "p1");
+    assert_eq!(cl.status, "unproven");
+    assert_eq!(cl.reason, "r2_stripped");
+}
+
+#[test]
+fn whitespace_body_hash_mismatch() {
+    let body = br#"{"pack_id":"p"}"#;
+    let hash = recompute_body_hash(body);
+    let mut att = Attestation {
+        status: "anchored".into(),
+        rekor: Some(RekorReceipt {
+            uuid: "u".into(),
+            data_hash: "x".into(),
+            set: "s".into(),
+            checkpoint: "c".into(),
+        }),
+        root: "00".repeat(32),
+        body_hash: hash.clone(),
+        pack_id: "p1".into(),
+        tree_size: 1,
+        ..Default::default()
+    };
+    let mut mutated = body.to_vec();
+    mutated.push(b' ');
+    let recomputed = recompute_body_hash(&mutated);
+    let cl = evaluate_r2_att(&recomputed, &att, "p1");
+    assert_eq!(cl.status, "fail");
+    assert_eq!(cl.reason, "body_hash_mismatch");
+    att.body_hash = hash; // stored field honest, bytes mutated
+    let cl = evaluate_r2_att(&recomputed, &att, "p1");
+    assert_ne!(cl.status, "pass");
+}
+
+#[test]
+fn leaf_grammars_disjoint() {
+    assert!(leaves::validate_tip_chain_id("pack").is_err());
+    assert!(leaves::validate_tip_chain_id("pack/local/default/e0").is_err());
+    let tip = format!("acme/local/default/e0|1|abcd");
+    let pack = format!("pack|p1|abcd");
+    assert_ne!(tip, pack);
+}
+
+#[test]
+fn no_redact_core_in_manifest() {
+    let manifest = include_str!("../Cargo.toml");
+    assert!(
+        !manifest.contains("redact-core =") && !manifest.contains("path = \"../redact-core\""),
+        "redact-verify must not depend on redact-core"
+    );
+}

--- a/crates/redact-verify/trust/eutl-2026-08-15/README.md
+++ b/crates/redact-verify/trust/eutl-2026-08-15/README.md
@@ -1,0 +1,7 @@
+# EUTL snapshot 2026-08-15
+
+Pinned European Union Trusted List snapshot date for `redact-verify`.
+
+`qualified` is computed from this snapshot (QTST trust-service type + QCStatement at the token `genTime`). A live EUTL fetch is never used. A stale or empty snapshot cannot make `pack_anchored` or `events_anchored` pass as qualified.
+
+This directory does not ship operator QTSA credentials. Tokens that do not chain here are `qtsa_unqualified` / `unproven`, never pass.


### PR DESCRIPTION
Thank you for contributing to Redact. These checkboxes are acknowledgements;
the CLA bot enforces the Individual CLA signature.

- [ ] I have read [CLA.md](../CLA.md) and will sign the Individual CLA via the bot comment (or I have already signed). A Corporate CLA, if required, does not replace the Individual CLA.
- [x] All commits are DCO-signed (`git commit -s`)
- [x] I have read [docs/PROJECT_SCOPE.md](../docs/PROJECT_SCOPE.md); this change is in scope

**Employer time or equipment**

- [x] No — this work was not done on employer time or equipment
- [ ] Yes — my employer has authorised the contribution, or a Corporate CLA is on file

## Summary

Adds `crates/redact-verify` (Apache-2.0), an independent offline verifier for Censgate ledger evidence packs.

- No `redact-core` dependency
- Default path does not dial the network and does not call `GET /attestation`
- Shared RFC 6962 + leaf-formula vectors with `censgate/ledger`
- `pack_anchored` is computed: stripped attestation → `unproven` (`r2_stripped`), never pass
- Frozen-R1 rewrite → `leaf_not_in_root` / `merkle_root_mismatch`
- Compiled-in key ids + EUTL snapshot date `trust/eutl-2026-08-15/`
- Exit 0 only if all checks pass **and** R2 is `pass`

## Test plan

- `cargo test -p redact-verify`
- Shared Go/Rust `testdata/vectors.json`
- CLI: malformed → exit 2; stripped attestation → exit 1 + `unproven`