### PR TITLE
ci(release): gate crates.io on image verify; pin prerelease tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,9 @@ jobs:
 
   publish-crates:
     name: Publish to crates.io
+    # Least reversible publish step: wait until every image family has been
+    # pushed and smoke-tested on the digest a stranger would pull.
+    needs: [build-binaries, verify-pushed-images]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -232,12 +235,11 @@ jobs:
       - name: Compute Docker tags
         id: meta
         run: |
+          set -euo pipefail
           VER="${VERSION#v}"
-          MAJOR="${VER%%.*}"
-          MINOR="${VER%.*}"
           IMAGE="ghcr.io/${{ github.repository }}"
-          TAGS="${IMAGE}:${VER},${IMAGE}:${MINOR},${IMAGE}:${MAJOR},${IMAGE}:latest"
-          echo "tags=$TAGS" >> $GITHUB_OUTPUT
+          TAGS="$(./scripts/ci/docker-tags.sh api "${VER}" "${IMAGE}")"
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
 
       - name: Build API image for smoke test (amd64)
         uses: docker/build-push-action@v7
@@ -299,12 +301,11 @@ jobs:
       - name: Compute Docker tags (full)
         id: meta-full
         run: |
+          set -euo pipefail
           VER="${VERSION#v}"
-          MAJOR="${VER%%.*}"
-          MINOR="${VER%.*}"
           IMAGE="ghcr.io/${{ github.repository }}"
-          TAGS="${IMAGE}:full,${IMAGE}:${VER}-full,${IMAGE}:${MINOR}-full,${IMAGE}:${MAJOR}-full"
-          echo "tags=$TAGS" >> $GITHUB_OUTPUT
+          TAGS="$(./scripts/ci/docker-tags.sh full "${VER}" "${IMAGE}")"
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
 
       - name: Build full image for smoke test (amd64)
         uses: docker/build-push-action@v7
@@ -377,12 +378,11 @@ jobs:
       - name: Compute Docker tags (gateway)
         id: meta-gateway
         run: |
+          set -euo pipefail
           VER="${VERSION#v}"
-          MAJOR="${VER%%.*}"
-          MINOR="${VER%.*}"
           IMAGE="ghcr.io/${{ github.repository }}-gateway"
-          TAGS="${IMAGE}:${VER},${IMAGE}:${MINOR},${IMAGE}:${MAJOR},${IMAGE}:latest"
-          echo "tags=$TAGS" >> $GITHUB_OUTPUT
+          TAGS="$(./scripts/ci/docker-tags.sh gateway "${VER}" "${IMAGE}")"
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
 
       - name: Build gateway image for smoke test (amd64)
         uses: docker/build-push-action@v7
@@ -458,30 +458,28 @@ jobs:
         run: |
           set -euo pipefail
           VER="${VERSION#v}"
-          MAJOR="${VER%%.*}"
-          MINOR="${VER%.*}"
           REPO="ghcr.io/${{ github.repository }}"
-          case "${{ matrix.family }}" in
+          FAMILY="${{ matrix.family }}"
+          TAGS="$(./scripts/ci/docker-tags.sh "${FAMILY}" "${VER}")"
+          case "${FAMILY}" in
             api)
               echo "repo=${REPO}" >> "$GITHUB_OUTPUT"
-              echo "tags=${VER},${MINOR},${MAJOR},latest" >> "$GITHUB_OUTPUT"
               echo "smoke=api" >> "$GITHUB_OUTPUT"
               ;;
             full)
               echo "repo=${REPO}" >> "$GITHUB_OUTPUT"
-              echo "tags=${VER}-full,${MINOR}-full,${MAJOR}-full,full" >> "$GITHUB_OUTPUT"
               echo "smoke=ner" >> "$GITHUB_OUTPUT"
               ;;
             gateway)
               echo "repo=${REPO}-gateway" >> "$GITHUB_OUTPUT"
-              echo "tags=${VER},${MINOR},${MAJOR},latest" >> "$GITHUB_OUTPUT"
               echo "smoke=gateway" >> "$GITHUB_OUTPUT"
               ;;
             *)
-              echo "unknown family ${{ matrix.family }}" >&2
+              echo "unknown family ${FAMILY}" >&2
               exit 1
               ;;
           esac
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
 
       - name: Assert tags share one digest
         id: digest

--- a/scripts/ci/docker-tags.sh
+++ b/scripts/ci/docker-tags.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Compute the Docker tag list for a release image family.
+#
+# Usage:
+#   docker-tags.sh <family> <version> [image]
+#
+# family:  api | full | gateway
+# version: semver without a leading v (0.10.0 or 0.10.0-rc.1)
+# image:   optional repository prefix; when set, each tag is printed as image:tag
+#
+# Prints a CSV on stdout. Hyphenated (prerelease) versions emit only the
+# exact version tag so :latest / :MAJOR / :MINOR / :full are not rewritten.
+set -euo pipefail
+
+# shellcheck source=lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+usage() {
+  echo "Usage: docker-tags.sh <family> <version> [image]" >&2
+  echo "       docker-tags.sh --self-test" >&2
+}
+
+is_prerelease() {
+  [[ "$1" == *-* ]]
+}
+
+# Strip a leading v so callers can pass ${VERSION#v} or the raw tag.
+normalize_version() {
+  local ver="$1"
+  ver="${ver#v}"
+  [[ -n "${ver}" ]] || fail "empty version"
+  echo "${ver}"
+}
+
+tag_csv() {
+  local family="$1"
+  local ver="$2"
+  local major minor
+
+  case "${family}" in
+    api|gateway)
+      if is_prerelease "${ver}"; then
+        echo "${ver}"
+      else
+        major="${ver%%.*}"
+        minor="${ver%.*}"
+        echo "${ver},${minor},${major},latest"
+      fi
+      ;;
+    full)
+      if is_prerelease "${ver}"; then
+        echo "${ver}-full"
+      else
+        major="${ver%%.*}"
+        minor="${ver%.*}"
+        echo "${ver}-full,${minor}-full,${major}-full,full"
+      fi
+      ;;
+    *)
+      fail "unknown family: ${family} (expected api, full, or gateway)"
+      ;;
+  esac
+}
+
+prefix_csv() {
+  local csv="$1"
+  local image="$2"
+  local out="" tag
+  local IFS=','
+  # shellcheck disable=SC2086
+  for tag in ${csv}; do
+    out="${out:+${out},}${image}:${tag}"
+  done
+  echo "${out}"
+}
+
+expect_eq() {
+  local got="$1"
+  local want="$2"
+  local label="$3"
+  if [[ "${got}" != "${want}" ]]; then
+    fail "self-test ${label}: got '${got}', want '${want}'"
+  fi
+}
+
+self_test() {
+  expect_eq "$(tag_csv api 0.10.0)" "0.10.0,0.10,0,latest" "api stable"
+  expect_eq "$(tag_csv gateway 0.10.0)" "0.10.0,0.10,0,latest" "gateway stable"
+  expect_eq "$(tag_csv full 0.10.0)" "0.10.0-full,0.10-full,0-full,full" "full stable"
+  expect_eq "$(tag_csv api 0.10.0-rc.1)" "0.10.0-rc.1" "api prerelease"
+  expect_eq "$(tag_csv gateway 0.10.0-rc.1)" "0.10.0-rc.1" "gateway prerelease"
+  expect_eq "$(tag_csv full 0.10.0-rc.1)" "0.10.0-rc.1-full" "full prerelease"
+  expect_eq "$(tag_csv api 0.9.1)" "0.9.1,0.9,0,latest" "api patch"
+  expect_eq \
+    "$(prefix_csv "$(tag_csv api 0.10.0-rc.1)" "ghcr.io/censgate/redact")" \
+    "ghcr.io/censgate/redact:0.10.0-rc.1" \
+    "prefixed prerelease"
+  echo "OK: docker-tags.sh self-test"
+}
+
+main() {
+  if [[ "${1:-}" == "--self-test" ]]; then
+    self_test
+    return
+  fi
+  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -lt 2 ]]; then
+    usage
+    [[ $# -ge 2 ]] || exit 1
+    exit 0
+  fi
+
+  local family="$1"
+  local ver
+  ver="$(normalize_version "$2")"
+  local image="${3:-}"
+  local csv
+  csv="$(tag_csv "${family}" "${ver}")"
+  if [[ -n "${image}" ]]; then
+    prefix_csv "${csv}" "${image}"
+  else
+    echo "${csv}"
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
Thank you for contributing to Redact. These checkboxes are acknowledgements;
the CLA bot enforces the Individual CLA signature.

- [x] I have read [CLA.md](../CLA.md) and will sign the Individual CLA via the bot comment (or I have already signed). A Corporate CLA, if required, does not replace the Individual CLA.
- [x] All commits are DCO-signed (`git commit -s`)
- [x] I have read [docs/PROJECT_SCOPE.md](../docs/PROJECT_SCOPE.md); this change is in scope

**Employer time or equipment**

- [ ] No — this work was not done on employer time or equipment
- [x] Yes — my employer has authorised the contribution, or a Corporate CLA is on file

## Summary

Closes the two remaining #114-class holes after #137, before any `v0.10.0-rc.1` rehearsal.

- **G1 remainder** — `publish-crates` now `needs: [build-binaries, verify-pushed-images]`. A failed image job or post-push digest smoke blocks crates.io. `create-release` stays parallel with crates (same `needs` as today). crates.io is the least reversible publish step.
- **Prerelease tag guard** — `scripts/ci/docker-tags.sh` emits only the exact version tag when the version contains `-`. An rc cannot overwrite `:latest`, `:MAJOR`, `:MINOR`, or `:full`. Stable tag lists are unchanged. `verify-pushed-images` uses the same list, so it only inspects tags that were pushed.
- **G4** — unchanged. Gateway smoke stays the default-profile contract: email replaced; email + AWS sample key **blocked** (fail-closed, original text preserved). That is email redaction plus credential fail-closed blocking, not “both replaced.” No `CENSGATE_TOKEN_DEK` is required. There is no bundled profile that replaces both.

Does not re-implement G2/G3/G5 (already in #137). Does not touch smoke scripts, stranger-path, Dockerfiles, or cache scopes.

## Test plan

- [x] `./scripts/ci/docker-tags.sh --self-test`
- [x] Stable: `api`/`gateway` → `0.10.0,0.10,0,latest`; `full` → `0.10.0-full,0.10-full,0-full,full`
- [x] Prerelease: `api`/`gateway` → `0.10.0-rc.1`; `full` → `0.10.0-rc.1-full`
- [x] `shellcheck -x scripts/ci/*.sh` (SC1091 info on sourced `lib.sh` only)
- [x] `release.yml` parses; `publish-crates` and `create-release` both need `[build-binaries, verify-pushed-images]`; `create-release` does not wait on crates