### PR TITLE
docs(agents): add Cursor Cloud environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,3 +203,29 @@ Before committing:
 - **Rust**: 1.93.0 (see `.tool-versions`)
 - **MSRV**: 1.88
 - **Python**: 3.8+ (for NER model export only)
+
+## Cursor Cloud specific instructions
+
+The VM snapshot already has Rust 1.93.0 (rustfmt + clippy), the native build deps
+(`pkg-config`, `cmake`, `g++`, `libssl-dev`), and the fixes below applied; the startup
+update script only refreshes the toolchain and pre-fetches crates (`cargo fetch --locked`).
+Standard build/lint/test/run commands live in **Development Commands** and **Testing
+Strategy** above — use those. Non-obvious caveats:
+
+- **C++ compiler must be GNU, not clang.** The workspace pulls in `tokenizers` →
+  `esaxx-rs`, whose C++ build fails under clang with `esaxx.cpp: 'cstdint' file not found`.
+  The environment sets `cc`/`c++` to GNU via `update-alternatives` (`gcc`/`g++`). If you
+  ever hit that error, either re-run `sudo update-alternatives --set c++ /usr/bin/g++`
+  and `sudo update-alternatives --set cc /usr/bin/gcc`, or build with `CC=gcc CXX=g++`.
+- **CLI has no root default-run binary.** Use `cargo run -p redact-cli -- <args>`
+  (e.g. `... -- analyze "test@example.com"`); `--bin redact-cli` fails from the workspace root.
+- **redact-api and redact-gateway both default to port 8080.** Run only one on 8080, or
+  override: `redact-api` uses `HOST`/`PORT`; `redact-gateway` uses `--host/--port`
+  (or `CENSGATE_HOST`/`CENSGATE_PORT`). Example dev split: API on 8080, gateway on 8081.
+- **Gateway dev tips.** Pass `OTEL_SDK_DISABLED=true` to silence telemetry-export noise.
+  Health: `GET /healthz`. Redaction: `POST /v1/redact` with a `profile`
+  (`strict` blocks, `reversible` tokenizes). `POST /v1/restore` returns `403` under the
+  default no-auth config — that is expected; it needs `auth.mode = api_key` or `oidc`.
+- **NER is optional.** `redact-ner` builds without a model (the `ort` crate uses
+  `load-dynamic`), but the NER e2e tests are `#[ignore]` and need an exported ONNX model
+  plus `libonnxruntime.so` (`ORT_DYLIB_PATH`) — not provisioned by default.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for the Redact Rust workspace and documents the non-obvious caveats found during setup. The only code change is an addition to `AGENTS.md` (`## Cursor Cloud specific instructions`); the toolchain/dependency setup lives in the VM snapshot + startup update script.

## Environment setup performed

- Installed **Rust 1.93.0** (`.tool-versions`) with `rustfmt` + `clippy`, set as default (base image had 1.83).
- Installed native build dep `libssl-dev` (`pkg-config`, `cmake`, `g++` already present).
- Switched system `cc`/`c++` alternatives to GNU `gcc`/`g++` — the default `clang` fails to build `tokenizers` → `esaxx-rs` (`esaxx.cpp: 'cstdint' file not found`).

### Startup update script (minimal, idempotent)
```
rustup toolchain install 1.93.0 --profile minimal --component rustfmt --component clippy
rustup default 1.93.0
cargo fetch --locked
```

## Verification

| Service | Command | Result |
|---|---|---|
| Build | `cargo build --workspace` | OK |
| Lint | `cargo fmt --all -- --check` / `cargo clippy --all-targets --all-features -- -D warnings` | OK, 0 warnings |
| Tests | `cargo test --workspace --all-features` | 535 passed, 0 failed (2 NER e2e ignored) |
| CLI | `cargo run -p redact-cli -- analyze ...` | Detected email / phone / SSN |
| REST API | `redact-api` on :8080 → `/api/v1/analyze`, `/api/v1/anonymize` | Detection + placeholder anonymization |
| Gateway | `redact-gateway` on :8081 → `/v1/redact` | `strict` blocks, `reversible` tokenizes |

NER (ONNX) was left out of scope — it is an optional add-on requiring a downloaded model + ONNX Runtime.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-166f1b31-d5ac-46d0-96e5-0d388b07d8a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-166f1b31-d5ac-46d0-96e5-0d388b07d8a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

