### PR TITLE
docs(agents): portable build/run gotchas, no vendor cloud section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,15 +213,18 @@ Before committing:
 - **Rust**: 1.93.0 (see `.tool-versions`)
 - **MSRV**: 1.88
 - **Python**: 3.8+ (for NER model export only)
-- **Native build deps**: `pkg-config`, `cmake`, `g++`, `libssl-dev`
+- **Native build deps**: `pkg-config`, `cmake`, a GNU C++ compiler, OpenSSL
+  headers. Debian/Ubuntu package names: `g++`, `libssl-dev`.
 
 ### Build and run gotchas
 
-These apply on any Linux/macOS checkout, not a particular CI or cloud image.
+Workspace facts (any host). Compiler/library names differ by OS.
 
 - **C++ must be GNU, not clang.** `tokenizers` → `esaxx-rs` fails under clang
-  (`esaxx.cpp: 'cstdint' file not found`). Use `CC=gcc CXX=g++`, or on Debian/
-  Ubuntu point `cc`/`c++` at gcc/g++ (`update-alternatives --set`).
+  (`esaxx.cpp: 'cstdint' file not found`). On Debian/Ubuntu: `CC=gcc CXX=g++`,
+  or point `cc`/`c++` at gcc/g++ (`update-alternatives --set`). On macOS,
+  Homebrew `gcc`/`g++` are versioned (`g++-14`); Apple `gcc` is a clang shim
+  and does not count.
 - **No workspace default-run binary.** From the repo root use
   `cargo run -p <crate> -- …`. `cargo run --bin redact-cli` from the root
   does not select the package.
@@ -235,4 +238,5 @@ These apply on any Linux/macOS checkout, not a particular CI or cloud image.
   `api_key` or `oidc`.
 - **NER is optional.** `redact-ner` builds without a model (`ort` is
   `load-dynamic`). The NER e2e tests are `#[ignore]` and need an exported
-  ONNX model plus `libonnxruntime.so` (`ORT_DYLIB_PATH`).
+  ONNX model plus the ONNX Runtime dylib (`ORT_DYLIB_PATH`:
+  `libonnxruntime.so` on Linux, `libonnxruntime.dylib` on macOS).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # Agent Instructions
 
-Concise guidance for AI agents working with the Redact codebase.
+Concise, harness-agnostic guidance for anyone (human or automated) working
+in this checkout. Do not add vendor-specific cloud/VM sections here.
 
 ## Project Overview
 
@@ -75,11 +76,12 @@ cargo clippy --all-targets --all-features -- -D warnings
 # Benchmarks
 cargo bench --package redact-core
 
-# Run API server
-cargo run --release --bin redact-api
-
-# Run CLI
-cargo run --bin redact-cli -- analyze "test@example.com"
+# Run binaries from the workspace root via -p (no default-run package)
+cargo run -p redact-cli -- analyze "test@example.com"
+cargo run -p redact-api
+cargo run -p redact-gateway -- --host 127.0.0.1
+cargo run -p redact-scan -- --help
+cargo run -p redact-verify -- --help
 ```
 
 ## Code Conventions
@@ -211,3 +213,26 @@ Before committing:
 - **Rust**: 1.93.0 (see `.tool-versions`)
 - **MSRV**: 1.88
 - **Python**: 3.8+ (for NER model export only)
+- **Native build deps**: `pkg-config`, `cmake`, `g++`, `libssl-dev`
+
+### Build and run gotchas
+
+These apply on any Linux/macOS checkout, not a particular CI or cloud image.
+
+- **C++ must be GNU, not clang.** `tokenizers` → `esaxx-rs` fails under clang
+  (`esaxx.cpp: 'cstdint' file not found`). Use `CC=gcc CXX=g++`, or on Debian/
+  Ubuntu point `cc`/`c++` at gcc/g++ (`update-alternatives --set`).
+- **No workspace default-run binary.** From the repo root use
+  `cargo run -p <crate> -- …`. `cargo run --bin redact-cli` from the root
+  does not select the package.
+- **`redact-api` and `redact-gateway` both default to port 8080.** Run one
+  of them on 8080, or override: API uses `HOST`/`PORT`; gateway uses
+  `--host`/`--port` (or `CENSGATE_HOST`/`CENSGATE_PORT`).
+- **Gateway.** `OTEL_SDK_DISABLED=true` silences telemetry-export noise.
+  Health: `GET /healthz`. Redact: `POST /v1/redact` with a `profile`
+  (`strict` blocks, `reversible` tokenizes). `POST /v1/restore` is `403`
+  under the default no-auth config — expected until `auth.mode` is
+  `api_key` or `oidc`.
+- **NER is optional.** `redact-ner` builds without a model (`ort` is
+  `load-dynamic`). The NER e2e tests are `#[ignore]` and need an exported
+  ONNX model plus `libonnxruntime.so` (`ORT_DYLIB_PATH`).


### PR DESCRIPTION
Thank you for contributing to Redact. These checkboxes are acknowledgements;
the CLA bot enforces the Individual CLA signature.

- [x] I have read [CLA.md](../CLA.md) and will sign the Individual CLA via the bot comment (or I have already signed). A Corporate CLA, if required, does not replace the Individual CLA.
- [x] All commits are DCO-signed (`git commit -s`)
- [x] I have read [docs/PROJECT_SCOPE.md](../docs/PROJECT_SCOPE.md); this change is in scope

**Employer time or equipment**

- [ ] No — this work was not done on employer time or equipment
- [x] Yes — my employer has authorised the contribution, or a Corporate CLA is on file

## Summary

Alternative to #136. That PR's caveats are real; a `## Cursor Cloud specific instructions` block is the wrong place for an Apache-2.0 repo that other agents and humans clone.

This change:

- Keeps `AGENTS.md` harness-agnostic (explicitly: do not add vendor cloud/VM sections)
- Puts the portable gotchas under **Environment** / **Development Commands**
- Fixes the existing `cargo run --bin redact-cli` line (workspace root has no default-run package)

Snapshot / startup-script notes stay out of this repo. Those belong in the operator environment that provisions the VM, not in product `AGENTS.md`.

## Test plan

- [x] `rg -i cursor AGENTS.md` — no matches
- [x] Gotchas from #136 retained (GNU C++, ports, OTEL, restore 403, NER optional)
