### PR TITLE
fix(cla): allowlist Censgate maintainer-run agent identities

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -42,7 +42,7 @@ jobs:
           path-to-signatures: signatures/version1/cla.json
           path-to-document: https://github.com/censgate/redact/blob/main/CLA.md
           branch: cla-signatures
-          allowlist: dependabot[bot],github-actions[bot],cursoragent,cursor[bot]
+          allowlist: dependabot[bot],github-actions[bot],cursoragent,cursor[bot],censgate-coder,censgate-qa
           custom-notsigned-prcomment: |
             Thank you for your pull request. Each human contributor must sign
             the Individual Contributor License Agreement (CLA.md) before this
@@ -77,6 +77,8 @@ jobs:
               'github-actions[bot]',
               'cursoragent',
               'cursor[bot]',
+              'censgate-coder',
+              'censgate-qa',
             ]);
             const prNumber = context.payload.pull_request
               ? context.payload.pull_request.number

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -42,7 +42,7 @@ jobs:
           path-to-signatures: signatures/version1/cla.json
           path-to-document: https://github.com/censgate/redact/blob/main/CLA.md
           branch: cla-signatures
-          allowlist: dependabot[bot],github-actions[bot],cursoragent,cursor[bot],censgate-coder,censgate-qa
+          allowlist: dependabot[bot],github-actions[bot],cursoragent,cursor[bot],censgate-coder,censgate-qa,censgate-mark
           custom-notsigned-prcomment: |
             Thank you for your pull request. Each human contributor must sign
             the Individual Contributor License Agreement (CLA.md) before this
@@ -79,6 +79,7 @@ jobs:
               'cursor[bot]',
               'censgate-coder',
               'censgate-qa',
+              'censgate-mark',
             ]);
             const prNumber = context.payload.pull_request
               ? context.payload.pull_request.number


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Allowlist maintainer-run Censgate identities that cannot post an Individual CLA sign-off: `censgate-coder`, `censgate-qa`, and `censgate-mark` (plus the existing `cursoragent` / `cursor[bot]` entries).

Those GitHub ids are also in the `cla-signatures` store so in-flight PRs can pass before this workflow reaches `main`.

Humans who are not on this list still must sign.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85647f93-5b7e-4fe1-8fad-9cd59c7bd2c2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85647f93-5b7e-4fe1-8fad-9cd59c7bd2c2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

