### PR TITLE
docs: reconcile 0.10.0 notes with git history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,37 +10,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `GENERIC_SECRET`: charset-aware Shannon entropy over assignment-like values
-  (length-aware floor, segment keyword allow/deny, value-only spans). Independently
-  disableable via CLI `--disable`, WASM `analyze_excluding`, or gateway
-  `{ action: allow }`. See `docs/secrets-detection.md`. Phase 2 of #101.
+  only (length-aware floor, segment keyword allow/deny, value-only spans).
+  It will catch `api_key=…` / `export SERVICE_SECRET=…` that pass the
+  charset, length, and keyword gates. It will not catch arbitrary
+  high-entropy blobs, hashes or UUIDs on a digest LHS, lockfile
+  `integrity=` lines, placeholders, or prefixed types (those stay named
+  types). Independently disableable via CLI `--disable`, WASM
+  `analyze_excluding`, or gateway `{ action: allow }`. See
+  `docs/secrets-detection.md`. Phase 2 of #101 (#138).
 - Named secret types: `HUGGINGFACE_TOKEN`, `DATABRICKS_TOKEN`,
   `DIGITALOCEAN_TOKEN`, `NOTION_API_KEY`, `PERPLEXITY_API_KEY`,
   `HTTP_BASIC_AUTH` (decode-validated). GitLab length-closed shapes and AWS
   Bedrock under `AWS_ACCESS_KEY`. Compiled entity count is 61 (60 pattern +
-  `GENERIC_SECRET`).
+  `GENERIC_SECRET`) (#138).
 - Optional long-tail pack `patterns/optional/providers-v1.yaml` (gitleaks MIT,
-  pinned commit). Not on the Docker / compose / Kubernetes default path.
-- CLI `redact --format json list-entities` and host-only
-  `scripts/extract-facts.mjs` → `data/facts.json`.
+  pinned commit). Opt-in only: not on the Docker / compose / Kubernetes
+  default path, and not compiled into WASM. This is not gitleaks parity
+  (#138).
+- CLI `--disable` (subtracts from `--entities`, or from the full compiled
+  set when `--entities` is omitted; empty remaining set is an error),
+  `redact --format json list-entities`, and host-only
+  `scripts/extract-facts.mjs` → `data/facts.json` (#138).
 - `redact-scan`: new workspace crate and `redact-scan` binary for read-only
   Postgres PII discovery. Report types, credential scrubber, CLI preflight,
   a read-only safety session (refuse superuser and write grants), and
   layers 0 / 0.5 / 1 / 2 (catalog, `pg_stats`, bounded `TABLESAMPLE`,
   JSON paths). Optional `--report-url` POSTs the report JSON; `--fail-on`
   exits 1 on matching findings. Reports contain locations and counts
-  only — never sample values. See `docs/scanning-model.md`.
+  only — never sample values. See `docs/scanning-model.md` (#131).
+- `redact-verify`: new workspace crate and `redact-verify` binary for
+  independent offline verification of Censgate ledger evidence packs.
+  No `redact-core` dependency; default path does not dial the network
+  (#132).
+- Contributor License Agreement and Code of Conduct, with a CLA GitHub
+  Action (#119, #120).
 
 ### Changed
 
+- **Gateway default pattern-pack path (migration).** 0.9.x images set
+  `CENSGATE_PATTERN_PACKS=/app/patterns`, which loaded the whole tree
+  including `patterns/security`. Images now set
+  `/app/patterns/compliance:/app/patterns/pii`. Existing gateway users
+  lose `patterns/security` on the default path (including the now-disabled
+  credentials catch-alls). Directories named `optional/` and `quarantine/`
+  are never auto-walked. Restore the old tree with
+  `CENSGATE_PATTERN_PACKS=/app/patterns` only if you accept the catch-all
+  risk; the supported opt-in for long-tail prefixes is
+  `patterns/optional/providers-v1.yaml` (#138).
 - Release: GitHub Release publication waits for all three image jobs and a
   post-push digest smoke on `linux/amd64` and `linux/arm64` (the load-then-push
-  split is what let #114 ship).
-- Release: gateway image smoke asserts `/v1/redact` (email replace + AWS key
-  block), not only `--version`.
-- Release: crates.io publish is checked against the index after the
-  `continue-on-error` publish steps.
-- Release: a no-checkout stranger-path job installs from crates.io and pulls
-  the published gateway image the way a consumer would.
+  split is what let #114 ship). Gateway image smoke asserts `/v1/redact`
+  (email replace + AWS key block on the default profile), not only
+  `--version`. crates.io publish is checked against the index after the
+  `continue-on-error` publish steps. A no-checkout stranger-path job
+  installs from crates.io and pulls the published gateway image (#137).
 
 ### Fixed
 
@@ -51,16 +74,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   delimiter instead of `\\b` after `=`. Pack `entropy: generic` requires
   capture group 1 at analyze time. Non-entropy pack rules keep the full
   match unless they set `value_group`. HTTP Basic matching is
-  case-insensitive.
-- Gateway default pack path is `/app/patterns/compliance:/app/patterns/pii`.
-  Noisy `credentials.yaml` rules are disabled; `optional/` and `quarantine/`
-  directories are not auto-discovered. Removed `api_key` → `PRIVATE_KEY` alias.
+  case-insensitive (#138).
+- Removed the `api_key` → `PRIVATE_KEY` alias (#138).
+- Encrypt nonces adapted for `aes-gcm` 0.11 (`Nonce::from` instead of
+  deprecated `Nonce::from_slice`); envelope layout unchanged (#135).
 - `redact-scan`: upgrade `testcontainers-modules` so CI `cargo audit` is not
   failed by `astral-tokio-tar` advisories in the Postgres acceptance-test
   tree. Ignore unfixed `RUSTSEC-2023-0071` (`rsa` / Marvin) which is pulled
-  only by unused optional `sqlx-mysql` — this crate enables Postgres only.
+  only by unused optional `sqlx-mysql` — this crate enables Postgres only
+  (#131).
 - `redact-scan`: retry testcontainer start and pre-pull `postgres:16-alpine`
-  in CI so Hub `bytes remaining on stream` flakes do not fail the job.
+  in CI so Hub `bytes remaining on stream` flakes do not fail the job
+  (#131).
+
+### Security
+
+- `patterns/security/credentials.yaml` catch-alls are disabled. In
+  particular `sec_aws_secret_key` was `\b[A-Za-z0-9/+=]{40}\b`, which
+  matched any 40-character blob — including every SHA-1. Combined with
+  the default pack-path change above, those rules are no longer on the
+  Docker path (#138).
 
 ## [0.9.1] - 2026-08-08
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,16 @@ Enhancement suggestions are tracked as GitHub issues. When creating an enhanceme
 - **Why this enhancement would be useful** to most users
 - **Possible implementation approach** (optional)
 
+### Pattern-pack PRs (provider coverage)
+
+New prefixed provider tokens belong in a YAML pattern pack, not in
+`redact-core`. Core is not taking the full [gitleaks](https://github.com/gitleaks/gitleaks)
+rule set. The opt-in long-tail pack is
+`patterns/optional/providers-v1.yaml` (not on the Docker default path,
+not compiled into WASM). How to load and write a pack:
+[docs/gateway/configuration.md](docs/gateway/configuration.md#pattern-packs).
+Confirm the idea is in [project scope](docs/PROJECT_SCOPE.md).
+
 ### Pull Requests
 
 1. **Fork the repository** and create your branch from `main`
@@ -239,12 +249,15 @@ redact/
 │   ├── redact-api/          # REST API server
 │   ├── redact-cli/          # CLI tool
 │   ├── redact-wasm/         # WASM bindings
-│   └── redact-gateway/      # OpenAI-compatible privacy gateway
+│   ├── redact-gateway/      # OpenAI-compatible privacy gateway
+│   ├── redact-scan/         # Read-only Postgres PII discovery
+│   └── redact-verify/       # Independent ledger pack verifier
 ├── deploy/                  # Gateway Collector config and Kubernetes manifests
 ├── scripts/                 # Utility scripts
 ├── examples/                # Usage examples
 ├── docs/
 │   ├── PROJECT_SCOPE.md     # What this repository accepts
+│   ├── secrets-detection.md # Entropy model and precision corpora
 │   ├── gateway/             # Gateway operator documentation
 │   └── benchmarks/          # Benchmark methodology and results
 └── .github/workflows/       # CI/CD pipelines
@@ -256,7 +269,7 @@ Confirm the idea is in [project scope](docs/PROJECT_SCOPE.md) before starting.
 
 ### High Priority
 
-- [ ] Additional entity type patterns
+- [ ] Additional entity type patterns via **pattern-pack PRs** (see above; core is not taking the full gitleaks set)
 - [ ] Performance optimizations
 - [ ] Documentation improvements
 - [ ] Example applications

--- a/README.md
+++ b/README.md
@@ -138,7 +138,20 @@ fi
 redact analyze --entities EmailAddress --entities UsSsn \
   "Email: test@example.com, SSN: 123-45-6789, Phone: (555) 123-4567"
 # Only detects EmailAddress and UsSsn, ignores PhoneNumber
+
+# Subtract from the full compiled set, or from --entities when both are set
+redact analyze --disable DomainName -i notes.txt
+redact anonymize --entities EmailAddress,UsSsn --disable UsSsn -i notes.txt
+
+# Empty remaining set is an error. List compiled names:
+redact --format json list-entities
 ```
+
+`--disable` subtracts from `--entities` when both are given, or from the
+full compiled set when `--entities` is omitted. On the gateway the
+equivalent is `{ action: allow }` on the profile — see
+[getting started](docs/gateway/getting-started.md#disable-an-entity-via-policy)
+and [policy](docs/gateway/policy.md).
 
 ## WebAssembly
 
@@ -495,6 +508,14 @@ With the bundled `default` profile the provider sees `[EMAIL_ADDRESS]` instead o
 | Telemetry | OpenTelemetry traces, metrics, and audit log records (`OTEL_*` + `CENSGATE_TRACE_*`) |
 | Streaming | Buffered (default, in-place SSE rewrite) or incremental with a hold-back window |
 
+To pass an entity through untouched (the gateway equivalent of CLI
+`--disable`), set `{ action: allow }` on that type in the active profile.
+See [getting started](docs/gateway/getting-started.md#disable-an-entity-via-policy).
+
+Pattern packs: load extra YAML with `CENSGATE_PATTERN_PACKS` /
+`--pattern-pack`. How to write one, and where the opt-in long-tail pack
+lives, is in [configuration](docs/gateway/configuration.md#pattern-packs).
+
 Docker / Compose / Kubernetes assets: `Dockerfile.gateway`, `docker-compose.gateway.yml`, `deploy/`. Full docs: [`docs/gateway/getting-started.md`](docs/gateway/getting-started.md), [`crates/redact-gateway/README.md`](crates/redact-gateway/README.md), and [`docs/gateway/`](docs/gateway/).
 
 ## Supported Entity Types
@@ -702,6 +723,7 @@ See [TEST_COVERAGE.md](/censgate/redact/blob/main/TEST_COVERAGE.md) for detailed
 - [API Documentation](https://docs.rs/redact-core) — Rust API docs
 - [Gateway getting started](/censgate/redact/blob/main/docs/gateway/getting-started.md) — Local redaction, Ollama chat, OpenAI SDK
 - [Gateway Documentation](/censgate/redact/blob/main/docs/gateway) — Configuration, policy, tokenization, auth, telemetry, audit, streaming, deployment
+- [Secrets detection](/censgate/redact/blob/main/docs/secrets-detection.md) — Entropy model, exclusions, precision corpora
 - [Test Coverage](/censgate/redact/blob/main/TEST_COVERAGE.md) — Testing details
 - [Contributing Guide](/censgate/redact/blob/main/CONTRIBUTING.md) — How to contribute
 - [Project scope](/censgate/redact/blob/main/docs/PROJECT_SCOPE.md) — What this repository accepts

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -241,4 +241,56 @@ Telemetry **transport** (exporters, endpoints, protocol, sampling, resource attr
 
 ## Pattern packs
 
-`CENSGATE_PATTERN_PACKS` / `packs.paths` load additional YAML pattern packs at startup (same schema as `/patterns/**/*.yaml`). A single bad third-party regex is skipped and reported rather than taking the process down. Set `disable_builtin: true` only when your packs fully replace the compiled engine patterns.
+`CENSGATE_PATTERN_PACKS` / `packs.paths` / `--pattern-pack` load additional
+YAML pattern packs at startup (same schema as `/patterns/**/*.yaml`). A
+single bad third-party regex is skipped and reported rather than taking
+the process down. Set `disable_builtin: true` only when your packs fully
+replace the compiled engine patterns.
+
+### How to load
+
+```bash
+# Colon / comma / semicolon-separated files or directories
+export CENSGATE_PATTERN_PACKS=/app/patterns/compliance:/app/patterns/pii
+
+# CLI (written into the same env before load)
+redact-gateway --pattern-pack ./patterns/optional/providers-v1.yaml
+```
+
+Default Docker / Compose / Kubernetes images set
+`CENSGATE_PATTERN_PACKS=/app/patterns/compliance:/app/patterns/pii`.
+The loader skips directories named `optional/` and `quarantine/` even
+when you point `ENV` at `/app/patterns`.
+
+### How to write one
+
+A pack is a YAML document with a `patterns:` list. Required per rule:
+`id` and `regex`. Optional: `name`, `entity_type`, `confidence`
+(default 0.5), `enabled` (default true), `description`, `examples`,
+`replacement`, `value_group`, `entropy`.
+
+```yaml
+version: "1.0"
+name: "example-pack"
+patterns:
+  - id: "ex_vendor_token"
+    name: "Vendor token"
+    entity_type: "VENDOR_TOKEN"
+    regex: '\bven_[A-Za-z0-9]{32}\b'
+    confidence: 0.95
+    enabled: true
+```
+
+`entropy: generic` is the only accepted entropy gate. Those rules **must**
+expose capture group 1 (the value) and go through
+`evaluate_generic_candidate` — they cannot score a bare value and skip
+the keyword / denylist / exclusion checks. Other rules keep the full
+match unless they set `value_group`.
+
+### Opt-in long-tail pack
+
+`patterns/optional/providers-v1.yaml` holds prefixed provider tokens
+that are not compiled into `redact-core` (gitleaks MIT, pinned commit).
+It is **not** on the Docker default path and is **not** compiled into
+WASM. This is not gitleaks parity; further provider coverage belongs in
+pattern-pack PRs (see [CONTRIBUTING.md](../../CONTRIBUTING.md)).

--- a/docs/gateway/getting-started.md
+++ b/docs/gateway/getting-started.md
@@ -96,6 +96,23 @@ curl -s http://127.0.0.1:8080/v1/compliance/check \
 
 Health probes work without authentication: `GET /livez`, `GET /readyz`, `GET /health`.
 
+## Disable an entity via policy
+
+The CLI subtracts types with `--disable`. The gateway equivalent is
+`{ action: allow }` on the active profile: the span is detected and
+reported, but the payload is left untouched.
+
+```yaml
+profiles:
+  default:
+    entities:
+      DOMAIN_NAME: { action: allow }
+      GENERIC_SECRET: { action: allow }
+```
+
+See [policy](policy.md) for the full action set. `GENERIC_SECRET` is
+independently disableable the same way.
+
 ## 2. Chat proxy with Ollama
 
 Point the gateway at a local OpenAI-compatible provider. The examples use [Ollama](https://ollama.com/) and the `llama3.2` model.

--- a/docs/secrets-detection.md
+++ b/docs/secrets-detection.md
@@ -107,3 +107,55 @@ redact --format json list-entities
 In addition to the Phase 1 prefixes: `HUGGINGFACE_TOKEN`, `DATABRICKS_TOKEN`, `DIGITALOCEAN_TOKEN`, `NOTION_API_KEY`, `PERPLEXITY_API_KEY`, `HTTP_BASIC_AUTH` (hand-rolled base64 decode, canonical padding including unused bits, `user:password` both non-empty). GitLab keeps `glpat-` length 20 and adds gitleaks-closed routable / `glcbt-` / `glagent-` / `gloas-` / `gldt-` / `glft-` / `glptt-` shapes. AWS Bedrock (`ABSK…` and the short-lived `bedrock-api-key-YmVk…` literal) is an `AWS_ACCESS_KEY` alternation. Trailing `=` uses a delimiter class rather than `\\b`.
 
 Not compiled-in (pack or later): Azure AD `Q~` infix, GCP SA JSON, Teams webhooks, Discord, Datadog, Azure storage, Cloudflare global, generic-api-key, live API checks.
+
+## Precision corpora (measured)
+
+These figures are from hermetic tests in this repository. They are **not**
+a general precision/recall claim. The meaningful gates are the negative
+corpora. CI prints the numbers; it does not print raw secret values.
+
+### Exclusion / lockfile / digest-keyed corpus
+
+Test: `crates/redact-core/tests/generic_secret_corpus.rs`
+(`exclusion_corpus_has_zero_generic_secret`).
+
+**Gate: 0 `GENERIC_SECRET`.** Measured on this tree:
+`exclusion_generic_secret_count=0`. Covers weak-keyword UUIDs,
+digest-keyed hashes, `password=password`, `api_key=your-key-here`,
+lockfile `integrity=sha512-…`, all-alpha identifiers, prose, `#fff` /
+`#aabbcc`, `data:image;base64,…`.
+
+### Labeled generated positives
+
+Test: `labeled_positive_corpus_precision_recall` in the same file.
+
+Seeded fixtures, assembled at run time (labels and spans only in output).
+This is a labelled set, not a production sample. Do not restate these
+figures as a general result.
+
+Gates: recall **≥ 0.90**; default gateway profile (`replace` @ 0.6) must
+**act on ≥ 90%** of labeled generics. Precision is computed against the
+exclusion corpus (0 FPs by the gate above), so it is not an independent
+general result.
+
+Measured on this tree (labelled set only):
+`generic_secret_precision=1.0000`, `generic_secret_recall=1.0000`,
+`generic_secret_acted_under_default_profile=1.0000`.
+
+### Vendored OSS slice
+
+Test: `crates/redact-core/tests/oss_slice.rs`.
+
+Hermetic MIT/BSD/Apache slice (pinned SHAs of `facebook/react`,
+`redis/redis` 7.2.4 BSD-3 — not RSALv2/SSPL — `pallets/flask`,
+`clap-rs/clap`). Do not vendor `git/git` (GPL).
+
+- **≤ 5 unreviewed `GENERIC_SECRET` / 100k lines**
+- Secret-named + secret-shaped literals in upstream docs count as true
+  positives, not FPs
+- Every remaining hit is a reviewed fingerprint (`tp` or `waived`)
+
+Measured on this tree: `oss_slice_lines=56201` `generic_hits=0`
+`unreviewed=0` `unreviewed_per_100k=0.0000`.
+
+Exceeding a ceiling is a detector bug. Do not raise N to land a change.


### PR DESCRIPTION
Thank you for contributing to Redact. These checkboxes are acknowledgements;
the CLA bot enforces the Individual CLA signature.

- [x] I have read [CLA.md](../CLA.md) and will sign the Individual CLA via the bot comment (or I have already signed). A Corporate CLA, if required, does not replace the Individual CLA.
- [x] All commits are DCO-signed (`git commit -s`)
- [x] I have read [docs/PROJECT_SCOPE.md](../docs/PROJECT_SCOPE.md); this change is in scope

**Employer time or equipment**

- [ ] No — this work was not done on employer time or equipment
- [x] Yes — my employer has authorised the contribution, or a Corporate CLA is on file

## Summary

Documents what actually shipped since `v0.9.0` / `v0.9.1`. Version stays **0.9.1** (no tag). Changelog is built from `git log v0.9.0..HEAD`, not PR titles.

**Version justification for the forthcoming 0.10.0:** new crates (`redact-scan`, `redact-verify`), `GENERIC_SECRET` + six named types, CLI `--disable`, and a behaviour-affecting gateway default pack path. Not a patch. Pre-1.0, so not a major.

**Changed (the entry that matters):** gateway default pack path migration.

- Before (0.9.x images): `CENSGATE_PATTERN_PACKS=/app/patterns`
- After: `/app/patterns/compliance:/app/patterns/pii`
- Existing users lose `patterns/security` on the default path. `optional/` and `quarantine/` are never auto-walked.

Also explicit:

- `GENERIC_SECRET` is entropy-gated and assignment-position-only (will / will not).
- `patterns/optional/providers-v1.yaml` is opt-in, not on the Docker path, not in WASM. Not gitleaks parity.
- `sec_aws_secret_key` was `\b[A-Za-z0-9/+=]{40}\b` (every SHA-1) — now under Security.

README: `--disable`, `list-entities`, `--disable` subtracts from `--entities` or the full set. Gateway: `{ action: allow }`. Pattern packs: how to load, how to write one, where the opt-in pack lives. `docs/secrets-detection.md` now has a measured precision-corpora section citing the actual tests (labelled-set only; negative corpora are the meaningful figures). CONTRIBUTING: pattern-pack PRs are the route for provider coverage.

## Test plan

- [x] `cargo test -p redact-core --test generic_secret_corpus --test oss_slice -- --nocapture`
  - `exclusion_generic_secret_count=0`
  - labelled set printed `precision=1.0000 recall=1.0000 acted=1.0000` (labelled set only)
  - `oss_slice_lines=56201 unreviewed=0 unreviewed_per_100k=0.0000`
- [x] `cargo build -p redact-cli && node scripts/extract-facts.mjs --check --bin ./target/debug/redact` → `facts ok: 61 entity types`
- [x] Changelog compiled count is 61, matching the extractor