### PR TITLE
feat(core): pattern quality harness and precision-first gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Pattern quality harness: hermetic exact-span sets for default PII
+  (`testdata/quality/pattern-v1`), compiled secrets, and the opt-in
+  providers pack. Precision gates reject impossible ISO dates, null and
+  broadcast MACs, order-like phone/card values, commit-shaped SHA-1, and
+  junk `%40` / `u00XX` domain fragments. Token matching keeps
+  `commitment`, digit-leading domains, and hotel/cartel context from
+  being over-suppressed. This is a named-set score, not a general
+  precision result. Supersedes #108.
+
 ## [0.10.0] - 2026-08-16
 
 ### Added

--- a/TEST_COVERAGE.md
+++ b/TEST_COVERAGE.md
@@ -27,6 +27,19 @@ Comprehensive test coverage improvements addressing all critical gaps identified
 
 **Run**: `cargo test --package redact-core --test pattern_coverage`
 
+### 1b. Pattern quality harness (hermetic precision)
+
+Not a general precision result. Exact UTF-8 spans; `config.min_score` and
+`ner: false` are enforced. Out-of-scope predictions fail.
+
+| Suite | File | Run |
+|-------|------|-----|
+| pattern-v1 PII | `testdata/quality/pattern-v1.json` + `crates/redact-core/tests/quality_pattern_v1.rs` | `cargo test -p redact-core --test quality_pattern_v1` |
+| secrets-default | `crates/redact-core/tests/quality_secrets_default.rs` | `cargo test -p redact-core --test quality_secrets_default` |
+| optional providers | `crates/redact-gateway/tests/packs.rs` (`quality_optional_providers_exact_spans`) | `cargo test -p redact-gateway --test packs quality_optional` |
+
+See `testdata/quality/README.md` and `docs/secrets-detection.md`.
+
 ### 2. NER End-to-End Tests (10 tests)
 **File**: `crates/redact-ner/tests/ner_e2e.rs`
 

--- a/crates/redact-core/src/recognizers/pattern.rs
+++ b/crates/redact-core/src/recognizers/pattern.rs
@@ -631,6 +631,98 @@ impl Default for PatternRecognizer {
     }
 }
 
+fn left_context(text: &str, start: usize, bytes: usize) -> &str {
+    let mut from = start.saturating_sub(bytes);
+    while from < start && !text.is_char_boundary(from) {
+        from += 1;
+    }
+    &text[from..start]
+}
+
+fn tokens(left_lower: &str) -> impl Iterator<Item = &str> {
+    left_lower
+        .split(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+        .filter(|tok| !tok.is_empty())
+}
+
+fn has_token(left_lower: &str, needle: &str) -> bool {
+    tokens(left_lower).any(|tok| tok == needle)
+}
+
+fn order_like_context(left_lower: &str) -> bool {
+    left_lower.contains("order_id")
+        || left_lower.contains("orderid")
+        || has_token(left_lower, "order")
+}
+
+fn phone_or_card_cue(left_lower: &str) -> bool {
+    const CUES: &[&str] = &[
+        "phone",
+        "tel",
+        "mobile",
+        "cell",
+        "call",
+        "card",
+        "visa",
+        "mastercard",
+        "amex",
+        "payment",
+        "credit",
+    ];
+    tokens(left_lower).any(|tok| CUES.contains(&tok))
+}
+
+fn junk_domain_fragment(text: &str, start: usize, value: &str) -> bool {
+    if let Some(prev) = text[..start].chars().next_back() {
+        if matches!(prev, '%' | '\\' | '@') {
+            return true;
+        }
+    }
+    let lower = value.to_ascii_lowercase();
+    // Digit-leading domains (1password.com) are valid. Only reject the
+    // `\u00XX` / `u00XX` escaped-@ fragment used in encoded emails.
+    if lower.starts_with("u00") && lower.len() > 6 {
+        let hex = &lower[3..5];
+        if hex.chars().all(|c| c.is_ascii_hexdigit()) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Context gates that zero a candidate the regex alone would emit.
+///
+/// Token matching (not substring `contains`) so `commitment`, `hotel`,
+/// and `cartel` do not trip `commit` / `order` / `card` cues.
+fn precision_gate(entity_type: &EntityType, text: &str, start: usize, value: &str) -> f32 {
+    let left = left_context(text, start, 50);
+    let left_lower = left.to_ascii_lowercase();
+    match entity_type {
+        EntityType::PhoneNumber | EntityType::CreditCard => {
+            if order_like_context(&left_lower) && !phone_or_card_cue(&left_lower) {
+                0.0
+            } else {
+                1.0
+            }
+        }
+        EntityType::Sha1Hash => {
+            if has_token(&left_lower, "commit") {
+                0.0
+            } else {
+                1.0
+            }
+        }
+        EntityType::DomainName => {
+            if junk_domain_fragment(text, start, value) {
+                0.0
+            } else {
+                1.0
+            }
+        }
+        _ => 1.0,
+    }
+}
+
 impl Recognizer for PatternRecognizer {
     fn name(&self) -> &str {
         &self.name
@@ -746,6 +838,7 @@ impl Recognizer for PatternRecognizer {
                         // This can reduce or zero out the score for invalid matches
                         let validation_factor = validate_entity(entity_type, matched_text);
                         score *= validation_factor;
+                        score *= precision_gate(entity_type, text, start, matched_text);
 
                         if score >= self.min_score {
                             results.push(

--- a/crates/redact-core/src/recognizers/pattern.rs
+++ b/crates/redact-core/src/recognizers/pattern.rs
@@ -698,27 +698,13 @@ fn precision_gate(entity_type: &EntityType, text: &str, start: usize, value: &st
     let left = left_context(text, start, 50);
     let left_lower = left.to_ascii_lowercase();
     match entity_type {
-        EntityType::PhoneNumber | EntityType::CreditCard => {
-            if order_like_context(&left_lower) && !phone_or_card_cue(&left_lower) {
-                0.0
-            } else {
-                1.0
-            }
+        EntityType::PhoneNumber | EntityType::CreditCard
+            if order_like_context(&left_lower) && !phone_or_card_cue(&left_lower) =>
+        {
+            0.0
         }
-        EntityType::Sha1Hash => {
-            if has_token(&left_lower, "commit") {
-                0.0
-            } else {
-                1.0
-            }
-        }
-        EntityType::DomainName => {
-            if junk_domain_fragment(text, start, value) {
-                0.0
-            } else {
-                1.0
-            }
-        }
+        EntityType::Sha1Hash if has_token(&left_lower, "commit") => 0.0,
+        EntityType::DomainName if junk_domain_fragment(text, start, value) => 0.0,
         _ => 1.0,
     }
 }

--- a/crates/redact-core/src/recognizers/validation.rs
+++ b/crates/redact-core/src/recognizers/validation.rs
@@ -9,6 +9,7 @@
 //! pass the Luhn checksum, and IBANs have country-specific formats.
 
 use crate::types::EntityType;
+use chrono::NaiveDate;
 
 /// Validate a detected entity value based on its type.
 ///
@@ -26,6 +27,8 @@ pub fn validate_entity(entity_type: &EntityType, value: &str) -> f32 {
         EntityType::Isbn => validate_isbn(value),
         EntityType::IpAddress => validate_ip_address(value),
         EntityType::HttpBasicAuth => validate_http_basic_auth(value),
+        EntityType::DateTime => validate_date_time(value),
+        EntityType::MacAddress => validate_mac_address(value),
         _ => 1.0, // No validation available
     }
 }
@@ -454,6 +457,65 @@ fn validate_isbn13(isbn: &str) -> f32 {
     }
 }
 
+/// Validate an ISO `YYYY-MM-DD` date, optionally with `HH:MM` or `HH:MM:SS`.
+///
+/// The compiled DATE_TIME pattern is already ISO-shaped. This rejects
+/// impossible calendar dates and out-of-range clock fields. Time-zone
+/// suffixes are not accepted (the pattern does not emit them).
+pub fn validate_date_time(value: &str) -> f32 {
+    let value = value.trim();
+    let date_part = value.split(['T', ' ']).next().unwrap_or(value);
+
+    if NaiveDate::parse_from_str(date_part, "%Y-%m-%d").is_err() {
+        return 0.0;
+    }
+
+    if let Some(rest) = value
+        .strip_prefix(date_part)
+        .map(str::trim_start)
+        .filter(|s| !s.is_empty())
+    {
+        let time = rest.trim_start_matches(['T', ' ']);
+        let ok = matches!(time.len(), 5 | 8)
+            && time.as_bytes().get(2) == Some(&b':')
+            && (time.len() == 5 || time.as_bytes().get(5) == Some(&b':'))
+            && time.chars().all(|c| c.is_ascii_digit() || c == ':');
+        if !ok {
+            return 0.0;
+        }
+        let hh = time.get(0..2).and_then(|s| s.parse().ok()).unwrap_or(99);
+        let mm = time.get(3..5).and_then(|s| s.parse().ok()).unwrap_or(99);
+        if hh > 23 || mm > 59 {
+            return 0.0;
+        }
+        if time.len() == 8 {
+            let ss = time.get(6..8).and_then(|s| s.parse().ok()).unwrap_or(99);
+            if ss > 59 {
+                return 0.0;
+            }
+        }
+    }
+
+    1.0
+}
+
+/// Reject the all-zero (null) and all-`f` (broadcast) MAC addresses.
+pub fn validate_mac_address(value: &str) -> f32 {
+    let cleaned: String = value
+        .chars()
+        .filter(|c| c.is_ascii_hexdigit())
+        .flat_map(|c| c.to_lowercase())
+        .collect();
+
+    if cleaned.len() != 12 {
+        return 0.0;
+    }
+    if cleaned.chars().all(|c| c == '0') || cleaned.chars().all(|c| c == 'f') {
+        return 0.0;
+    }
+    1.0
+}
+
 /// Validate IPv4 address octets are in valid range.
 pub fn validate_ip_address(value: &str) -> f32 {
     let octets: Vec<&str> = value.split('.').collect();
@@ -556,6 +618,23 @@ mod tests {
         assert_eq!(validate_http_basic_auth("not-base64"), 0.0);
         // "::::" is valid base64 alphabet but decodes without a colon pair.
         assert_eq!(validate_http_basic_auth("QQ=="), 0.0);
+    }
+
+    #[test]
+    fn test_date_time_rejects_impossible_calendar() {
+        assert_eq!(validate_date_time("2026-07-13"), 1.0);
+        assert_eq!(validate_date_time("2026-07-13T12:00:00"), 1.0);
+        assert_eq!(validate_date_time("2026-99-13"), 0.0);
+        assert_eq!(validate_date_time("2026-02-31"), 0.0);
+        assert_eq!(validate_date_time("2026-07-13T25:00:00"), 0.0);
+    }
+
+    #[test]
+    fn test_mac_rejects_null_and_broadcast() {
+        assert_eq!(validate_mac_address("02:42:ac:11:00:02"), 1.0);
+        assert_eq!(validate_mac_address("00:00:00:00:00:00"), 0.0);
+        assert_eq!(validate_mac_address("ff:ff:ff:ff:ff:ff"), 0.0);
+        assert_eq!(validate_mac_address("FF-FF-FF-FF-FF-FF"), 0.0);
     }
 
     #[test]

--- a/crates/redact-core/tests/common/mod.rs
+++ b/crates/redact-core/tests/common/mod.rs
@@ -1,0 +1,3 @@
+#![allow(dead_code)]
+
+pub mod quality;

--- a/crates/redact-core/tests/common/quality.rs
+++ b/crates/redact-core/tests/common/quality.rs
@@ -1,0 +1,309 @@
+//! Shared exact-span scorer for hermetic pattern-quality corpora.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use redact_core::AnalyzerEngine;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+
+#[derive(Debug, Deserialize)]
+pub struct Corpus {
+    pub version: String,
+    pub config: CorpusConfig,
+    pub cases: Vec<Case>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CorpusConfig {
+    pub language: String,
+    pub min_score: f32,
+    pub ner: bool,
+    pub entity_types_in_scope: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Case {
+    pub id: String,
+    pub input: String,
+    pub expected: Vec<ExpectedSpan>,
+    pub tier: String,
+}
+
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+pub struct ExpectedSpan {
+    pub entity_type: String,
+    pub start: usize,
+    pub end: usize,
+    pub raw: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Baseline {
+    pub corpus_sha256: String,
+    pub max_fp_overall: u32,
+    pub max_fp_negative_tier: u32,
+    pub min_precision_ppm: u32,
+    pub require_contract_exact: bool,
+}
+
+#[derive(Debug, Default)]
+pub struct Counts {
+    pub tp: u32,
+    pub fp: u32,
+    pub fn_: u32,
+}
+
+pub fn quality_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../testdata/quality")
+}
+
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
+
+pub fn load_json_corpus(name: &str) -> (Corpus, Vec<u8>) {
+    let path = quality_dir().join(name);
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let corpus: Corpus =
+        serde_json::from_slice(&bytes).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()));
+    (corpus, bytes)
+}
+
+pub fn load_baseline(name: &str) -> Baseline {
+    let path = quality_dir().join(name);
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    serde_json::from_slice(&bytes).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+}
+
+pub fn enforce_corpus_config(corpus: &Corpus, expected_version: &str) {
+    assert_eq!(corpus.version, expected_version);
+    assert!(
+        !corpus.config.ner,
+        "NER quality is out of scope for {expected_version}; set config.ner=false"
+    );
+    assert!(
+        corpus.config.min_score > 0.0,
+        "{expected_version}: config.min_score must be enforced and > 0"
+    );
+    assert!(
+        !corpus.config.entity_types_in_scope.is_empty(),
+        "{expected_version}: entity_types_in_scope must not be empty"
+    );
+
+    let mut seen = HashSet::new();
+    for case in &corpus.cases {
+        assert!(
+            seen.insert(case.id.as_str()),
+            "duplicate case id: {}",
+            case.id
+        );
+        for exp in &case.expected {
+            let slice = case.input.get(exp.start..exp.end).unwrap_or_else(|| {
+                panic!(
+                    "{}: span {}..{} out of range (len={})",
+                    case.id,
+                    exp.start,
+                    exp.end,
+                    case.input.len()
+                )
+            });
+            assert_eq!(
+                slice, exp.raw,
+                "{}: raw mismatch for {}..{}",
+                case.id, exp.start, exp.end
+            );
+            assert!(
+                corpus
+                    .config
+                    .entity_types_in_scope
+                    .iter()
+                    .any(|t| t == &exp.entity_type),
+                "{}: expected type {} is outside entity_types_in_scope",
+                case.id,
+                exp.entity_type
+            );
+        }
+    }
+}
+
+pub type Pred = (String, usize, usize);
+
+pub fn predictions_for_case(
+    engine: &AnalyzerEngine,
+    case: &Case,
+    config: &CorpusConfig,
+) -> Vec<Pred> {
+    let result = engine
+        .analyze(&case.input, Some(&config.language))
+        .unwrap_or_else(|e| panic!("{}: analyze failed: {e}", case.id));
+
+    let in_scope: HashSet<&str> = config
+        .entity_types_in_scope
+        .iter()
+        .map(String::as_str)
+        .collect();
+
+    let mut preds = Vec::new();
+    for entity in result.detected_entities {
+        let ty = entity.entity_type.as_str().to_string();
+        if entity.score < config.min_score {
+            panic!(
+                "{}: engine emitted {} @ {} below config.min_score {}",
+                case.id, ty, entity.score, config.min_score
+            );
+        }
+        if !in_scope.contains(ty.as_str()) {
+            panic!(
+                "{}: prediction {} {}..{} is outside entity_types_in_scope",
+                case.id, ty, entity.start, entity.end
+            );
+        }
+        preds.push((ty, entity.start, entity.end));
+    }
+    preds
+}
+
+pub fn score_case(preds: &[Pred], expected: &[ExpectedSpan]) -> Counts {
+    let mut counts = Counts::default();
+    let mut used = vec![false; preds.len()];
+    let expected: Vec<Pred> = expected
+        .iter()
+        .map(|e| (e.entity_type.clone(), e.start, e.end))
+        .collect();
+
+    for exp in &expected {
+        if let Some((idx, _)) = preds
+            .iter()
+            .enumerate()
+            .find(|(i, p)| !used[*i] && *p == exp)
+        {
+            used[idx] = true;
+            counts.tp += 1;
+        } else {
+            counts.fn_ += 1;
+        }
+    }
+    for (i, pred) in preds.iter().enumerate() {
+        if !used[i] {
+            counts.fp += 1;
+            let _ = pred;
+        }
+    }
+    counts
+}
+
+pub fn run_corpus(engine: &AnalyzerEngine, corpus: &Corpus, baseline: &Baseline) {
+    enforce_corpus_config(corpus, &corpus.version);
+
+    let mut overall = Counts::default();
+    let mut negative_fp = 0u32;
+    let mut failures = Vec::new();
+
+    for case in &corpus.cases {
+        let preds = predictions_for_case(engine, case, &corpus.config);
+        let counts = score_case(&preds, &case.expected);
+        if case.tier == "negative" {
+            negative_fp += counts.fp;
+        }
+        if baseline.require_contract_exact
+            && case.tier == "contract"
+            && (counts.fp > 0 || counts.fn_ > 0)
+        {
+            failures.push(format!(
+                "{}: contract not exact tp={} fp={} fn={} preds={preds:?}",
+                case.id, counts.tp, counts.fp, counts.fn_
+            ));
+        }
+        if case.tier == "negative" && counts.fp > 0 {
+            failures.push(format!("{}: negative-tier FP preds={preds:?}", case.id));
+        }
+        overall.tp += counts.tp;
+        overall.fp += counts.fp;
+        overall.fn_ += counts.fn_;
+    }
+
+    let denom = overall.tp + overall.fp;
+    let precision_ppm = if denom == 0 {
+        1_000_000
+    } else {
+        (u64::from(overall.tp) * 1_000_000 / u64::from(denom)) as u32
+    };
+
+    println!(
+        "quality_{} tp={} fp={} fn={} precision_ppm={} negative_fp={}",
+        corpus.version, overall.tp, overall.fp, overall.fn_, precision_ppm, negative_fp
+    );
+
+    if !failures.is_empty() {
+        panic!("quality failures:\n{}", failures.join("\n"));
+    }
+    assert!(
+        overall.fp <= baseline.max_fp_overall,
+        "fp {} exceeds max_fp_overall {}",
+        overall.fp,
+        baseline.max_fp_overall
+    );
+    assert!(
+        negative_fp <= baseline.max_fp_negative_tier,
+        "negative fp {} exceeds max_fp_negative_tier {}",
+        negative_fp,
+        baseline.max_fp_negative_tier
+    );
+    assert!(
+        precision_ppm >= baseline.min_precision_ppm,
+        "precision_ppm {precision_ppm} below {}",
+        baseline.min_precision_ppm
+    );
+}
+
+/// Programmatic case used by runtime-assembled secret corpora.
+pub struct RuntimeCase {
+    pub id: String,
+    pub input: String,
+    pub expected: Vec<ExpectedSpan>,
+    pub tier: String,
+}
+
+pub fn run_runtime_cases(
+    engine: &AnalyzerEngine,
+    version: &str,
+    config: &CorpusConfig,
+    cases: &[RuntimeCase],
+    baseline: &Baseline,
+) {
+    let corpus = Corpus {
+        version: version.to_string(),
+        config: CorpusConfig {
+            language: config.language.clone(),
+            min_score: config.min_score,
+            ner: config.ner,
+            entity_types_in_scope: config.entity_types_in_scope.clone(),
+        },
+        cases: cases
+            .iter()
+            .map(|c| Case {
+                id: c.id.clone(),
+                input: c.input.clone(),
+                expected: c.expected.clone(),
+                tier: c.tier.clone(),
+            })
+            .collect(),
+    };
+    run_corpus(engine, &corpus, baseline);
+}
+
+pub fn expected_span(input: &str, entity_type: &str, raw: &str) -> ExpectedSpan {
+    let start = input
+        .find(raw)
+        .unwrap_or_else(|| panic!("raw {raw:?} not in {input:?}"));
+    ExpectedSpan {
+        entity_type: entity_type.to_string(),
+        start,
+        end: start + raw.len(),
+        raw: raw.to_string(),
+    }
+}

--- a/crates/redact-core/tests/quality_pattern_v1.rs
+++ b/crates/redact-core/tests/quality_pattern_v1.rs
@@ -1,0 +1,21 @@
+//! Pattern-v1 PII precision harness.
+//!
+//! Scores `testdata/quality/pattern-v1.json` with exact UTF-8 spans.
+//! Precision 1.0 here is a hermetic-set result, not a general claim.
+
+mod common;
+
+use common::quality::{load_baseline, load_json_corpus, run_corpus, sha256_hex};
+use redact_core::AnalyzerEngine;
+
+#[test]
+fn pattern_v1_precision_gates() {
+    let (corpus, bytes) = load_json_corpus("pattern-v1.json");
+    let baseline = load_baseline("pattern-v1-baseline.json");
+    assert_eq!(
+        sha256_hex(&bytes),
+        baseline.corpus_sha256,
+        "pattern-v1.json hash mismatch; update testdata/quality/pattern-v1-baseline.json when changing the corpus"
+    );
+    run_corpus(&AnalyzerEngine::new(), &corpus, &baseline);
+}

--- a/crates/redact-core/tests/quality_secrets_default.rs
+++ b/crates/redact-core/tests/quality_secrets_default.rs
@@ -1,0 +1,302 @@
+//! Default-pack secret quality: exact spans for compiled named types and
+//! `GENERIC_SECRET`. Tokens are assembled at run time so committed source
+//! has no contiguous secret-shaped literal.
+
+mod common;
+
+use common::quality::{expected_span, run_runtime_cases, Baseline, CorpusConfig, RuntimeCase};
+use redact_core::AnalyzerEngine;
+
+fn token(prefix: &str, body: &str) -> String {
+    format!("{prefix}{body}")
+}
+
+fn secrets_config() -> CorpusConfig {
+    CorpusConfig {
+        language: "en".to_string(),
+        min_score: 0.6,
+        ner: false,
+        entity_types_in_scope: vec![
+            "GENERIC_SECRET".into(),
+            "HUGGINGFACE_TOKEN".into(),
+            "DATABRICKS_TOKEN".into(),
+            "DIGITALOCEAN_TOKEN".into(),
+            "NOTION_API_KEY".into(),
+            "PERPLEXITY_API_KEY".into(),
+            "HTTP_BASIC_AUTH".into(),
+            "AWS_ACCESS_KEY".into(),
+            "GITLAB_TOKEN".into(),
+            "GUID".into(),
+            "SHA1_HASH".into(),
+            "SHA256_HASH".into(),
+            "MD5_HASH".into(),
+        ],
+    }
+}
+
+fn baseline() -> Baseline {
+    Baseline {
+        corpus_sha256: String::new(),
+        max_fp_overall: 0,
+        max_fp_negative_tier: 0,
+        min_precision_ppm: 1_000_000,
+        require_contract_exact: true,
+    }
+}
+
+fn contract(id: &str, input: String, entity_type: &str, raw: &str) -> RuntimeCase {
+    let expected = vec![expected_span(&input, entity_type, raw)];
+    RuntimeCase {
+        id: id.to_string(),
+        input,
+        expected,
+        tier: "contract".into(),
+    }
+}
+
+fn negative(id: &str, input: String) -> RuntimeCase {
+    RuntimeCase {
+        id: id.to_string(),
+        input,
+        expected: Vec::new(),
+        tier: "negative".into(),
+    }
+}
+
+fn mixed_hex(seed: u64, n: usize) -> String {
+    const ALPH: &[u8] = b"0123456789abcdef";
+    let mut x = seed | 1;
+    let mut out = String::with_capacity(n);
+    for i in 0..n {
+        x = x.wrapping_mul(6364136223846793005).wrapping_add(1);
+        let mut idx = (x >> 33) as usize % ALPH.len();
+        if i == 0 {
+            idx = 10 + (idx % 6);
+        }
+        if i == 1 {
+            idx %= 10;
+        }
+        out.push(ALPH[idx] as char);
+    }
+    out
+}
+
+fn mixed_alnum(seed: u64, n: usize) -> String {
+    const ALPH: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    let mut x = seed | 1;
+    let mut out = String::with_capacity(n);
+    let mut has_digit = false;
+    let mut has_letter = false;
+    for i in 0..n {
+        x = x.wrapping_mul(6364136223846793005).wrapping_add(1);
+        let mut idx = (x >> 33) as usize % ALPH.len();
+        if i == n - 2 && !has_digit {
+            idx = 52 + (idx % 10);
+        }
+        if i == n - 1 && !has_letter {
+            idx %= 52;
+        }
+        let c = ALPH[idx] as char;
+        has_digit |= c.is_ascii_digit();
+        has_letter |= c.is_ascii_alphabetic();
+        out.push(c);
+    }
+    out
+}
+
+fn cases() -> Vec<RuntimeCase> {
+    let mut out = Vec::new();
+
+    let hf = token("hf_", &"A".repeat(34));
+    out.push(contract(
+        "huggingface-token",
+        format!("model token {hf}"),
+        "HUGGINGFACE_TOKEN",
+        &hf,
+    ));
+
+    let dapi = token("dapi", &"a".repeat(32));
+    out.push(contract(
+        "databricks-token",
+        format!("workspace {dapi}"),
+        "DATABRICKS_TOKEN",
+        &dapi,
+    ));
+
+    let dop = token("dop_v1_", &"a".repeat(64));
+    out.push(contract(
+        "digitalocean-token",
+        format!("do token {dop}"),
+        "DIGITALOCEAN_TOKEN",
+        &dop,
+    ));
+
+    let ntn = token("ntn_", &format!("{}{}", "1".repeat(11), "A".repeat(35)));
+    out.push(contract(
+        "notion-api-key",
+        format!("notion {ntn}"),
+        "NOTION_API_KEY",
+        &ntn,
+    ));
+
+    let pplx = token("pplx-", &"A".repeat(48));
+    out.push(contract(
+        "perplexity-api-key",
+        format!("pplx {pplx}"),
+        "PERPLEXITY_API_KEY",
+        &pplx,
+    ));
+
+    let basic = format!("{}{}", "dXNlcm5hbWU6", "cGFzc3dvcmQ=");
+    out.push(contract(
+        "http-basic-canonical",
+        format!("Authorization: Basic {basic}"),
+        "HTTP_BASIC_AUTH",
+        &basic,
+    ));
+    out.push(contract(
+        "http-basic-case-insensitive",
+        format!("Authorization: BASIC {basic}"),
+        "HTTP_BASIC_AUTH",
+        &basic,
+    ));
+
+    let akia = token("AKIA", "IOSFODNN7EXAMPLE");
+    out.push(contract(
+        "aws-akia",
+        format!("aws {akia}"),
+        "AWS_ACCESS_KEY",
+        &akia,
+    ));
+
+    let absk = token("ABSK", &format!("{}==", "A".repeat(109)));
+    out.push(contract(
+        "aws-bedrock-absk-padded",
+        format!("bedrock {absk} trailing"),
+        "AWS_ACCESS_KEY",
+        &absk,
+    ));
+
+    let short_lived = token("bedrock-api-key-", "YmVkcm9jay5hbWF6b25hd3MuY29t");
+    out.push(contract(
+        "aws-bedrock-short-lived",
+        format!("key {short_lived}"),
+        "AWS_ACCESS_KEY",
+        &short_lived,
+    ));
+
+    let glpat = token("glpat-", &"A".repeat(20));
+    out.push(contract(
+        "gitlab-glpat",
+        format!("gitlab {glpat}"),
+        "GITLAB_TOKEN",
+        &glpat,
+    ));
+
+    let glagent = token("glagent-", &"A".repeat(50));
+    out.push(contract(
+        "gitlab-glagent",
+        format!("agent {glagent}"),
+        "GITLAB_TOKEN",
+        &glagent,
+    ));
+
+    let generic_body = mixed_alnum(0xC0FFEE, 28);
+    let generic_text = format!("api_key={generic_body}");
+    out.push(contract(
+        "generic-secret-assignment",
+        generic_text,
+        "GENERIC_SECRET",
+        &generic_body,
+    ));
+
+    let uuid = "550e8400-e29b-41d4-a716-446655440000";
+    let strong_uuid = format!("api_key={uuid}");
+    out.push(RuntimeCase {
+        id: "uuid-strong-keyword-is-generic-secret".into(),
+        input: strong_uuid.clone(),
+        expected: vec![expected_span(&strong_uuid, "GENERIC_SECRET", uuid)],
+        tier: "contract".into(),
+    });
+
+    let sha1 = mixed_hex(0x5A11, 40);
+    let secret_sha1 = format!("api_key={sha1}");
+    out.push(RuntimeCase {
+        id: "sha1-under-secret-keyword-is-generic".into(),
+        input: secret_sha1.clone(),
+        expected: vec![expected_span(&secret_sha1, "GENERIC_SECRET", &sha1)],
+        tier: "contract".into(),
+    });
+
+    // Exclusion / lockfile / digest-keyed: no GENERIC_SECRET. Weak-keyword
+    // UUID must stay GUID (the documented hole is strong-keyword only).
+    let weak_uuid = format!("revision={uuid}");
+    out.push(RuntimeCase {
+        id: "uuid-weak-keyword-is-guid".into(),
+        input: weak_uuid.clone(),
+        expected: vec![expected_span(&weak_uuid, "GUID", uuid)],
+        tier: "contract".into(),
+    });
+
+    let etag = format!("etag={uuid}");
+    out.push(RuntimeCase {
+        id: "etag-uuid-is-guid-not-generic".into(),
+        input: etag.clone(),
+        expected: vec![expected_span(&etag, "GUID", uuid)],
+        tier: "contract".into(),
+    });
+    let checksum = format!("checksum={}", "a".repeat(64));
+    out.push(RuntimeCase {
+        id: "checksum-sha256-is-hash-not-generic".into(),
+        input: checksum.clone(),
+        expected: vec![expected_span(&checksum, "SHA256_HASH", &"a".repeat(64))],
+        tier: "contract".into(),
+    });
+    out.push(negative(
+        "exclusion-integrity-lockfile",
+        format!("integrity=sha512-{}", "A+/".repeat(24)),
+    ));
+    out.push(negative(
+        "exclusion-password-stopword",
+        "password=password".into(),
+    ));
+    out.push(negative(
+        "exclusion-placeholder-key",
+        "api_key=your-key-here".into(),
+    ));
+    out.push(negative(
+        "exclusion-prose-token",
+        "Please send the token to the reviewer.".into(),
+    ));
+    out.push(negative("exclusion-hex-color", "color: #aabbcc;".into()));
+    out.push(negative(
+        "exclusion-data-uri",
+        format!("data:image/png;base64,{}", "A+/".repeat(16)),
+    ));
+    out.push(negative(
+        "http-basic-noncanonical-unused-bits",
+        format!("Authorization: Basic {}", "dTpwYXN="),
+    ));
+    out.push(negative(
+        "huggingface-truncated",
+        format!("token {}", token("hf_", "tooshort")),
+    ));
+    out.push(negative(
+        "optional-shopify-not-default",
+        format!("shop {}", token("shpat_", &"a".repeat(32))),
+    ));
+
+    out
+}
+
+#[test]
+fn secrets_default_exact_span_quality() {
+    let config = secrets_config();
+    run_runtime_cases(
+        &AnalyzerEngine::new(),
+        "secrets-default",
+        &config,
+        &cases(),
+        &baseline(),
+    );
+}

--- a/crates/redact-gateway/tests/packs.rs
+++ b/crates/redact-gateway/tests/packs.rs
@@ -345,3 +345,105 @@ fn optional_providers_v1_loads_explicitly_and_stays_off_the_tree_walk() {
         "tree walk must not load providers-v1: {walked_hits:?}"
     );
 }
+
+fn assert_custom_span(text: &str, hits: &[redact_core::types::RecognizerResult], name: &str) {
+    let hit = hits
+        .iter()
+        .find(|h| matches!(&h.entity_type, EntityType::Custom(n) if n == name))
+        .unwrap_or_else(|| panic!("{name} missing from {hits:?}"));
+    assert_eq!(
+        &text[hit.start..hit.end],
+        text.trim(),
+        "{name} span {}..{} on {text}",
+        hit.start,
+        hit.end
+    );
+}
+
+#[test]
+fn quality_optional_providers_exact_spans() {
+    let pack = repo_patterns_dir().join("optional/providers-v1.yaml");
+    let (recognizer, report) = load_packs(&[pack]).expect("explicit optional pack");
+    let recognizer = recognizer.expect("providers-v1 should compile");
+    assert_eq!(report.packs_loaded, 1);
+    assert_eq!(report.patterns_skipped, 0, "errors: {:?}", report.errors);
+
+    let shopify = format!("shpat_{}", "a".repeat(32));
+    let adobe = format!("p8e-{}", "A".repeat(32));
+    let linear = format!("lin_api_{}", "A".repeat(40));
+    let postman = format!("PMAK-{}-{}", "a".repeat(24), "b".repeat(34));
+    let pulumi = format!("pul-{}", "a".repeat(40));
+    let newrelic = format!("NRAK-{}", "A".repeat(27));
+
+    let cases = [
+        (shopify.as_str(), "SHOPIFY_ACCESS_TOKEN"),
+        (adobe.as_str(), "ADOBE_CLIENT_SECRET"),
+        (linear.as_str(), "LINEAR_API_KEY"),
+        (postman.as_str(), "POSTMAN_API_TOKEN"),
+        (pulumi.as_str(), "PULUMI_API_TOKEN"),
+        (newrelic.as_str(), "NEW_RELIC_USER_API_KEY"),
+    ];
+
+    let mut tp = 0u32;
+    for (text, name) in cases {
+        let hits = recognizer.analyze(text, "en").expect("analyze");
+        assert_custom_span(text, &hits, name);
+        tp += 1;
+    }
+
+    let hf = format!("hf_{}", "A".repeat(34));
+    let hf_hits = recognizer.analyze(&hf, "en").expect("analyze");
+    assert!(
+        hf_hits.iter().all(|h| {
+            !matches!(&h.entity_type, EntityType::Custom(n) if n == "HUGGINGFACE_TOKEN")
+                && h.entity_type != EntityType::HuggingFaceToken
+        }),
+        "optional pack must not compile core prefixes: {hf_hits:?}"
+    );
+
+    println!("quality_optional_providers tp={tp} fp=0");
+    assert_eq!(tp, 6);
+}
+
+#[test]
+fn default_compliance_pii_path_does_not_load_optional_or_security() {
+    let patterns = repo_patterns_dir();
+    let paths = [patterns.join("compliance"), patterns.join("pii")];
+    let (recognizer, report) = load_packs(&paths).expect("default packs");
+    let recognizer = recognizer.expect("default packs should yield a recognizer");
+    assert!(
+        report.sources.iter().all(|s| {
+            let p = s.to_string_lossy();
+            !p.contains("/optional/") && !p.contains("/security/") && !p.contains("/quarantine/")
+        }),
+        "default path loaded unexpected sources: {:?}",
+        report.sources
+    );
+
+    let shopify = format!("shpat_{}", "a".repeat(32));
+    let hits = recognizer.analyze(&shopify, "en").expect("analyze");
+    assert!(
+        hits.iter().all(|h| {
+            !matches!(&h.entity_type, EntityType::Custom(n) if n == "SHOPIFY_ACCESS_TOKEN")
+        }),
+        "default compliance+pii must not load providers-v1: {hits:?}"
+    );
+}
+
+#[test]
+fn default_image_pack_env_is_compliance_and_pii_only() {
+    let compose = include_str!("../../../docker-compose.gateway.yml");
+    assert!(
+        compose.contains("CENSGATE_PATTERN_PACKS: /app/patterns/compliance:/app/patterns/pii"),
+        "compose default pack path drifted"
+    );
+    let k8s = include_str!("../../../deploy/kubernetes/redact-gateway.yaml");
+    assert!(
+        k8s.contains("/app/patterns/compliance:/app/patterns/pii"),
+        "k8s default pack path drifted"
+    );
+    assert!(
+        !compose.contains("/app/patterns/optional") && !compose.contains("/app/patterns/security"),
+        "compose must not default-load optional or security"
+    );
+}

--- a/docs/secrets-detection.md
+++ b/docs/secrets-detection.md
@@ -108,6 +108,23 @@ In addition to the Phase 1 prefixes: `HUGGINGFACE_TOKEN`, `DATABRICKS_TOKEN`, `D
 
 Not compiled-in (pack or later): Azure AD `Q~` infix, GCP SA JSON, Teams webhooks, Discord, Datadog, Azure storage, Cloudflare global, generic-api-key, live API checks.
 
+## Pattern quality harness
+
+Exact-span precision sets live under `testdata/quality/` and in runtime-
+assembled tests. They are **not** the performance tree in
+`docs/benchmarks/`. A printed precision of 1.0 is hermetic-set-only.
+
+| Set | Command | Scope |
+|-----|---------|-------|
+| `pattern-v1` | `cargo test -p redact-core --test quality_pattern_v1` | 11 default PII types; impossible dates, null/broadcast MACs, order-like phone/card, commit-shaped SHA-1, junk `%40` / `u00XX` domains. Token gates so `commitment`, `hotel`, and `cartel` do not trip `commit` / `order` / `card`. Digit-leading domains stay valid. |
+| `secrets-default` | `cargo test -p redact-core --test quality_secrets_default` | Compiled named types (`HUGGINGFACE_TOKEN`, `DATABRICKS_TOKEN`, `DIGITALOCEAN_TOKEN`, `NOTION_API_KEY`, `PERPLEXITY_API_KEY`, `HTTP_BASIC_AUTH`), AWS Bedrock / GitLab shapes, assignment-only `GENERIC_SECRET`, exclusion overlap vs GUID/hashes. Gateway floor 0.6. |
+| optional providers | `cargo test -p redact-gateway --test packs quality_optional` | `patterns/optional/providers-v1.yaml` only. Not mixed into the default score. |
+
+`CorpusConfig.min_score` and `ner: false` are enforced. Predictions
+outside `entity_types_in_scope` fail the case (they are not ignored).
+NER and formatted-value recall stay out of this harness. Do not claim
+gitleaks parity. Compiled entity count remains **61**.
+
 ## Precision corpora (measured)
 
 These figures are from hermetic tests in this repository. They are **not**

--- a/testdata/quality/README.md
+++ b/testdata/quality/README.md
@@ -1,0 +1,18 @@
+# Pattern quality corpora
+
+Hermetic, project-owned precision sets. They are **not** a general
+precision or recall result, and they are not the performance tree in
+`docs/benchmarks/`.
+
+| Set | Test | What it scores |
+|-----|------|----------------|
+| `pattern-v1.json` | `cargo test -p redact-core --test quality_pattern_v1` | Default-engine PII precision (11 types) plus adversarial gate regressions |
+| secrets-default (runtime) | `cargo test -p redact-core --test quality_secrets_default` | Compiled named secrets + `GENERIC_SECRET` exact spans |
+| optional providers (runtime) | `cargo test -p redact-gateway --test packs quality_optional` | Opt-in `patterns/optional/providers-v1.yaml` only |
+
+NER and formatted-value recall are out of scope. Do not claim gitleaks
+parity. A `min_precision_ppm` of `1000000` means zero in-scope false
+positives **on that named set**.
+
+`pattern-v1-baseline.json` ratchets the PII set. Update
+`corpus_sha256` when the JSON bytes change.

--- a/testdata/quality/pattern-v1-baseline.json
+++ b/testdata/quality/pattern-v1-baseline.json
@@ -1,0 +1,7 @@
+{
+  "corpus_sha256": "4ad86277cfbaefe94f01dfe0ee6f641398ccfd82f736ceee9e12c5932f72a34f",
+  "max_fp_overall": 0,
+  "max_fp_negative_tier": 0,
+  "min_precision_ppm": 1000000,
+  "require_contract_exact": true
+}

--- a/testdata/quality/pattern-v1.json
+++ b/testdata/quality/pattern-v1.json
@@ -1,0 +1,313 @@
+{
+  "version": "pattern-v1",
+  "config": {
+    "language": "en",
+    "min_score": 0.5,
+    "ner": false,
+    "entity_types_in_scope": [
+      "EMAIL_ADDRESS",
+      "PHONE_NUMBER",
+      "CREDIT_CARD",
+      "IBAN_CODE",
+      "IP_ADDRESS",
+      "URL",
+      "GUID",
+      "MAC_ADDRESS",
+      "DATE_TIME",
+      "SHA1_HASH",
+      "DOMAIN_NAME"
+    ]
+  },
+  "cases": [
+    {
+      "id": "negative-date-month",
+      "input": "created_at=2026-99-13",
+      "expected": [],
+      "tier": "negative",
+      "provenance": {
+        "source": "adapted-from-anon-pii",
+        "commit": "1a22680e43b29c80e141a39b0a66eb3dcafb7522"
+      }
+    },
+    {
+      "id": "negative-impossible-calendar-date",
+      "input": "created_at=2026-02-31",
+      "expected": [],
+      "tier": "negative",
+      "provenance": {
+        "source": "adapted-from-anon-pii",
+        "commit": "1a22680e43b29c80e141a39b0a66eb3dcafb7522"
+      }
+    },
+    {
+      "id": "negative-mac-null",
+      "input": "device=00:00:00:00:00:00",
+      "expected": [],
+      "tier": "negative",
+      "provenance": {
+        "source": "adapted-from-anon-pii",
+        "commit": "1a22680e43b29c80e141a39b0a66eb3dcafb7522"
+      }
+    },
+    {
+      "id": "negative-mac-broadcast",
+      "input": "device=ff:ff:ff:ff:ff:ff",
+      "expected": [],
+      "tier": "negative",
+      "provenance": {
+        "source": "adapted-from-anon-pii",
+        "commit": "1a22680e43b29c80e141a39b0a66eb3dcafb7522"
+      }
+    },
+    {
+      "id": "negative-phone-like-order",
+      "input": "order 202-555-0142",
+      "expected": [],
+      "tier": "negative",
+      "provenance": {
+        "source": "adapted-from-anon-pii",
+        "commit": "1a22680e43b29c80e141a39b0a66eb3dcafb7522"
+      }
+    },
+    {
+      "id": "negative-card-like-order",
+      "input": "order_id=4111111111111111",
+      "expected": [],
+      "tier": "negative",
+      "provenance": {
+        "source": "adapted-from-anon-pii",
+        "commit": "1a22680e43b29c80e141a39b0a66eb3dcafb7522"
+      }
+    },
+    {
+      "id": "negative-commit-hash",
+      "input": "commit=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "expected": [],
+      "tier": "negative",
+      "provenance": {
+        "source": "adapted-from-anon-pii",
+        "commit": "1a22680e43b29c80e141a39b0a66eb3dcafb7522"
+      }
+    },
+    {
+      "id": "negative-card-luhn",
+      "input": "Card: 4111111111111112",
+      "expected": [],
+      "tier": "negative",
+      "provenance": {
+        "source": "adapted-from-anon-pii",
+        "commit": "1a22680e43b29c80e141a39b0a66eb3dcafb7522"
+      }
+    },
+    {
+      "id": "negative-percent-encoded-domain",
+      "input": "ada%40censgate.com",
+      "expected": [],
+      "tier": "negative"
+    },
+    {
+      "id": "negative-escaped-at-domain",
+      "input": "u0040example.com",
+      "expected": [],
+      "tier": "negative"
+    },
+    {
+      "id": "email-basic",
+      "input": "Email ada@example.com",
+      "expected": [
+        {
+          "entity_type": "EMAIL_ADDRESS",
+          "start": 6,
+          "end": 21,
+          "raw": "ada@example.com"
+        }
+      ],
+      "tier": "contract",
+      "provenance": {
+        "source": "adapted-from-anon-pii",
+        "commit": "1a22680e43b29c80e141a39b0a66eb3dcafb7522"
+      }
+    },
+    {
+      "id": "card-visa-compact",
+      "input": "Payment card 4111111111111111",
+      "expected": [
+        {
+          "entity_type": "CREDIT_CARD",
+          "start": 13,
+          "end": 29,
+          "raw": "4111111111111111"
+        }
+      ],
+      "tier": "contract",
+      "provenance": {
+        "source": "adapted-from-anon-pii",
+        "commit": "1a22680e43b29c80e141a39b0a66eb3dcafb7522"
+      }
+    },
+    {
+      "id": "iban-gb-compact",
+      "input": "IBAN GB82WEST12345698765432",
+      "expected": [
+        {
+          "entity_type": "IBAN_CODE",
+          "start": 5,
+          "end": 27,
+          "raw": "GB82WEST12345698765432"
+        }
+      ],
+      "tier": "contract",
+      "provenance": {
+        "source": "adapted-from-anon-pii",
+        "commit": "1a22680e43b29c80e141a39b0a66eb3dcafb7522"
+      }
+    },
+    {
+      "id": "uuid-request-id",
+      "input": "request_id=550e8400-e29b-41d4-a716-446655440000",
+      "expected": [
+        {
+          "entity_type": "GUID",
+          "start": 11,
+          "end": 47,
+          "raw": "550e8400-e29b-41d4-a716-446655440000"
+        }
+      ],
+      "tier": "contract"
+    },
+    {
+      "id": "mac-locally-administered",
+      "input": "MAC 02:42:ac:11:00:02",
+      "expected": [
+        {
+          "entity_type": "MAC_ADDRESS",
+          "start": 4,
+          "end": 21,
+          "raw": "02:42:ac:11:00:02"
+        }
+      ],
+      "tier": "contract",
+      "provenance": {
+        "source": "adapted-from-anon-pii",
+        "commit": "1a22680e43b29c80e141a39b0a66eb3dcafb7522"
+      }
+    },
+    {
+      "id": "url-basic",
+      "input": "See https://example.com/path",
+      "expected": [
+        {
+          "entity_type": "URL",
+          "start": 4,
+          "end": 28,
+          "raw": "https://example.com/path"
+        }
+      ],
+      "tier": "contract"
+    },
+    {
+      "id": "ipv4-documentation",
+      "input": "Host 192.0.2.44",
+      "expected": [
+        {
+          "entity_type": "IP_ADDRESS",
+          "start": 5,
+          "end": 15,
+          "raw": "192.0.2.44"
+        }
+      ],
+      "tier": "contract"
+    },
+    {
+      "id": "phone-us-context",
+      "input": "Call (202) 555-0142",
+      "expected": [
+        {
+          "entity_type": "PHONE_NUMBER",
+          "start": 5,
+          "end": 19,
+          "raw": "(202) 555-0142"
+        }
+      ],
+      "tier": "contract"
+    },
+    {
+      "id": "date-iso-date-only",
+      "input": "created_at=2026-07-13",
+      "expected": [
+        {
+          "entity_type": "DATE_TIME",
+          "start": 11,
+          "end": 21,
+          "raw": "2026-07-13"
+        }
+      ],
+      "tier": "contract"
+    },
+    {
+      "id": "domain-digit-leading",
+      "input": "Visit 1password.com today",
+      "expected": [
+        {
+          "entity_type": "DOMAIN_NAME",
+          "start": 6,
+          "end": 19,
+          "raw": "1password.com"
+        }
+      ],
+      "tier": "contract"
+    },
+    {
+      "id": "sha1-commitment-not-commit",
+      "input": "Our commitment aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa stands",
+      "expected": [
+        {
+          "entity_type": "SHA1_HASH",
+          "start": 15,
+          "end": 55,
+          "raw": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        }
+      ],
+      "tier": "contract"
+    },
+    {
+      "id": "phone-hotel-not-order",
+      "input": "Hotel desk (202) 555-0142",
+      "expected": [
+        {
+          "entity_type": "PHONE_NUMBER",
+          "start": 11,
+          "end": 25,
+          "raw": "(202) 555-0142"
+        }
+      ],
+      "tier": "contract"
+    },
+    {
+      "id": "card-cartel-not-card-cue",
+      "input": "Cartel invoice 4111111111111111",
+      "expected": [
+        {
+          "entity_type": "CREDIT_CARD",
+          "start": 15,
+          "end": 31,
+          "raw": "4111111111111111"
+        }
+      ],
+      "tier": "contract"
+    },
+    {
+      "id": "email-unicode-context",
+      "input": "José emailed ada@example.com yesterday",
+      "expected": [
+        {
+          "entity_type": "EMAIL_ADDRESS",
+          "start": 14,
+          "end": 29,
+          "raw": "ada@example.com"
+        }
+      ],
+      "tier": "contract"
+    }
+  ]
+}


### PR DESCRIPTION
- [x] I have read [CLA.md](../CLA.md) and will sign the Individual CLA via the bot comment (or I have already signed). A Corporate CLA, if required, does not replace the Individual CLA.
- [x] All commits are DCO-signed (`git commit -s`)
- [x] I have read [docs/PROJECT_SCOPE.md](../docs/PROJECT_SCOPE.md); this change is in scope

**Employer time or equipment**

- [x] No — this work was not done on employer time or equipment
- [ ] Yes — my employer has authorised the contribution, or a Corporate CLA is on file

## Summary

Replacement for [#108](https://github.com/censgate/redact/pull/108). That branch is stale and conflicting against post-0.10.0 `main`; this PR re-applies the useful precision gates and expands the quality benchmark to the shipped security surface.

**Precision gates (default engine)**

- Impossible ISO `DATE_TIME` (month 99, Feb 31)
- Null / broadcast `MAC_ADDRESS`
- Order-like `PHONE_NUMBER` / `CREDIT_CARD` without a phone/card cue
- Commit-shaped `SHA1_HASH` (`commit=` token, not the substring `commitment`)
- Junk `DOMAIN_NAME` fragments (`%40…`, `u00XX…`)
- Digit-leading domains, hotel/cartel context, and Unicode email context stay valid

**Harness**

- `testdata/quality/pattern-v1.json` — 11-type PII set; `CorpusConfig.min_score` and `ner: false` are enforced; out-of-scope predictions fail
- `quality_secrets_default` — exact spans for the six named types, `GENERIC_SECRET`, AWS Bedrock, GitLab; exclusion overlap vs GUID/hashes; gateway floor 0.6
- Optional `providers-v1` scored separately; default compliance+pii path and image env must not load `optional` / `security` / `quarantine`

Precision 1.0 here is a **named hermetic-set** score, not a general result. NER and formatted-value recall stay out of scope. No gitleaks parity claim. Compiled entity count remains 61.

Supersedes #108.

## Test plan

- [x] `cargo test -p redact-core --test quality_pattern_v1` — `tp=14 fp=0 precision_ppm=1000000`
- [x] `cargo test -p redact-core --test quality_secrets_default` — `tp=18 fp=0`
- [x] `cargo test -p redact-core` (full crate)
- [x] `cargo test -p redact-gateway --test packs`
- [x] `cargo clippy -p redact-core -p redact-gateway --all-targets -- -D warnings`
- [x] `cargo fmt --all`