### PR TITLE
ci: harden release so a broken image cannot ship (#114)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,7 @@ jobs:
         run: ./scripts/check-docker-base-compat.sh
 
   # Build and smoke-test publishable images so GLIBC mismatches fail in CI.
+  # Gateway smoke asserts /v1/redact (email replace + AWS key block), not --version.
   docker-images:
     name: Docker image smoke tests
     runs-on: ubuntu-latest
@@ -227,31 +228,10 @@ jobs:
         run: docker build -f Dockerfile.gateway -t redact-gateway:ci .
 
       - name: Smoke test gateway image
-        run: docker run --rm redact-gateway:ci --version
+        run: IMAGE=redact-gateway:ci ./scripts/ci/smoke-gateway.sh
 
       - name: Build API image
         run: docker build -f Dockerfile -t redact-api:ci .
 
       - name: Smoke test API image
-        run: |
-          set -euo pipefail
-          docker run -d --name api-smoke -p 8080:8080 redact-api:ci
-          cleanup() { docker rm -f api-smoke >/dev/null 2>&1 || true; }
-          trap cleanup EXIT
-          echo "Waiting for API to become healthy..."
-          for i in $(seq 1 30); do
-            if curl -sf http://localhost:8080/healthz > /dev/null 2>&1; then
-              echo "API ready after ${i}s"
-              curl -sf http://localhost:8080/healthz | python3 -m json.tool
-              exit 0
-            fi
-            if ! docker ps -q -f name=api-smoke | grep -q .; then
-              echo "ERROR: API container exited early"
-              docker logs api-smoke || true
-              exit 1
-            fi
-            sleep 1
-          done
-          echo "ERROR: API failed to become healthy within 30s"
-          docker logs api-smoke || true
-          exit 1
+        run: IMAGE=redact-api:ci ./scripts/ci/smoke-api.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,6 +252,19 @@ jobs:
           cache-on-failure: true
           key: redact-scan-integration
 
+      - name: Pre-pull Postgres test image
+        run: |
+          set -euo pipefail
+          for i in 1 2 3 4 5; do
+            if docker pull postgres:16-alpine; then
+              exit 0
+            fi
+            echo "docker pull failed (attempt ${i}), retrying..."
+            sleep $((i * 2))
+          done
+          echo "ERROR: could not pull postgres:16-alpine" >&2
+          exit 1
+
       - name: Run gated Postgres tests
         env:
           REDACT_SCAN_INTEGRATION: "1"

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -74,3 +74,13 @@ jobs:
             echo "Waiting for crates.io index..."
             sleep 45
           done
+
+      - name: Verify crates.io versions
+        env:
+          CRATES: ${{ steps.resolve.outputs.packages }}
+        run: |
+          set -euo pipefail
+          TAG_VERSION="$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')"
+          export TAG_VERSION
+          echo "Asserting crates.io has ${TAG_VERSION} for: ${CRATES}"
+          ./scripts/ci/verify-crates.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -615,25 +615,33 @@ jobs:
           import json, sys
           data = json.load(sys.stdin)
           text = data.get('text', '')
-          if data.get('blocked') is True:
-              raise SystemExit('ERROR: email-only request was blocked')
+          if data.get('blocked') is not False:
+              raise SystemExit('ERROR: email-only request must set blocked=false, got ' + repr(data.get('blocked')))
           if 'alice@example.com' in text:
               raise SystemExit('ERROR: plaintext email still present')
           if '[EMAIL_ADDRESS]' not in text:
               raise SystemExit('ERROR: expected [EMAIL_ADDRESS] placeholder')
-          print('OK: email replaced')
+          print('OK: email replaced, blocked=false')
           "
 
           AWS_KEY="AKIA""IOSFODNN7EXAMPLE"
+          ORIGINAL="Contact alice@example.com with key ${AWS_KEY}"
           COMBO_BODY="$(curl -sf http://127.0.0.1:8080/v1/redact \
             -H "content-type: application/json" \
-            -d "{\"text\":\"Contact alice@example.com with key ${AWS_KEY}\"}")"
+            -d "{\"text\":\"${ORIGINAL}\"}")"
           echo "${COMBO_BODY}" | python3 -m json.tool
-          echo "${COMBO_BODY}" | python3 -c "
-          import json, sys
+          echo "${COMBO_BODY}" | ORIGINAL="${ORIGINAL}" python3 -c "
+          import json, os, sys
           data = json.load(sys.stdin)
+          original = os.environ['ORIGINAL']
           if data.get('blocked') is not True:
               raise SystemExit('ERROR: expected blocked=true for AWS access key')
+          got = data.get('text')
+          if got != original:
+              raise SystemExit(
+                  'ERROR: blocked response must keep original text; '
+                  f'expected {original!r}, got {got!r}'
+              )
           blocked = data.get('outcome', {}).get('blocked_entities') or []
           if 'AWS_ACCESS_KEY' not in blocked:
               raise SystemExit('ERROR: expected AWS_ACCESS_KEY in blocked_entities')
@@ -645,6 +653,6 @@ jobs:
           )
           if email_replace < 1:
               raise SystemExit('ERROR: expected EMAIL_ADDRESS replace in outcome')
-          print('OK: AWS key blocked, email counted as replace')
+          print('OK: blocked=true, original text preserved, email counted as replace')
           "
           echo "OK: stranger pulled ${IMAGE} and it redacts"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
 
   create-release:
     name: Create Release
-    needs: build-binaries
+    needs: [build-binaries, verify-pushed-images]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -202,6 +202,11 @@ jobs:
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p redact-gateway
         continue-on-error: true
 
+      - name: Verify crates.io versions
+        run: ./scripts/ci/verify-crates.sh
+        env:
+          TAG_VERSION: ${{ env.TAG_VERSION }}
+
   docker:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
@@ -234,7 +239,7 @@ jobs:
           TAGS="${IMAGE}:${VER},${IMAGE}:${MINOR},${IMAGE}:${MAJOR},${IMAGE}:latest"
           echo "tags=$TAGS" >> $GITHUB_OUTPUT
 
-      - name: Build API image for smoke test (amd64 only)
+      - name: Build API image for smoke test (amd64)
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -243,29 +248,21 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Smoke test API image
-        run: |
-          set -euo pipefail
-          docker run -d --name api-smoke -p 8080:8080 redact-api:smoke-test
-          cleanup() { docker rm -f api-smoke >/dev/null 2>&1 || true; }
-          trap cleanup EXIT
-          echo "Waiting for API to become healthy..."
-          for i in $(seq 1 30); do
-            if curl -sf http://localhost:8080/healthz > /dev/null 2>&1; then
-              echo "API ready after ${i}s"
-              curl -sf http://localhost:8080/healthz | python3 -m json.tool
-              exit 0
-            fi
-            if ! docker ps -q -f name=api-smoke | grep -q .; then
-              echo "ERROR: API container exited early"
-              docker logs api-smoke || true
-              exit 1
-            fi
-            sleep 1
-          done
-          echo "ERROR: API failed to become healthy within 30s"
-          docker logs api-smoke || true
-          exit 1
+      - name: Smoke test API image (amd64)
+        run: IMAGE=redact-api:smoke-test ./scripts/ci/smoke-api.sh
+
+      - name: Build API image for smoke test (arm64)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/arm64
+          load: true
+          tags: redact-api:smoke-test-arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test API image (arm64)
+        run: IMAGE=redact-api:smoke-test-arm64 PLATFORM=linux/arm64 ./scripts/ci/smoke-api.sh
 
       - name: Build and push
         uses: docker/build-push-action@v7
@@ -309,7 +306,7 @@ jobs:
           TAGS="${IMAGE}:full,${IMAGE}:${VER}-full,${IMAGE}:${MINOR}-full,${IMAGE}:${MAJOR}-full"
           echo "tags=$TAGS" >> $GITHUB_OUTPUT
 
-      - name: Build full image for smoke test (amd64 only)
+      - name: Build full image for smoke test (amd64)
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -321,57 +318,24 @@ jobs:
           cache-from: type=gha,scope=ner-full
           cache-to: type=gha,mode=max,scope=ner-full
 
-      - name: Smoke test NER image
-        run: |
-          echo "--- Starting smoke test container ---"
-          docker run -d --name smoke-test -p 8080:8080 redact-full:smoke-test
-          echo "Waiting for server to start..."
-          for i in $(seq 1 30); do
-            if curl -sf http://localhost:8080/healthz > /dev/null 2>&1; then
-              echo "Server ready after ${i}s"
-              break
-            fi
-            if [ "$i" = "30" ]; then
-              echo "ERROR: Server failed to start within 30s"
-              docker logs smoke-test
-              exit 1
-            fi
-            sleep 1
-          done
+      - name: Smoke test NER image (amd64)
+        run: IMAGE=redact-full:smoke-test ./scripts/ci/smoke-ner.sh
 
-          echo "--- Health check ---"
-          HEALTH=$(curl -sf http://localhost:8080/healthz)
-          echo "$HEALTH" | python3 -m json.tool
-          RECOGNIZERS=$(echo "$HEALTH" | python3 -c "import sys,json; print(json.load(sys.stdin).get('recognizers',0))")
-          if [ "$RECOGNIZERS" -lt 2 ]; then
-            echo "ERROR: Expected at least 2 recognizers (pattern + NER), got $RECOGNIZERS"
-            docker rm -f smoke-test
-            exit 1
-          fi
-          echo "OK: $RECOGNIZERS recognizers"
+      - name: Build full image for smoke test (arm64)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile.ner
+          platforms: linux/arm64
+          load: true
+          tags: redact-full:smoke-test-arm64
+          build-args: |
+            NER_BASE=ghcr.io/${{ github.repository }}-ner-base:v2
+          cache-from: type=gha,scope=ner-full
+          cache-to: type=gha,mode=max,scope=ner-full
 
-          echo "--- NER entity detection ---"
-          RESULT=$(curl -sf http://localhost:8080/api/v1/analyze \
-            -H 'Content-Type: application/json' \
-            -d '{"text": "John Smith works at Microsoft in Seattle"}')
-          echo "$RESULT" | python3 -m json.tool
-          NER_FOUND=$(echo "$RESULT" | python3 -c "
-          import sys, json
-          data = json.load(sys.stdin)
-          results = data.get('results', [])
-          types = {e['entity_type'] for e in results}
-          ner_types = types & {'PERSON', 'ORGANIZATION', 'LOCATION'}
-          print(len(ner_types))
-          ")
-          if [ "$NER_FOUND" -lt 2 ]; then
-            echo "ERROR: Expected at least 2 NER entity types (PERSON/ORG/LOC), found $NER_FOUND"
-            docker rm -f smoke-test
-            exit 1
-          fi
-          echo "OK: $NER_FOUND NER entity types detected"
-
-          docker rm -f smoke-test
-          echo "--- Smoke test passed ---"
+      - name: Smoke test NER image (arm64)
+        run: IMAGE=redact-full:smoke-test-arm64 PLATFORM=linux/arm64 ./scripts/ci/smoke-ner.sh
 
       - name: Build and push full image (pattern + ONNX NER)
         uses: docker/build-push-action@v7
@@ -420,7 +384,7 @@ jobs:
           TAGS="${IMAGE}:${VER},${IMAGE}:${MINOR},${IMAGE}:${MAJOR},${IMAGE}:latest"
           echo "tags=$TAGS" >> $GITHUB_OUTPUT
 
-      - name: Build gateway image for smoke test (amd64 only)
+      - name: Build gateway image for smoke test (amd64)
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -430,8 +394,22 @@ jobs:
           cache-from: type=gha,scope=gateway
           cache-to: type=gha,mode=max,scope=gateway
 
-      - name: Smoke test gateway image
-        run: docker run --rm redact-gateway:smoke-test --version
+      - name: Smoke test gateway image (amd64)
+        run: IMAGE=redact-gateway:smoke-test ./scripts/ci/smoke-gateway.sh
+
+      - name: Build gateway image for smoke test (arm64)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile.gateway
+          platforms: linux/arm64
+          load: true
+          tags: redact-gateway:smoke-test-arm64
+          cache-from: type=gha,scope=gateway
+          cache-to: type=gha,mode=max,scope=gateway
+
+      - name: Smoke test gateway image (arm64)
+        run: IMAGE=redact-gateway:smoke-test-arm64 PLATFORM=linux/arm64 ./scripts/ci/smoke-gateway.sh
 
       - name: Build and push gateway image
         uses: docker/build-push-action@v7
@@ -443,3 +421,230 @@ jobs:
           cache-from: type=gha,scope=gateway
           cache-to: type=gha,mode=max,scope=gateway
           platforms: linux/amd64,linux/arm64
+
+  # Pull the published multi-arch manifest by digest and smoke both
+  # architectures. This is the only test that asserts the artifact a stranger
+  # receives — load:true and push:true are separate buildx invocations.
+  verify-pushed-images:
+    name: Verify pushed ${{ matrix.family }} (${{ matrix.platform }})
+    needs: [docker, docker-full, docker-gateway]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [linux/amd64, linux/arm64]
+        family: [api, full, gateway]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ env.VERSION }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve image family
+        id: image
+        run: |
+          set -euo pipefail
+          VER="${VERSION#v}"
+          MAJOR="${VER%%.*}"
+          MINOR="${VER%.*}"
+          REPO="ghcr.io/${{ github.repository }}"
+          case "${{ matrix.family }}" in
+            api)
+              echo "repo=${REPO}" >> "$GITHUB_OUTPUT"
+              echo "tags=${VER},${MINOR},${MAJOR},latest" >> "$GITHUB_OUTPUT"
+              echo "smoke=api" >> "$GITHUB_OUTPUT"
+              ;;
+            full)
+              echo "repo=${REPO}" >> "$GITHUB_OUTPUT"
+              echo "tags=${VER}-full,${MINOR}-full,${MAJOR}-full,full" >> "$GITHUB_OUTPUT"
+              echo "smoke=ner" >> "$GITHUB_OUTPUT"
+              ;;
+            gateway)
+              echo "repo=${REPO}-gateway" >> "$GITHUB_OUTPUT"
+              echo "tags=${VER},${MINOR},${MAJOR},latest" >> "$GITHUB_OUTPUT"
+              echo "smoke=gateway" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "unknown family ${{ matrix.family }}" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Assert tags share one digest
+        id: digest
+        run: |
+          set -euo pipefail
+          DIGEST="$(./scripts/ci/verify-image-digest.sh "${{ steps.image.outputs.repo }}" "${{ steps.image.outputs.tags }}")"
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "Resolved ${{ steps.image.outputs.repo }}@${DIGEST}"
+
+      - name: Pull by digest
+        run: |
+          docker pull --platform ${{ matrix.platform }} \
+            "${{ steps.image.outputs.repo }}@${{ steps.digest.outputs.digest }}"
+
+      - name: Smoke pulled image
+        env:
+          IMAGE: ${{ steps.image.outputs.repo }}@${{ steps.digest.outputs.digest }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+          case "${{ steps.image.outputs.smoke }}" in
+            api) ./scripts/ci/smoke-api.sh ;;
+            ner) ./scripts/ci/smoke-ner.sh ;;
+            gateway) ./scripts/ci/smoke-gateway.sh ;;
+            *) echo "unknown smoke ${{ steps.image.outputs.smoke }}" >&2; exit 1 ;;
+          esac
+
+  # Consume published artifacts the way a stranger does: no repo checkout.
+  stranger-path:
+    name: Consume as a stranger
+    needs: [verify-pushed-images, publish-crates]
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Resolve version
+        id: ver
+        run: |
+          VER="${VERSION#v}"
+          echo "ver=${VER}" >> "$GITHUB_OUTPUT"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: README quickstart in a clean Rust container
+        env:
+          TAG_VERSION: ${{ steps.ver.outputs.ver }}
+        run: |
+          set -euo pipefail
+          docker run --rm --network host \
+            -e TAG_VERSION="${TAG_VERSION}" \
+            rust:1.93-bookworm bash -lc '
+              set -euo pipefail
+              apt-get update
+              apt-get install -y --no-install-recommends curl
+              cargo install redact-cli
+              redact --version
+              redact --version | grep -F "${TAG_VERSION}"
+              cargo install redact-gateway
+              export OTEL_SDK_DISABLED=true
+              redact-gateway --host 127.0.0.1 &
+              gw_pid=$!
+              cleanup() { kill "${gw_pid}" >/dev/null 2>&1 || true; }
+              trap cleanup EXIT
+              echo "Waiting for gateway /healthz..."
+              for i in $(seq 1 60); do
+                if curl -sf http://127.0.0.1:8080/healthz >/dev/null 2>&1; then
+                  echo "Gateway ready after ${i}s"
+                  break
+                fi
+                if ! kill -0 "${gw_pid}" 2>/dev/null; then
+                  echo "ERROR: redact-gateway exited early" >&2
+                  exit 1
+                fi
+                if [ "${i}" = "60" ]; then
+                  echo "ERROR: gateway not ready within 60s" >&2
+                  exit 1
+                fi
+                sleep 1
+              done
+              BODY="$(curl -sS http://127.0.0.1:8080/v1/redact \
+                -H "content-type: application/json" \
+                -d "{\"text\":\"Email me at alice@example.com\"}")"
+              echo "${BODY}"
+              echo "${BODY}" | grep -q "\[EMAIL_ADDRESS\]"
+              if echo "${BODY}" | grep -q "alice@example.com"; then
+                echo "ERROR: plaintext email still present" >&2
+                exit 1
+              fi
+              echo "OK: README quickstart redacted the sample email"
+            '
+
+      - name: Pull and exercise published gateway image
+        env:
+          TAG_VERSION: ${{ steps.ver.outputs.ver }}
+        run: |
+          set -euo pipefail
+          IMAGE="ghcr.io/${{ github.repository }}-gateway:${TAG_VERSION}"
+          docker pull "${IMAGE}"
+          NAME="stranger-gw"
+          docker run -d --name "${NAME}" -p 8080:8080 -e OTEL_SDK_DISABLED=true "${IMAGE}"
+          cleanup() { docker rm -f "${NAME}" >/dev/null 2>&1 || true; }
+          trap cleanup EXIT
+          echo "Waiting for published gateway /healthz..."
+          for i in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:8080/healthz >/dev/null 2>&1; then
+              echo "Gateway ready after ${i}s"
+              break
+            fi
+            if ! docker ps -q -f "name=^/${NAME}$" | grep -q .; then
+              echo "ERROR: container exited early" >&2
+              docker logs "${NAME}" >&2 || true
+              exit 1
+            fi
+            if [ "${i}" = "30" ]; then
+              echo "ERROR: gateway not ready within 30s" >&2
+              docker logs "${NAME}" >&2 || true
+              exit 1
+            fi
+            sleep 1
+          done
+
+          EMAIL_BODY="$(curl -sf http://127.0.0.1:8080/v1/redact \
+            -H "content-type: application/json" \
+            -d "{\"text\":\"Email me at alice@example.com\"}")"
+          echo "${EMAIL_BODY}" | python3 -m json.tool
+          echo "${EMAIL_BODY}" | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          text = data.get('text', '')
+          if data.get('blocked') is True:
+              raise SystemExit('ERROR: email-only request was blocked')
+          if 'alice@example.com' in text:
+              raise SystemExit('ERROR: plaintext email still present')
+          if '[EMAIL_ADDRESS]' not in text:
+              raise SystemExit('ERROR: expected [EMAIL_ADDRESS] placeholder')
+          print('OK: email replaced')
+          "
+
+          AWS_KEY="AKIA""IOSFODNN7EXAMPLE"
+          COMBO_BODY="$(curl -sf http://127.0.0.1:8080/v1/redact \
+            -H "content-type: application/json" \
+            -d "{\"text\":\"Contact alice@example.com with key ${AWS_KEY}\"}")"
+          echo "${COMBO_BODY}" | python3 -m json.tool
+          echo "${COMBO_BODY}" | python3 -c "
+          import json, sys
+          data = json.load(sys.stdin)
+          if data.get('blocked') is not True:
+              raise SystemExit('ERROR: expected blocked=true for AWS access key')
+          blocked = data.get('outcome', {}).get('blocked_entities') or []
+          if 'AWS_ACCESS_KEY' not in blocked:
+              raise SystemExit('ERROR: expected AWS_ACCESS_KEY in blocked_entities')
+          email_replace = (
+              data.get('outcome', {})
+              .get('entity_action_counts', {})
+              .get('EMAIL_ADDRESS', {})
+              .get('replace', 0)
+          )
+          if email_replace < 1:
+              raise SystemExit('ERROR: expected EMAIL_ADDRESS replace in outcome')
+          print('OK: AWS key blocked, email counted as replace')
+          "
+          echo "OK: stranger pulled ${IMAGE} and it redacts"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   failed by `astral-tokio-tar` advisories in the Postgres acceptance-test
   tree. Ignore unfixed `RUSTSEC-2023-0071` (`rsa` / Marvin) which is pulled
   only by unused optional `sqlx-mysql` — this crate enables Postgres only.
+- `redact-scan`: retry testcontainer start and pre-pull `postgres:16-alpine`
+  in CI so Hub `bytes remaining on stream` flakes do not fail the job.
 
 ## [0.9.1] - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Release: GitHub Release publication waits for all three image jobs and a
+  post-push digest smoke on `linux/amd64` and `linux/arm64` (the load-then-push
+  split is what let #114 ship).
+- Release: gateway image smoke asserts `/v1/redact` (email replace + AWS key
+  block), not only `--version`.
+- Release: crates.io publish is checked against the index after the
+  `continue-on-error` publish steps.
+- Release: a no-checkout stranger-path job installs from crates.io and pulls
+  the published gateway image the way a consumer would.
+
 ## [0.9.1] - 2026-08-08
 
 ### Fixed

--- a/crates/redact-scan/tests/postgres.rs
+++ b/crates/redact-scan/tests/postgres.rs
@@ -34,21 +34,35 @@ async fn start_postgres() -> (
     String,
     String,
 ) {
-    let container = Postgres::default()
-        .with_tag("16-alpine")
-        .with_cmd([
-            "postgres",
-            "-c",
-            "shared_preload_libraries=pg_stat_statements",
-        ])
-        .start()
-        .await
-        .expect("start postgres");
-    let host = container.get_host().await.expect("host").to_string();
-    let port = container.get_host_port_ipv4(5432).await.expect("port");
-    let admin = format!("postgres://postgres:postgres@{host}:{port}/postgres");
-    let scanner = format!("postgres://scanner:scan-pass-not-super@{host}:{port}/postgres");
-    (container, admin, scanner)
+    // Hub pulls flake with "bytes remaining on stream"; retry before failing CI.
+    let mut last_err = None;
+    for attempt in 1..=5u32 {
+        match Postgres::default()
+            .with_tag("16-alpine")
+            .with_cmd([
+                "postgres",
+                "-c",
+                "shared_preload_libraries=pg_stat_statements",
+            ])
+            .start()
+            .await
+        {
+            Ok(container) => {
+                let host = container.get_host().await.expect("host").to_string();
+                let port = container.get_host_port_ipv4(5432).await.expect("port");
+                let admin = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+                let scanner =
+                    format!("postgres://scanner:scan-pass-not-super@{host}:{port}/postgres");
+                return (container, admin, scanner);
+            }
+            Err(err) => {
+                eprintln!("start postgres attempt {attempt}/5 failed: {err}");
+                last_err = Some(err);
+                tokio::time::sleep(Duration::from_secs(u64::from(attempt))).await;
+            }
+        }
+    }
+    panic!("start postgres: {last_err:?}");
 }
 
 async fn admin_pool(url: &str) -> sqlx::PgPool {

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Shared helpers for release/CI image smoke scripts.
+# shellcheck shell=bash
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+# Default wait: 30s native, 180s under QEMU/arm64 (NER especially).
+smoke_wait_secs() {
+  if [[ -n "${SMOKE_WAIT_SECS:-}" ]]; then
+    echo "${SMOKE_WAIT_SECS}"
+    return
+  fi
+  case "${PLATFORM:-${SMOKE_PLATFORM:-}}" in
+    *arm64*) echo 180 ;;
+    *) echo 30 ;;
+  esac
+}
+
+# Append --platform when PLATFORM or SMOKE_PLATFORM is set.
+append_platform() {
+  local -n _smoke_args=$1
+  local platform="${PLATFORM:-${SMOKE_PLATFORM:-}}"
+  if [[ -n "${platform}" ]]; then
+    _smoke_args+=(--platform "${platform}")
+  fi
+}
+
+# Wait until url answers, or the named container exits.
+wait_for_http() {
+  local url="$1"
+  local name="$2"
+  local secs="$3"
+  local i
+  echo "Waiting for ${url} (${secs}s)..."
+  for i in $(seq 1 "${secs}"); do
+    if curl -sf "${url}" >/dev/null 2>&1; then
+      echo "Ready after ${i}s"
+      return 0
+    fi
+    if ! docker ps -q -f "name=^/${name}$" | grep -q .; then
+      echo "ERROR: container ${name} exited early" >&2
+      docker logs "${name}" >&2 || true
+      return 1
+    fi
+    sleep 1
+  done
+  echo "ERROR: ${url} not ready within ${secs}s" >&2
+  docker logs "${name}" >&2 || true
+  return 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}

--- a/scripts/ci/smoke-api.sh
+++ b/scripts/ci/smoke-api.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Smoke-test a redact-api image: start it and wait for /healthz.
+set -euo pipefail
+
+# shellcheck source=lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+IMAGE="${1:-${IMAGE:?IMAGE is required (arg or env)}}"
+NAME="${SMOKE_NAME:-api-smoke}"
+HOST_PORT="${SMOKE_PORT:-8080}"
+WAIT_SECS="$(smoke_wait_secs)"
+
+require_cmd docker
+require_cmd curl
+
+run_cmd=(docker run -d --name "${NAME}" -p "${HOST_PORT}:8080")
+append_platform run_cmd
+run_cmd+=("${IMAGE}")
+"${run_cmd[@]}"
+cleanup() { docker rm -f "${NAME}" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+wait_for_http "http://127.0.0.1:${HOST_PORT}/healthz" "${NAME}" "${WAIT_SECS}"
+curl -sf "http://127.0.0.1:${HOST_PORT}/healthz" | python3 -m json.tool
+echo "OK: API smoke passed (${IMAGE})"

--- a/scripts/ci/smoke-gateway.sh
+++ b/scripts/ci/smoke-gateway.sh
@@ -3,9 +3,8 @@
 #
 # Two POSTs, matching docs/gateway/getting-started.md:
 #   1. Email only → replaced, blocked=false
-#   2. Email + AWS sample key → blocked=true, AWS_ACCESS_KEY in blocked_entities
-# A single body with both cannot show both values replaced: the default profile
-# fail-closes on credentials and returns the original text.
+#   2. Email + AWS sample key → blocked=true, text unchanged, AWS_ACCESS_KEY
+#      in blocked_entities. Default profile fail-closes on credentials.
 set -euo pipefail
 
 # shellcheck source=lib.sh
@@ -39,27 +38,35 @@ echo "${EMAIL_BODY}" | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
 text = data.get('text', '')
-if data.get('blocked') is True:
-    raise SystemExit('ERROR: email-only request was blocked')
+if data.get('blocked') is not False:
+    raise SystemExit('ERROR: email-only request must set blocked=false, got ' + repr(data.get('blocked')))
 if 'alice@example.com' in text:
     raise SystemExit('ERROR: plaintext email still present')
 if '[EMAIL_ADDRESS]' not in text:
     raise SystemExit('ERROR: expected [EMAIL_ADDRESS] placeholder, got: ' + text)
-print('OK: email replaced')
+print('OK: email replaced, blocked=false')
 "
 
 echo "--- Email + AWS access key (default profile blocks credentials) ---"
 # AWS docs sample shape; split so scanners do not see a contiguous secret.
 AWS_KEY="AKIA""IOSFODNN7EXAMPLE"
+ORIGINAL="Contact alice@example.com with key ${AWS_KEY}"
 COMBO_BODY="$(curl -sf "${BASE}/v1/redact" \
   -H 'content-type: application/json' \
-  -d "{\"text\":\"Contact alice@example.com with key ${AWS_KEY}\"}")"
+  -d "{\"text\":\"${ORIGINAL}\"}")"
 echo "${COMBO_BODY}" | python3 -m json.tool
-echo "${COMBO_BODY}" | python3 -c "
-import json, sys
+echo "${COMBO_BODY}" | ORIGINAL="${ORIGINAL}" python3 -c "
+import json, os, sys
 data = json.load(sys.stdin)
+original = os.environ['ORIGINAL']
 if data.get('blocked') is not True:
     raise SystemExit('ERROR: expected blocked=true for AWS access key')
+got = data.get('text')
+if got != original:
+    raise SystemExit(
+        'ERROR: blocked response must keep original text; '
+        f'expected {original!r}, got {got!r}'
+    )
 blocked = data.get('outcome', {}).get('blocked_entities') or []
 if 'AWS_ACCESS_KEY' not in blocked:
     raise SystemExit('ERROR: expected AWS_ACCESS_KEY in blocked_entities, got ' + str(blocked))
@@ -71,7 +78,7 @@ email_replace = (
 )
 if email_replace < 1:
     raise SystemExit('ERROR: expected EMAIL_ADDRESS replace in outcome')
-print('OK: AWS key blocked, email counted as replace')
+print('OK: blocked=true, original text preserved, email counted as replace')
 "
 
 echo "OK: gateway smoke passed (${IMAGE})"

--- a/scripts/ci/smoke-gateway.sh
+++ b/scripts/ci/smoke-gateway.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Smoke-test a redact-gateway image: it must redact, not merely link.
+#
+# Two POSTs, matching docs/gateway/getting-started.md:
+#   1. Email only → replaced, blocked=false
+#   2. Email + AWS sample key → blocked=true, AWS_ACCESS_KEY in blocked_entities
+# A single body with both cannot show both values replaced: the default profile
+# fail-closes on credentials and returns the original text.
+set -euo pipefail
+
+# shellcheck source=lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+IMAGE="${1:-${IMAGE:?IMAGE is required (arg or env)}}"
+NAME="${SMOKE_NAME:-gw-smoke}"
+HOST_PORT="${SMOKE_PORT:-8080}"
+WAIT_SECS="$(smoke_wait_secs)"
+BASE="http://127.0.0.1:${HOST_PORT}"
+
+require_cmd docker
+require_cmd curl
+require_cmd python3
+
+run_cmd=(docker run -d --name "${NAME}" -p "${HOST_PORT}:8080" -e OTEL_SDK_DISABLED=true)
+append_platform run_cmd
+run_cmd+=("${IMAGE}")
+"${run_cmd[@]}"
+cleanup() { docker rm -f "${NAME}" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+wait_for_http "${BASE}/healthz" "${NAME}" "${WAIT_SECS}"
+
+echo "--- Email-only redact ---"
+EMAIL_BODY="$(curl -sf "${BASE}/v1/redact" \
+  -H 'content-type: application/json' \
+  -d '{"text":"Email me at alice@example.com"}')"
+echo "${EMAIL_BODY}" | python3 -m json.tool
+echo "${EMAIL_BODY}" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+text = data.get('text', '')
+if data.get('blocked') is True:
+    raise SystemExit('ERROR: email-only request was blocked')
+if 'alice@example.com' in text:
+    raise SystemExit('ERROR: plaintext email still present')
+if '[EMAIL_ADDRESS]' not in text:
+    raise SystemExit('ERROR: expected [EMAIL_ADDRESS] placeholder, got: ' + text)
+print('OK: email replaced')
+"
+
+echo "--- Email + AWS access key (default profile blocks credentials) ---"
+# AWS docs sample shape; split so scanners do not see a contiguous secret.
+AWS_KEY="AKIA""IOSFODNN7EXAMPLE"
+COMBO_BODY="$(curl -sf "${BASE}/v1/redact" \
+  -H 'content-type: application/json' \
+  -d "{\"text\":\"Contact alice@example.com with key ${AWS_KEY}\"}")"
+echo "${COMBO_BODY}" | python3 -m json.tool
+echo "${COMBO_BODY}" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+if data.get('blocked') is not True:
+    raise SystemExit('ERROR: expected blocked=true for AWS access key')
+blocked = data.get('outcome', {}).get('blocked_entities') or []
+if 'AWS_ACCESS_KEY' not in blocked:
+    raise SystemExit('ERROR: expected AWS_ACCESS_KEY in blocked_entities, got ' + str(blocked))
+email_replace = (
+    data.get('outcome', {})
+    .get('entity_action_counts', {})
+    .get('EMAIL_ADDRESS', {})
+    .get('replace', 0)
+)
+if email_replace < 1:
+    raise SystemExit('ERROR: expected EMAIL_ADDRESS replace in outcome')
+print('OK: AWS key blocked, email counted as replace')
+"
+
+echo "OK: gateway smoke passed (${IMAGE})"

--- a/scripts/ci/smoke-ner.sh
+++ b/scripts/ci/smoke-ner.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Smoke-test a redact-full (pattern + ONNX NER) image.
+# Asserts recognizers >= 2 and at least two of PERSON/ORGANIZATION/LOCATION
+# on a real sentence — the same bar the release job already set.
+set -euo pipefail
+
+# shellcheck source=lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+IMAGE="${1:-${IMAGE:?IMAGE is required (arg or env)}}"
+NAME="${SMOKE_NAME:-ner-smoke}"
+HOST_PORT="${SMOKE_PORT:-8080}"
+WAIT_SECS="$(smoke_wait_secs)"
+
+require_cmd docker
+require_cmd curl
+require_cmd python3
+
+run_cmd=(docker run -d --name "${NAME}" -p "${HOST_PORT}:8080")
+append_platform run_cmd
+run_cmd+=("${IMAGE}")
+"${run_cmd[@]}"
+cleanup() { docker rm -f "${NAME}" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+wait_for_http "http://127.0.0.1:${HOST_PORT}/healthz" "${NAME}" "${WAIT_SECS}"
+
+echo "--- Health check ---"
+HEALTH="$(curl -sf "http://127.0.0.1:${HOST_PORT}/healthz")"
+echo "${HEALTH}" | python3 -m json.tool
+RECOGNIZERS="$(echo "${HEALTH}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('recognizers',0))")"
+if [[ "${RECOGNIZERS}" -lt 2 ]]; then
+  fail "Expected at least 2 recognizers (pattern + NER), got ${RECOGNIZERS}"
+fi
+echo "OK: ${RECOGNIZERS} recognizers"
+
+echo "--- NER entity detection ---"
+RESULT="$(curl -sf "http://127.0.0.1:${HOST_PORT}/api/v1/analyze" \
+  -H 'Content-Type: application/json' \
+  -d '{"text": "John Smith works at Microsoft in Seattle"}')"
+echo "${RESULT}" | python3 -m json.tool
+NER_FOUND="$(echo "${RESULT}" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+results = data.get('results', [])
+types = {e['entity_type'] for e in results}
+ner_types = types & {'PERSON', 'ORGANIZATION', 'LOCATION'}
+print(len(ner_types))
+")"
+if [[ "${NER_FOUND}" -lt 2 ]]; then
+  fail "Expected at least 2 NER entity types (PERSON/ORG/LOC), found ${NER_FOUND}"
+fi
+echo "OK: ${NER_FOUND} NER entity types detected"
+echo "OK: NER smoke passed (${IMAGE})"

--- a/scripts/ci/verify-crates.sh
+++ b/scripts/ci/verify-crates.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Assert each expected crate version is present on the crates.io index.
+# Used after `cargo publish` steps that carry continue-on-error (already-published
+# vs genuine failure are otherwise indistinguishable).
+set -euo pipefail
+
+# shellcheck source=lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+TAG_VERSION="${TAG_VERSION:?TAG_VERSION is required (semver without leading v)}"
+# Space-separated; override when publishing a subset (publish-crates.yml).
+CRATES="${CRATES:-redact-core redact-ner redact-api redact-cli redact-gateway}"
+USER_AGENT="${CRATES_USER_AGENT:-censgate-redact-ci (https://github.com/censgate/redact)}"
+TIMEOUT_SECS="${CRATES_VERIFY_TIMEOUT_SECS:-300}"
+SLEEP_SECS="${CRATES_VERIFY_SLEEP_SECS:-15}"
+
+require_cmd curl
+require_cmd python3
+
+crate_has_version() {
+  local crate="$1"
+  local version="$2"
+  local body
+  body="$(curl -fsSL -A "${USER_AGENT}" "https://crates.io/api/v1/crates/${crate}")" || return 1
+  echo "${body}" | python3 -c "
+import json, sys
+wanted = sys.argv[1]
+data = json.load(sys.stdin)
+nums = {v.get('num') for v in data.get('versions', [])}
+sys.exit(0 if wanted in nums else 1)
+" "${version}"
+}
+
+deadline=$((SECONDS + TIMEOUT_SECS))
+pending="${CRATES}"
+echo "Waiting up to ${TIMEOUT_SECS}s for crates.io to list ${TAG_VERSION}:"
+echo "  ${pending}"
+
+while :; do
+  still=""
+  for crate in ${pending}; do
+    if crate_has_version "${crate}" "${TAG_VERSION}"; then
+      echo "OK: ${crate} ${TAG_VERSION} is on crates.io"
+    else
+      echo "missing: ${crate} ${TAG_VERSION}"
+      still="${still} ${crate}"
+    fi
+  done
+  still="${still# }"
+  if [[ -z "${still}" ]]; then
+    echo "All expected crate versions are present."
+    exit 0
+  fi
+  if (( SECONDS >= deadline )); then
+    fail "crates.io still missing ${TAG_VERSION} for:${still}"
+  fi
+  pending="${still}"
+  echo "Retrying in ${SLEEP_SECS}s..."
+  sleep "${SLEEP_SECS}"
+done

--- a/scripts/ci/verify-image-digest.sh
+++ b/scripts/ci/verify-image-digest.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Resolve a family of tags on one repository to a single manifest-list digest.
+# Prints the digest on stdout; tag comparisons go to stderr.
+#
+# Usage: verify-image-digest.sh <repo> <tag,tag,tag>
+# Example: verify-image-digest.sh ghcr.io/censgate/redact-gateway 0.9.1,0.9,0,latest
+set -euo pipefail
+
+# shellcheck source=lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+REPO="${1:-${IMAGE_REPO:?IMAGE_REPO or repo arg is required}}"
+TAGS_CSV="${2:-${IMAGE_TAGS:?IMAGE_TAGS or tags arg is required}}"
+
+require_cmd docker
+
+digest_for() {
+  local ref="$1"
+  local out digest
+  out="$(docker buildx imagetools inspect "${ref}")" || fail "imagetools inspect failed for ${ref}"
+  digest="$(awk '/^Digest:/{print $2; exit}' <<<"${out}")"
+  [[ -n "${digest}" ]] || fail "could not parse Digest from imagetools inspect of ${ref}"
+  echo "${digest}"
+}
+
+IFS=',' read -r -a tags <<<"${TAGS_CSV}"
+[[ ${#tags[@]} -gt 0 ]] || fail "no tags provided"
+
+first_tag=""
+first_digest=""
+for tag in "${tags[@]}"; do
+  tag="${tag#"${tag%%[![:space:]]*}"}"
+  tag="${tag%"${tag##*[![:space:]]}"}"
+  [[ -n "${tag}" ]] || continue
+  ref="${REPO}:${tag}"
+  digest="$(digest_for "${ref}")"
+  echo "${ref} -> ${digest}" >&2
+  if [[ -z "${first_digest}" ]]; then
+    first_tag="${tag}"
+    first_digest="${digest}"
+  elif [[ "${digest}" != "${first_digest}" ]]; then
+    fail "${REPO}:${tag} digest ${digest} != ${REPO}:${first_tag} digest ${first_digest}"
+  fi
+done
+
+[[ -n "${first_digest}" ]] || fail "no tags resolved"
+echo "OK: ${#tags[@]} tags share ${first_digest}" >&2
+echo "${first_digest}"


### PR DESCRIPTION
Thank you for contributing to Redact. These checkboxes are acknowledgements;
the CLA bot enforces the Individual CLA signature.

- [x] I have read [CLA.md](../CLA.md) and will sign the Individual CLA via the bot comment (or I have already signed). A Corporate CLA, if required, does not replace the Individual CLA.
- [x] All commits are DCO-signed (`git commit -s`)
- [x] I have read [docs/PROJECT_SCOPE.md](../docs/PROJECT_SCOPE.md); this change is in scope

**Employer time or equipment**

- [ ] No — this work was not done on employer time or equipment
- [x] Yes — my employer has authorised the contribution, or a Corporate CLA is on file

## Summary

Closes the four remaining #114-class gaps after the `--version` gateway smoke:

- **G1** — `create-release` now `needs: [build-binaries, verify-pushed-images]`, so a failed image job or post-push digest smoke blocks GitHub Release publication.
- **G2** — `docker`, `docker-full`, and `docker-gateway` each load+smoke `linux/arm64` (QEMU) before the multi-arch push.
- **G3** — `verify-pushed-images` resolves each published tag family to one digest, pulls by digest, and smokes both architectures.
- **G4** — Gateway smoke starts the image and POSTs `/v1/redact`: email-only must be replaced; email + AWS sample key must `blocked: true` with `AWS_ACCESS_KEY` (default profile fail-closes and keeps original text — see `docs/gateway/getting-started.md`).
- **G5** — After `continue-on-error` `cargo publish` steps, `verify-crates.sh` queries the crates.io index and fails if the expected version is missing. Same check on `publish-crates.yml`.
- **G6** — `stranger-path` has no repo checkout: README quickstart via `cargo install` in a clean `rust:1.93-bookworm` container, then pull the published gateway image by tag and exercise it.

Shared scripts live in `scripts/ci/`. PR CI `docker-images` uses the stronger gateway smoke (amd64 only).

## Test plan

- [x] `shellcheck -x scripts/ci/*.sh` (SC1091 info on sourced `lib.sh` only)
- [x] `TAG_VERSION=0.9.1 ./scripts/ci/verify-crates.sh` passes against live crates.io
- [x] `TAG_VERSION=0.0.0-not-a-release` fails as expected
- [x] Workflow YAML parsed; `needs` graph and no-checkout stranger-path asserted
- [ ] Full tag-release path cannot be run from this environment (no Docker daemon / no tag publish)