### PR TITLE
chore: release v0.10.0-rc.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,11 +118,15 @@ jobs:
         with:
           ref: ${{ env.VERSION }}
 
-      - name: Download all artifacts
+      - name: Download binary artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
           merge-multiple: true
+          # Binary archives only. buildx also uploads *-dockerbuild cache
+          # artifacts; pulling those here has flaked Create Release after
+          # the images already verified (run 31921441134).
+          pattern: redact-*
 
       - name: List artifacts
         run: ls -la artifacts/
@@ -534,14 +538,17 @@ jobs:
           set -euo pipefail
           docker run --rm --network host \
             -e TAG_VERSION="${TAG_VERSION}" \
-            rust:1.93-bookworm bash -lc '
+            rust:1.93-bookworm bash -c '
               set -euo pipefail
+              # Login shells reset PATH and drop /usr/local/cargo/bin (rc.1
+              # rehearsal: cargo: command not found). Stay non-login.
+              export PATH="/usr/local/cargo/bin:${PATH}"
               apt-get update
               apt-get install -y --no-install-recommends curl
-              cargo install redact-cli
+              cargo install redact-cli --version "${TAG_VERSION}"
               redact --version
               redact --version | grep -F "${TAG_VERSION}"
-              cargo install redact-gateway
+              cargo install redact-gateway --version "${TAG_VERSION}"
               export OTEL_SDK_DISABLED=true
               redact-gateway --host 127.0.0.1 &
               gw_pid=$!

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,9 @@ jobs:
 
   publish-crates:
     name: Publish to crates.io
+    # Least reversible publish step: wait until every image family has been
+    # pushed and smoke-tested on the digest a stranger would pull.
+    needs: [build-binaries, verify-pushed-images]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -232,12 +235,11 @@ jobs:
       - name: Compute Docker tags
         id: meta
         run: |
+          set -euo pipefail
           VER="${VERSION#v}"
-          MAJOR="${VER%%.*}"
-          MINOR="${VER%.*}"
           IMAGE="ghcr.io/${{ github.repository }}"
-          TAGS="${IMAGE}:${VER},${IMAGE}:${MINOR},${IMAGE}:${MAJOR},${IMAGE}:latest"
-          echo "tags=$TAGS" >> $GITHUB_OUTPUT
+          TAGS="$(./scripts/ci/docker-tags.sh api "${VER}" "${IMAGE}")"
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
 
       - name: Build API image for smoke test (amd64)
         uses: docker/build-push-action@v7
@@ -299,12 +301,11 @@ jobs:
       - name: Compute Docker tags (full)
         id: meta-full
         run: |
+          set -euo pipefail
           VER="${VERSION#v}"
-          MAJOR="${VER%%.*}"
-          MINOR="${VER%.*}"
           IMAGE="ghcr.io/${{ github.repository }}"
-          TAGS="${IMAGE}:full,${IMAGE}:${VER}-full,${IMAGE}:${MINOR}-full,${IMAGE}:${MAJOR}-full"
-          echo "tags=$TAGS" >> $GITHUB_OUTPUT
+          TAGS="$(./scripts/ci/docker-tags.sh full "${VER}" "${IMAGE}")"
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
 
       - name: Build full image for smoke test (amd64)
         uses: docker/build-push-action@v7
@@ -377,12 +378,11 @@ jobs:
       - name: Compute Docker tags (gateway)
         id: meta-gateway
         run: |
+          set -euo pipefail
           VER="${VERSION#v}"
-          MAJOR="${VER%%.*}"
-          MINOR="${VER%.*}"
           IMAGE="ghcr.io/${{ github.repository }}-gateway"
-          TAGS="${IMAGE}:${VER},${IMAGE}:${MINOR},${IMAGE}:${MAJOR},${IMAGE}:latest"
-          echo "tags=$TAGS" >> $GITHUB_OUTPUT
+          TAGS="$(./scripts/ci/docker-tags.sh gateway "${VER}" "${IMAGE}")"
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
 
       - name: Build gateway image for smoke test (amd64)
         uses: docker/build-push-action@v7
@@ -458,30 +458,28 @@ jobs:
         run: |
           set -euo pipefail
           VER="${VERSION#v}"
-          MAJOR="${VER%%.*}"
-          MINOR="${VER%.*}"
           REPO="ghcr.io/${{ github.repository }}"
-          case "${{ matrix.family }}" in
+          FAMILY="${{ matrix.family }}"
+          TAGS="$(./scripts/ci/docker-tags.sh "${FAMILY}" "${VER}")"
+          case "${FAMILY}" in
             api)
               echo "repo=${REPO}" >> "$GITHUB_OUTPUT"
-              echo "tags=${VER},${MINOR},${MAJOR},latest" >> "$GITHUB_OUTPUT"
               echo "smoke=api" >> "$GITHUB_OUTPUT"
               ;;
             full)
               echo "repo=${REPO}" >> "$GITHUB_OUTPUT"
-              echo "tags=${VER}-full,${MINOR}-full,${MAJOR}-full,full" >> "$GITHUB_OUTPUT"
               echo "smoke=ner" >> "$GITHUB_OUTPUT"
               ;;
             gateway)
               echo "repo=${REPO}-gateway" >> "$GITHUB_OUTPUT"
-              echo "tags=${VER},${MINOR},${MAJOR},latest" >> "$GITHUB_OUTPUT"
               echo "smoke=gateway" >> "$GITHUB_OUTPUT"
               ;;
             *)
-              echo "unknown family ${{ matrix.family }}" >&2
+              echo "unknown family ${FAMILY}" >&2
               exit 1
               ;;
           esac
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
 
       - name: Assert tags share one digest
         id: digest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,37 +10,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `GENERIC_SECRET`: charset-aware Shannon entropy over assignment-like values
-  (length-aware floor, segment keyword allow/deny, value-only spans). Independently
-  disableable via CLI `--disable`, WASM `analyze_excluding`, or gateway
-  `{ action: allow }`. See `docs/secrets-detection.md`. Phase 2 of #101.
+  only (length-aware floor, segment keyword allow/deny, value-only spans).
+  It will catch `api_key=…` / `export SERVICE_SECRET=…` that pass the
+  charset, length, and keyword gates. It will not catch arbitrary
+  high-entropy blobs, hashes or UUIDs on a digest LHS, lockfile
+  `integrity=` lines, placeholders, or prefixed types (those stay named
+  types). Independently disableable via CLI `--disable`, WASM
+  `analyze_excluding`, or gateway `{ action: allow }`. See
+  `docs/secrets-detection.md`. Phase 2 of #101 (#138).
 - Named secret types: `HUGGINGFACE_TOKEN`, `DATABRICKS_TOKEN`,
   `DIGITALOCEAN_TOKEN`, `NOTION_API_KEY`, `PERPLEXITY_API_KEY`,
   `HTTP_BASIC_AUTH` (decode-validated). GitLab length-closed shapes and AWS
   Bedrock under `AWS_ACCESS_KEY`. Compiled entity count is 61 (60 pattern +
-  `GENERIC_SECRET`).
+  `GENERIC_SECRET`) (#138).
 - Optional long-tail pack `patterns/optional/providers-v1.yaml` (gitleaks MIT,
-  pinned commit). Not on the Docker / compose / Kubernetes default path.
-- CLI `redact --format json list-entities` and host-only
-  `scripts/extract-facts.mjs` → `data/facts.json`.
+  pinned commit). Opt-in only: not on the Docker / compose / Kubernetes
+  default path, and not compiled into WASM. This is not gitleaks parity
+  (#138).
+- CLI `--disable` (subtracts from `--entities`, or from the full compiled
+  set when `--entities` is omitted; empty remaining set is an error),
+  `redact --format json list-entities`, and host-only
+  `scripts/extract-facts.mjs` → `data/facts.json` (#138).
 - `redact-scan`: new workspace crate and `redact-scan` binary for read-only
   Postgres PII discovery. Report types, credential scrubber, CLI preflight,
   a read-only safety session (refuse superuser and write grants), and
   layers 0 / 0.5 / 1 / 2 (catalog, `pg_stats`, bounded `TABLESAMPLE`,
   JSON paths). Optional `--report-url` POSTs the report JSON; `--fail-on`
   exits 1 on matching findings. Reports contain locations and counts
-  only — never sample values. See `docs/scanning-model.md`.
+  only — never sample values. See `docs/scanning-model.md` (#131).
+- `redact-verify`: new workspace crate and `redact-verify` binary for
+  independent offline verification of Censgate ledger evidence packs.
+  No `redact-core` dependency; default path does not dial the network
+  (#132).
+- Contributor License Agreement and Code of Conduct, with a CLA GitHub
+  Action (#119, #120).
 
 ### Changed
 
+- **Gateway default pattern-pack path (migration).** 0.9.x images set
+  `CENSGATE_PATTERN_PACKS=/app/patterns`, which loaded the whole tree
+  including `patterns/security`. Images now set
+  `/app/patterns/compliance:/app/patterns/pii`. Existing gateway users
+  lose `patterns/security` on the default path (including the now-disabled
+  credentials catch-alls). Directories named `optional/` and `quarantine/`
+  are never auto-walked. Restore the old tree with
+  `CENSGATE_PATTERN_PACKS=/app/patterns` only if you accept the catch-all
+  risk; the supported opt-in for long-tail prefixes is
+  `patterns/optional/providers-v1.yaml` (#138).
 - Release: GitHub Release publication waits for all three image jobs and a
   post-push digest smoke on `linux/amd64` and `linux/arm64` (the load-then-push
-  split is what let #114 ship).
-- Release: gateway image smoke asserts `/v1/redact` (email replace + AWS key
-  block), not only `--version`.
-- Release: crates.io publish is checked against the index after the
-  `continue-on-error` publish steps.
-- Release: a no-checkout stranger-path job installs from crates.io and pulls
-  the published gateway image the way a consumer would.
+  split is what let #114 ship). Gateway image smoke asserts `/v1/redact`
+  (email replace + AWS key block on the default profile), not only
+  `--version`. crates.io publish is checked against the index after the
+  `continue-on-error` publish steps. A no-checkout stranger-path job
+  installs from crates.io and pulls the published gateway image (#137).
 
 ### Fixed
 
@@ -51,16 +74,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   delimiter instead of `\\b` after `=`. Pack `entropy: generic` requires
   capture group 1 at analyze time. Non-entropy pack rules keep the full
   match unless they set `value_group`. HTTP Basic matching is
-  case-insensitive.
-- Gateway default pack path is `/app/patterns/compliance:/app/patterns/pii`.
-  Noisy `credentials.yaml` rules are disabled; `optional/` and `quarantine/`
-  directories are not auto-discovered. Removed `api_key` → `PRIVATE_KEY` alias.
+  case-insensitive (#138).
+- Removed the `api_key` → `PRIVATE_KEY` alias (#138).
+- Encrypt nonces adapted for `aes-gcm` 0.11 (`Nonce::from` instead of
+  deprecated `Nonce::from_slice`); envelope layout unchanged (#135).
 - `redact-scan`: upgrade `testcontainers-modules` so CI `cargo audit` is not
   failed by `astral-tokio-tar` advisories in the Postgres acceptance-test
   tree. Ignore unfixed `RUSTSEC-2023-0071` (`rsa` / Marvin) which is pulled
-  only by unused optional `sqlx-mysql` — this crate enables Postgres only.
+  only by unused optional `sqlx-mysql` — this crate enables Postgres only
+  (#131).
 - `redact-scan`: retry testcontainer start and pre-pull `postgres:16-alpine`
-  in CI so Hub `bytes remaining on stream` flakes do not fail the job.
+  in CI so Hub `bytes remaining on stream` flakes do not fail the job
+  (#131).
+
+### Security
+
+- `patterns/security/credentials.yaml` catch-alls are disabled. In
+  particular `sec_aws_secret_key` was `\b[A-Za-z0-9/+=]{40}\b`, which
+  matched any 40-character blob — including every SHA-1. Combined with
+  the default pack-path change above, those rules are no longer on the
+  Docker path (#138).
 
 ## [0.9.1] - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the `api_key` → `PRIVATE_KEY` alias (#138).
 - Encrypt nonces adapted for `aes-gcm` 0.11 (`Nonce::from` instead of
   deprecated `Nonce::from_slice`); envelope layout unchanged (#135).
+- Pin `ort` to `=2.0.0-rc.12` so the full image matches
+  `redact-ner-base:v2` (ONNX Runtime 1.24.4). `^2.0.0-rc.12` had
+  resolved to `rc.13`, which requires ONNX Runtime 1.28 and panicked
+  on startup (`BadVersion`). Caught by the `v0.10.0-rc.1` NER smoke.
 - `redact-scan`: upgrade `testcontainers-modules` so CI `cargo audit` is not
   failed by `astral-tokio-tar` advisories in the Postgres acceptance-test
   tree. Ignore unfixed `RUSTSEC-2023-0071` (`rsa` / Marvin) which is pulled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `redact-ner-base:v2` (ONNX Runtime 1.24.4). `^2.0.0-rc.12` had
   resolved to `rc.13`, which requires ONNX Runtime 1.28 and panicked
   on startup (`BadVersion`). Caught by the `v0.10.0-rc.1` NER smoke.
+- Published images no longer compile the native-arch path with
+  `target-cpu=native`. That baked the builder runner's µarch and
+  SIGILL'd `verify-pushed-images` on a different GitHub Actions
+  runner (empty logs, ~1s exit). Native amd64 now uses `x86-64-v3`
+  and native arm64 uses `neoverse-n1`, matching the existing
+  cross-compile flags.
 - `redact-scan`: upgrade `testcontainers-modules` so CI `cargo audit` is not
   failed by `astral-tokio-tar` advisories in the Postgres acceptance-test
   tree. Ignore unfixed `RUSTSEC-2023-0071` (`rsa` / Marvin) which is pulled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.10.0-rc.1] - 2026-08-16
 
 ### Added
 
@@ -64,6 +64,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--version`. crates.io publish is checked against the index after the
   `continue-on-error` publish steps. A no-checkout stranger-path job
   installs from crates.io and pulls the published gateway image (#137).
+  `publish-crates` now waits for `verify-pushed-images`. Hyphenated
+  (prerelease) versions push only the exact version tag so `:latest` /
+  `:MAJOR` / `:MINOR` / `:full` are not rewritten.
 
 ### Fixed
 
@@ -290,4 +293,4 @@ See [README.md](README.md) for usage examples.
 ## Previous Releases (Go Implementation)
 
 For historical reference, versions v0.1.0 through v0.4.1 were the Go implementation.
-Those versions are no longer maintained. Please upgrade to v0.9.1 or later.
+Those versions are no longer maintained. Please upgrade to v0.10.0-rc.1 or later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   runner (empty logs, ~1s exit). Native amd64 now uses `x86-64-v3`
   and native arm64 uses `neoverse-n1`, matching the existing
   cross-compile flags.
+- `create-release` downloads only `redact-*` binary artifacts so
+  buildx `*-dockerbuild` cache uploads cannot flake the GitHub
+  Release step after images already verified.
+- Stranger-path crate install uses a non-login shell (Cargo stays
+  on `PATH`) and `cargo install --version` so a prerelease tag is
+  what gets installed.
 - `redact-scan`: upgrade `testcontainers-modules` so CI `cargo audit` is not
   failed by `astral-tokio-tar` advisories in the Postgres acceptance-test
   tree. Ignore unfixed `RUSTSEC-2023-0071` (`rsa` / Marvin) which is pulled

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,16 @@ Enhancement suggestions are tracked as GitHub issues. When creating an enhanceme
 - **Why this enhancement would be useful** to most users
 - **Possible implementation approach** (optional)
 
+### Pattern-pack PRs (provider coverage)
+
+New prefixed provider tokens belong in a YAML pattern pack, not in
+`redact-core`. Core is not taking the full [gitleaks](https://github.com/gitleaks/gitleaks)
+rule set. The opt-in long-tail pack is
+`patterns/optional/providers-v1.yaml` (not on the Docker default path,
+not compiled into WASM). How to load and write a pack:
+[docs/gateway/configuration.md](docs/gateway/configuration.md#pattern-packs).
+Confirm the idea is in [project scope](docs/PROJECT_SCOPE.md).
+
 ### Pull Requests
 
 1. **Fork the repository** and create your branch from `main`
@@ -239,12 +249,15 @@ redact/
 │   ├── redact-api/          # REST API server
 │   ├── redact-cli/          # CLI tool
 │   ├── redact-wasm/         # WASM bindings
-│   └── redact-gateway/      # OpenAI-compatible privacy gateway
+│   ├── redact-gateway/      # OpenAI-compatible privacy gateway
+│   ├── redact-scan/         # Read-only Postgres PII discovery
+│   └── redact-verify/       # Independent ledger pack verifier
 ├── deploy/                  # Gateway Collector config and Kubernetes manifests
 ├── scripts/                 # Utility scripts
 ├── examples/                # Usage examples
 ├── docs/
 │   ├── PROJECT_SCOPE.md     # What this repository accepts
+│   ├── secrets-detection.md # Entropy model and precision corpora
 │   ├── gateway/             # Gateway operator documentation
 │   └── benchmarks/          # Benchmark methodology and results
 └── .github/workflows/       # CI/CD pipelines
@@ -256,7 +269,7 @@ Confirm the idea is in [project scope](docs/PROJECT_SCOPE.md) before starting.
 
 ### High Priority
 
-- [ ] Additional entity type patterns
+- [ ] Additional entity type patterns via **pattern-pack PRs** (see above; core is not taking the full gitleaks set)
 - [ ] Performance optimizations
 - [ ] Documentation improvements
 - [ ] Example applications

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3302,7 +3302,7 @@ dependencies = [
 
 [[package]]
 name = "redact-api"
-version = "0.9.1"
+version = "0.10.0-rc.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3319,7 +3319,7 @@ dependencies = [
 
 [[package]]
 name = "redact-cli"
-version = "0.9.1"
+version = "0.10.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3335,7 +3335,7 @@ dependencies = [
 
 [[package]]
 name = "redact-core"
-version = "0.9.1"
+version = "0.10.0-rc.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3357,7 +3357,7 @@ dependencies = [
 
 [[package]]
 name = "redact-examples"
-version = "0.9.1"
+version = "0.10.0-rc.1"
 dependencies = [
  "anyhow",
  "redact-api",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "redact-gateway"
-version = "0.9.1"
+version = "0.10.0-rc.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3412,7 +3412,7 @@ dependencies = [
 
 [[package]]
 name = "redact-ner"
-version = "0.9.1"
+version = "0.10.0-rc.1"
 dependencies = [
  "anyhow",
  "ndarray",
@@ -3429,7 +3429,7 @@ dependencies = [
 
 [[package]]
 name = "redact-scan"
-version = "0.9.1"
+version = "0.10.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3453,7 +3453,7 @@ dependencies = [
 
 [[package]]
 name = "redact-verify"
-version = "0.9.1"
+version = "0.10.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3470,7 +3470,7 @@ dependencies = [
 
 [[package]]
 name = "redact-wasm"
-version = "0.9.1"
+version = "0.10.0-rc.1"
 dependencies = [
  "getrandom 0.2.17",
  "getrandom 0.3.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2712,9 +2712,9 @@ dependencies = [
 
 [[package]]
 name = "ort"
-version = "2.0.0-rc.13"
+version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4336a1e2b38848325241c72889086886004e589b7c74f335e60a8e8db5138a0b"
+checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
 dependencies = [
  "half",
  "libloading",
@@ -2727,9 +2727,9 @@ dependencies = [
 
 [[package]]
 name = "ort-sys"
-version = "2.0.0-rc.13"
+version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf211e3776eea6aec988552fa118dd746d70e1b1e5e244058d1c98015f3e5872"
+checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
 dependencies = [
  "hmac-sha256",
  "lzma-rust2",
@@ -4494,7 +4494,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -5417,7 +5417,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,11 @@ axum = { version = "0.8", features = ["json", "tracing"] }
 tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.7", features = ["trace", "cors"] }
 
-# ONNX Runtime
-ort = { version = "2.0.0-rc.12", features = ["load-dynamic", "half"] }
+# ONNX Runtime — pin exactly. ^2.0.0-rc.12 resolved to rc.13, which requires
+# ONNX Runtime 1.28; ghcr.io/censgate/redact-ner-base:v2 ships 1.24.4
+# (ort 2.0.0-rc.12). A floating rc.13 is what made the full image panic
+# on v0.10.0-rc.1: BadVersion { version_str: "1.24.4" }.
+ort = { version = "=2.0.0-rc.12", features = ["load-dynamic", "half"] }
 ndarray = "0.17"
 tokenizers = "0.23"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.9.1"
+version = "0.10.0-rc.1"
 edition = "2021"
 rust-version = "1.88"
 authors = ["Censgate LLC <support@censgate.com>"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ ENV CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
 RUN case "$TARGETARCH" in \
         arm64) \
             if [ "$BUILDPLATFORM" = "linux/arm64" ]; then \
-                RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api; \
+                RUSTFLAGS="-C target-cpu=neoverse-n1" cargo build --release --package redact-api; \
             else \
                 RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc -C target-cpu=neoverse-n1" \
                 cargo build --release --package redact-api --target aarch64-unknown-linux-gnu \
@@ -62,7 +62,7 @@ RUN case "$TARGETARCH" in \
             fi ;; \
         amd64) \
             if [ "$BUILDPLATFORM" = "linux/amd64" ]; then \
-                RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api; \
+                RUSTFLAGS="-C target-cpu=x86-64-v3" cargo build --release --package redact-api; \
             else \
                 RUSTFLAGS="-C linker=x86_64-linux-gnu-gcc -C target-cpu=x86-64-v3" \
                 cargo build --release --package redact-api --target x86_64-unknown-linux-gnu \

--- a/Dockerfile.gateway
+++ b/Dockerfile.gateway
@@ -57,7 +57,7 @@ ENV CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
 RUN case "$TARGETARCH" in \
         arm64) \
             if [ "$BUILDPLATFORM" = "linux/arm64" ]; then \
-                RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-gateway; \
+                RUSTFLAGS="-C target-cpu=neoverse-n1" cargo build --release --package redact-gateway; \
             else \
                 RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc -C target-cpu=neoverse-n1" \
                 cargo build --release --package redact-gateway --target aarch64-unknown-linux-gnu \
@@ -65,7 +65,7 @@ RUN case "$TARGETARCH" in \
             fi ;; \
         amd64) \
             if [ "$BUILDPLATFORM" = "linux/amd64" ]; then \
-                RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-gateway; \
+                RUSTFLAGS="-C target-cpu=x86-64-v3" cargo build --release --package redact-gateway; \
             else \
                 RUSTFLAGS="-C linker=x86_64-linux-gnu-gcc -C target-cpu=x86-64-v3" \
                 cargo build --release --package redact-gateway --target x86_64-unknown-linux-gnu \

--- a/Dockerfile.ner
+++ b/Dockerfile.ner
@@ -77,7 +77,7 @@ ENV CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
 RUN case "$TARGETARCH" in \
         arm64) \
             if [ "$BUILDPLATFORM" = "linux/arm64" ]; then \
-                RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api; \
+                RUSTFLAGS="-C target-cpu=neoverse-n1" cargo build --release --package redact-api; \
             else \
                 RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc -C target-cpu=neoverse-n1" \
                 cargo build --release --package redact-api --target aarch64-unknown-linux-gnu \
@@ -85,7 +85,7 @@ RUN case "$TARGETARCH" in \
             fi ;; \
         amd64) \
             if [ "$BUILDPLATFORM" = "linux/amd64" ]; then \
-                RUSTFLAGS="-C target-cpu=native" cargo build --release --package redact-api; \
+                RUSTFLAGS="-C target-cpu=x86-64-v3" cargo build --release --package redact-api; \
             else \
                 RUSTFLAGS="-C linker=x86_64-linux-gnu-gcc -C target-cpu=x86-64-v3" \
                 cargo build --release --package redact-api --target x86_64-unknown-linux-gnu \

--- a/README.md
+++ b/README.md
@@ -138,7 +138,20 @@ fi
 redact analyze --entities EmailAddress --entities UsSsn \
   "Email: test@example.com, SSN: 123-45-6789, Phone: (555) 123-4567"
 # Only detects EmailAddress and UsSsn, ignores PhoneNumber
+
+# Subtract from the full compiled set, or from --entities when both are set
+redact analyze --disable DomainName -i notes.txt
+redact anonymize --entities EmailAddress,UsSsn --disable UsSsn -i notes.txt
+
+# Empty remaining set is an error. List compiled names:
+redact --format json list-entities
 ```
+
+`--disable` subtracts from `--entities` when both are given, or from the
+full compiled set when `--entities` is omitted. On the gateway the
+equivalent is `{ action: allow }` on the profile — see
+[getting started](docs/gateway/getting-started.md#disable-an-entity-via-policy)
+and [policy](docs/gateway/policy.md).
 
 ## WebAssembly
 
@@ -495,6 +508,14 @@ With the bundled `default` profile the provider sees `[EMAIL_ADDRESS]` instead o
 | Telemetry | OpenTelemetry traces, metrics, and audit log records (`OTEL_*` + `CENSGATE_TRACE_*`) |
 | Streaming | Buffered (default, in-place SSE rewrite) or incremental with a hold-back window |
 
+To pass an entity through untouched (the gateway equivalent of CLI
+`--disable`), set `{ action: allow }` on that type in the active profile.
+See [getting started](docs/gateway/getting-started.md#disable-an-entity-via-policy).
+
+Pattern packs: load extra YAML with `CENSGATE_PATTERN_PACKS` /
+`--pattern-pack`. How to write one, and where the opt-in long-tail pack
+lives, is in [configuration](docs/gateway/configuration.md#pattern-packs).
+
 Docker / Compose / Kubernetes assets: `Dockerfile.gateway`, `docker-compose.gateway.yml`, `deploy/`. Full docs: [`docs/gateway/getting-started.md`](docs/gateway/getting-started.md), [`crates/redact-gateway/README.md`](crates/redact-gateway/README.md), and [`docs/gateway/`](docs/gateway/).
 
 ## Supported Entity Types
@@ -702,6 +723,7 @@ See [TEST_COVERAGE.md](/censgate/redact/blob/main/TEST_COVERAGE.md) for detailed
 - [API Documentation](https://docs.rs/redact-core) — Rust API docs
 - [Gateway getting started](/censgate/redact/blob/main/docs/gateway/getting-started.md) — Local redaction, Ollama chat, OpenAI SDK
 - [Gateway Documentation](/censgate/redact/blob/main/docs/gateway) — Configuration, policy, tokenization, auth, telemetry, audit, streaming, deployment
+- [Secrets detection](/censgate/redact/blob/main/docs/secrets-detection.md) — Entropy model, exclusions, precision corpora
 - [Test Coverage](/censgate/redact/blob/main/TEST_COVERAGE.md) — Testing details
 - [Contributing Guide](/censgate/redact/blob/main/CONTRIBUTING.md) — How to contribute
 - [Project scope](/censgate/redact/blob/main/docs/PROJECT_SCOPE.md) — What this repository accepts

--- a/README.md
+++ b/README.md
@@ -314,8 +314,8 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-redact-core = "0.9.1"
-redact-ner = "0.9.1"  # Optional: for ML-based NER
+redact-core = "0.10.0-rc.1"
+redact-ner = "0.10.0-rc.1"  # Optional: for ML-based NER
 ```
 
 ### Basic Pattern Detection

--- a/crates/redact-api/Cargo.toml
+++ b/crates/redact-api/Cargo.toml
@@ -12,8 +12,8 @@ documentation = "https://docs.rs/redact-api"
 description = "REST API service for PII detection and anonymization"
 
 [dependencies]
-redact-core = { path = "../redact-core", version = "0.9.1" }
-redact-ner = { path = "../redact-ner", version = "0.9.1" }
+redact-core = { path = "../redact-core", version = "0.10.0-rc.1" }
+redact-ner = { path = "../redact-ner", version = "0.10.0-rc.1" }
 axum = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true }

--- a/crates/redact-cli/Cargo.toml
+++ b/crates/redact-cli/Cargo.toml
@@ -12,8 +12,8 @@ documentation = "https://docs.rs/redact-cli"
 description = "CLI tool for PII detection and anonymization"
 
 [dependencies]
-redact-core = { path = "../redact-core", version = "0.9.1" }
-redact-ner = { path = "../redact-ner", version = "0.9.1" }
+redact-core = { path = "../redact-core", version = "0.10.0-rc.1" }
+redact-ner = { path = "../redact-ner", version = "0.10.0-rc.1" }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/redact-gateway/Cargo.toml
+++ b/crates/redact-gateway/Cargo.toml
@@ -25,7 +25,7 @@ oidc = ["dep:jsonwebtoken"]
 prometheus = ["dep:opentelemetry-prometheus", "dep:prometheus"]
 
 [dependencies]
-redact-core = { path = "../redact-core", version = "0.9.1" }
+redact-core = { path = "../redact-core", version = "0.10.0-rc.1" }
 axum = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true }

--- a/crates/redact-ner/Cargo.toml
+++ b/crates/redact-ner/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/redact-ner"
 description = "Named Entity Recognition for PII detection using ONNX Runtime"
 
 [dependencies]
-redact-core = { path = "../redact-core", version = "0.9.1" }
+redact-core = { path = "../redact-core", version = "0.10.0-rc.1" }
 ort = { workspace = true }
 ndarray = { workspace = true }
 tokenizers = "0.23"

--- a/crates/redact-scan/Cargo.toml
+++ b/crates/redact-scan/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["pii", "postgres", "privacy", "gdpr", "discovery"]
 categories = ["command-line-utilities", "database"]
 
 [dependencies]
-redact-core = { path = "../redact-core", version = "0.9.1" }
+redact-core = { path = "../redact-core", version = "0.10.0-rc.1" }
 sqlx = { workspace = true }
 tokio = { workspace = true }
 clap = { workspace = true }

--- a/crates/redact-scan/README.md
+++ b/crates/redact-scan/README.md
@@ -23,7 +23,7 @@ See [docs/scanning-model.md](../../docs/scanning-model.md) for the four discover
     "version": "16.4"
   },
   "scanner": {
-    "version": "0.9.1",
+    "version": "0.10.0-rc.1",
     "pattern_pack": "builtin@<supported-entity-count>"
   },
   "sampling": {

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -64,7 +64,7 @@ Benchmarks include:
 
 ## Latest Results (2026-04-18)
 
-The **current** release is **[v0.9.1](https://github.com/censgate/redact/releases/tag/v0.9.1)**. The latest published REST API comparison report remains [results-20260418-175909.md](results-20260418-175909.md) (captured against v0.8.2); re-run `./scripts/benchmark-comparison.sh` for fresh numbers.
+The **current** release is **[v0.10.0-rc.1](https://github.com/censgate/redact/releases/tag/v0.10.0-rc.1)**. The latest published REST API comparison report remains [results-20260418-175909.md](results-20260418-175909.md) (captured against v0.8.2); re-run `./scripts/benchmark-comparison.sh` for fresh numbers.
 
 ### Latency (concurrency=1)
 

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -241,4 +241,56 @@ Telemetry **transport** (exporters, endpoints, protocol, sampling, resource attr
 
 ## Pattern packs
 
-`CENSGATE_PATTERN_PACKS` / `packs.paths` load additional YAML pattern packs at startup (same schema as `/patterns/**/*.yaml`). A single bad third-party regex is skipped and reported rather than taking the process down. Set `disable_builtin: true` only when your packs fully replace the compiled engine patterns.
+`CENSGATE_PATTERN_PACKS` / `packs.paths` / `--pattern-pack` load additional
+YAML pattern packs at startup (same schema as `/patterns/**/*.yaml`). A
+single bad third-party regex is skipped and reported rather than taking
+the process down. Set `disable_builtin: true` only when your packs fully
+replace the compiled engine patterns.
+
+### How to load
+
+```bash
+# Colon / comma / semicolon-separated files or directories
+export CENSGATE_PATTERN_PACKS=/app/patterns/compliance:/app/patterns/pii
+
+# CLI (written into the same env before load)
+redact-gateway --pattern-pack ./patterns/optional/providers-v1.yaml
+```
+
+Default Docker / Compose / Kubernetes images set
+`CENSGATE_PATTERN_PACKS=/app/patterns/compliance:/app/patterns/pii`.
+The loader skips directories named `optional/` and `quarantine/` even
+when you point `ENV` at `/app/patterns`.
+
+### How to write one
+
+A pack is a YAML document with a `patterns:` list. Required per rule:
+`id` and `regex`. Optional: `name`, `entity_type`, `confidence`
+(default 0.5), `enabled` (default true), `description`, `examples`,
+`replacement`, `value_group`, `entropy`.
+
+```yaml
+version: "1.0"
+name: "example-pack"
+patterns:
+  - id: "ex_vendor_token"
+    name: "Vendor token"
+    entity_type: "VENDOR_TOKEN"
+    regex: '\bven_[A-Za-z0-9]{32}\b'
+    confidence: 0.95
+    enabled: true
+```
+
+`entropy: generic` is the only accepted entropy gate. Those rules **must**
+expose capture group 1 (the value) and go through
+`evaluate_generic_candidate` — they cannot score a bare value and skip
+the keyword / denylist / exclusion checks. Other rules keep the full
+match unless they set `value_group`.
+
+### Opt-in long-tail pack
+
+`patterns/optional/providers-v1.yaml` holds prefixed provider tokens
+that are not compiled into `redact-core` (gitleaks MIT, pinned commit).
+It is **not** on the Docker default path and is **not** compiled into
+WASM. This is not gitleaks parity; further provider coverage belongs in
+pattern-pack PRs (see [CONTRIBUTING.md](../../CONTRIBUTING.md)).

--- a/docs/gateway/getting-started.md
+++ b/docs/gateway/getting-started.md
@@ -96,6 +96,23 @@ curl -s http://127.0.0.1:8080/v1/compliance/check \
 
 Health probes work without authentication: `GET /livez`, `GET /readyz`, `GET /health`.
 
+## Disable an entity via policy
+
+The CLI subtracts types with `--disable`. The gateway equivalent is
+`{ action: allow }` on the active profile: the span is detected and
+reported, but the payload is left untouched.
+
+```yaml
+profiles:
+  default:
+    entities:
+      DOMAIN_NAME: { action: allow }
+      GENERIC_SECRET: { action: allow }
+```
+
+See [policy](policy.md) for the full action set. `GENERIC_SECRET` is
+independently disableable the same way.
+
 ## 2. Chat proxy with Ollama
 
 Point the gateway at a local OpenAI-compatible provider. The examples use [Ollama](https://ollama.com/) and the `llama3.2` model.

--- a/docs/secrets-detection.md
+++ b/docs/secrets-detection.md
@@ -107,3 +107,55 @@ redact --format json list-entities
 In addition to the Phase 1 prefixes: `HUGGINGFACE_TOKEN`, `DATABRICKS_TOKEN`, `DIGITALOCEAN_TOKEN`, `NOTION_API_KEY`, `PERPLEXITY_API_KEY`, `HTTP_BASIC_AUTH` (hand-rolled base64 decode, canonical padding including unused bits, `user:password` both non-empty). GitLab keeps `glpat-` length 20 and adds gitleaks-closed routable / `glcbt-` / `glagent-` / `gloas-` / `gldt-` / `glft-` / `glptt-` shapes. AWS Bedrock (`ABSK…` and the short-lived `bedrock-api-key-YmVk…` literal) is an `AWS_ACCESS_KEY` alternation. Trailing `=` uses a delimiter class rather than `\\b`.
 
 Not compiled-in (pack or later): Azure AD `Q~` infix, GCP SA JSON, Teams webhooks, Discord, Datadog, Azure storage, Cloudflare global, generic-api-key, live API checks.
+
+## Precision corpora (measured)
+
+These figures are from hermetic tests in this repository. They are **not**
+a general precision/recall claim. The meaningful gates are the negative
+corpora. CI prints the numbers; it does not print raw secret values.
+
+### Exclusion / lockfile / digest-keyed corpus
+
+Test: `crates/redact-core/tests/generic_secret_corpus.rs`
+(`exclusion_corpus_has_zero_generic_secret`).
+
+**Gate: 0 `GENERIC_SECRET`.** Measured on this tree:
+`exclusion_generic_secret_count=0`. Covers weak-keyword UUIDs,
+digest-keyed hashes, `password=password`, `api_key=your-key-here`,
+lockfile `integrity=sha512-…`, all-alpha identifiers, prose, `#fff` /
+`#aabbcc`, `data:image;base64,…`.
+
+### Labeled generated positives
+
+Test: `labeled_positive_corpus_precision_recall` in the same file.
+
+Seeded fixtures, assembled at run time (labels and spans only in output).
+This is a labelled set, not a production sample. Do not restate these
+figures as a general result.
+
+Gates: recall **≥ 0.90**; default gateway profile (`replace` @ 0.6) must
+**act on ≥ 90%** of labeled generics. Precision is computed against the
+exclusion corpus (0 FPs by the gate above), so it is not an independent
+general result.
+
+Measured on this tree (labelled set only):
+`generic_secret_precision=1.0000`, `generic_secret_recall=1.0000`,
+`generic_secret_acted_under_default_profile=1.0000`.
+
+### Vendored OSS slice
+
+Test: `crates/redact-core/tests/oss_slice.rs`.
+
+Hermetic MIT/BSD/Apache slice (pinned SHAs of `facebook/react`,
+`redis/redis` 7.2.4 BSD-3 — not RSALv2/SSPL — `pallets/flask`,
+`clap-rs/clap`). Do not vendor `git/git` (GPL).
+
+- **≤ 5 unreviewed `GENERIC_SECRET` / 100k lines**
+- Secret-named + secret-shaped literals in upstream docs count as true
+  positives, not FPs
+- Every remaining hit is a reviewed fingerprint (`tp` or `waived`)
+
+Measured on this tree: `oss_slice_lines=56201` `generic_hits=0`
+`unreviewed=0` `unreviewed_per_100k=0.0000`.
+
+Exceeding a ceiling is a detector bug. Do not raise N to land a change.

--- a/scripts/ci/docker-tags.sh
+++ b/scripts/ci/docker-tags.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Compute the Docker tag list for a release image family.
+#
+# Usage:
+#   docker-tags.sh <family> <version> [image]
+#
+# family:  api | full | gateway
+# version: semver without a leading v (0.10.0 or 0.10.0-rc.1)
+# image:   optional repository prefix; when set, each tag is printed as image:tag
+#
+# Prints a CSV on stdout. Hyphenated (prerelease) versions emit only the
+# exact version tag so :latest / :MAJOR / :MINOR / :full are not rewritten.
+set -euo pipefail
+
+# shellcheck source=lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+usage() {
+  echo "Usage: docker-tags.sh <family> <version> [image]" >&2
+  echo "       docker-tags.sh --self-test" >&2
+}
+
+is_prerelease() {
+  [[ "$1" == *-* ]]
+}
+
+# Strip a leading v so callers can pass ${VERSION#v} or the raw tag.
+normalize_version() {
+  local ver="$1"
+  ver="${ver#v}"
+  [[ -n "${ver}" ]] || fail "empty version"
+  echo "${ver}"
+}
+
+tag_csv() {
+  local family="$1"
+  local ver="$2"
+  local major minor
+
+  case "${family}" in
+    api|gateway)
+      if is_prerelease "${ver}"; then
+        echo "${ver}"
+      else
+        major="${ver%%.*}"
+        minor="${ver%.*}"
+        echo "${ver},${minor},${major},latest"
+      fi
+      ;;
+    full)
+      if is_prerelease "${ver}"; then
+        echo "${ver}-full"
+      else
+        major="${ver%%.*}"
+        minor="${ver%.*}"
+        echo "${ver}-full,${minor}-full,${major}-full,full"
+      fi
+      ;;
+    *)
+      fail "unknown family: ${family} (expected api, full, or gateway)"
+      ;;
+  esac
+}
+
+prefix_csv() {
+  local csv="$1"
+  local image="$2"
+  local out="" tag
+  local IFS=','
+  # shellcheck disable=SC2086
+  for tag in ${csv}; do
+    out="${out:+${out},}${image}:${tag}"
+  done
+  echo "${out}"
+}
+
+expect_eq() {
+  local got="$1"
+  local want="$2"
+  local label="$3"
+  if [[ "${got}" != "${want}" ]]; then
+    fail "self-test ${label}: got '${got}', want '${want}'"
+  fi
+}
+
+self_test() {
+  expect_eq "$(tag_csv api 0.10.0)" "0.10.0,0.10,0,latest" "api stable"
+  expect_eq "$(tag_csv gateway 0.10.0)" "0.10.0,0.10,0,latest" "gateway stable"
+  expect_eq "$(tag_csv full 0.10.0)" "0.10.0-full,0.10-full,0-full,full" "full stable"
+  expect_eq "$(tag_csv api 0.10.0-rc.1)" "0.10.0-rc.1" "api prerelease"
+  expect_eq "$(tag_csv gateway 0.10.0-rc.1)" "0.10.0-rc.1" "gateway prerelease"
+  expect_eq "$(tag_csv full 0.10.0-rc.1)" "0.10.0-rc.1-full" "full prerelease"
+  expect_eq "$(tag_csv api 0.9.1)" "0.9.1,0.9,0,latest" "api patch"
+  expect_eq \
+    "$(prefix_csv "$(tag_csv api 0.10.0-rc.1)" "ghcr.io/censgate/redact")" \
+    "ghcr.io/censgate/redact:0.10.0-rc.1" \
+    "prefixed prerelease"
+  echo "OK: docker-tags.sh self-test"
+}
+
+main() {
+  if [[ "${1:-}" == "--self-test" ]]; then
+    self_test
+    return
+  fi
+  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" || $# -lt 2 ]]; then
+    usage
+    [[ $# -ge 2 ]] || exit 1
+    exit 0
+  fi
+
+  local family="$1"
+  local ver
+  ver="$(normalize_version "$2")"
+  local image="${3:-}"
+  local csv
+  csv="$(tag_csv "${family}" "${ver}")"
+  if [[ -n "${image}" ]]; then
+    prefix_csv "${csv}" "${image}"
+  else
+    echo "${csv}"
+  fi
+}
+
+main "$@"

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -40,14 +40,16 @@ wait_for_http() {
       echo "Ready after ${i}s"
       return 0
     fi
-    if ! docker ps -q -f "name=^/${name}$" | grep -q .; then
-      echo "ERROR: container ${name} exited early" >&2
+    if [ "$(docker inspect -f '{{.State.Running}}' "${name}" 2>/dev/null || echo false)" != "true" ]; then
+      echo "ERROR: container ${name} exited early (inspect follows)" >&2
+      docker inspect -f 'status={{.State.Status}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}} error={{.State.Error}}' "${name}" >&2 || true
       docker logs "${name}" >&2 || true
       return 1
     fi
     sleep 1
   done
   echo "ERROR: ${url} not ready within ${secs}s" >&2
+  docker inspect -f 'status={{.State.Status}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}} error={{.State.Error}}' "${name}" >&2 || true
   docker logs "${name}" >&2 || true
   return 1
 }


### PR DESCRIPTION
Thank you for contributing to Redact. These checkboxes are acknowledgements;
the CLA bot enforces the Individual CLA signature.

- [x] I have read [CLA.md](../CLA.md) and will sign the Individual CLA via the bot comment (or I have already signed). A Corporate CLA, if required, does not replace the Individual CLA.
- [x] All commits are DCO-signed (`git commit -s`)
- [x] I have read [docs/PROJECT_SCOPE.md](../docs/PROJECT_SCOPE.md); this change is in scope

**Employer time or equipment**

- [ ] No — this work was not done on employer time or equipment
- [x] Yes — my employer has authorised the contribution, or a Corporate CLA is on file

## Summary

Rehearsal release **0.10.0-rc.1** is **green**.

- Run: https://github.com/censgate/redact/actions/runs/31922368809
- Prerelease: https://github.com/censgate/redact/releases/tag/v0.10.0-rc.1
- crates.io lists `0.10.0-rc.1` for all five crates
- `:latest` / `:0` / `:full` still the 0.9.1 digests

Stable follow-up is #143 (`v0.10.0`).

## Test plan

- [x] `grep '^version' Cargo.toml` → `0.10.0-rc.1` (on this branch)
- [x] `docker-tags.sh api 0.10.0-rc.1` → `0.10.0-rc.1` only
- [x] Full Release workflow green on `v0.10.0-rc.1`
- [x] `:latest` / `:0` / `:full` unchanged after the run
