### PR TITLE
chore(deps): consolidate Dependabot bumps and fix h2 audit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,19 @@ updates:
       cargo:
         patterns:
           - "*"
+    ignore:
+      # sqlx 0.9's MSRV is 1.94; this workspace stays on 1.88.
+      - dependency-name: sqlx
+        versions: [">=0.9"]
+      # rc.13 needs ONNX Runtime 1.28; ghcr.io/censgate/redact-ner-base:v2
+      # still ships 1.24.4 (ort 2.0.0-rc.12). See workspace Cargo.toml.
+      - dependency-name: ort
+        versions: [">=2.0.0-rc.13"]
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      # dtolnay/rust-toolchain refs are toolchain versions (e.g. 1.88 MSRV),
+      # not action releases. Dependabot treats @1.88 as stale.
+      - dependency-name: dtolnay/rust-toolchain

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Verify all PR commit authors are signed
         if: github.event_name == 'pull_request_target' || github.event.issue.pull_request
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/ner-base.yml
+++ b/.github/workflows/ner-base.yml
@@ -41,13 +41,13 @@ jobs:
 
       - name: Set up QEMU
         if: matrix.arch == 'arm64'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -75,7 +75,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,7 @@ jobs:
         run: ./scripts/ci/changelog-notes.sh "${VERSION#v}" > release-notes.md
 
       - name: Create draft GitHub Release and upload assets
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ env.VERSION }}
           name: Release ${{ env.VERSION }}
@@ -239,13 +239,13 @@ jobs:
           ref: ${{ env.VERSION }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -305,13 +305,13 @@ jobs:
           ref: ${{ env.VERSION }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -382,13 +382,13 @@ jobs:
           ref: ${{ env.VERSION }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -460,13 +460,13 @@ jobs:
           ref: ${{ env.VERSION }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -540,7 +540,7 @@ jobs:
           echo "ver=${VER}" >> "$GITHUB_OUTPUT"
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,9 +1535,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3457,7 +3457,7 @@ version = "0.10.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
- "base64 0.22.1",
+ "base64 0.23.1",
  "clap",
  "ed25519-dalek",
  "hex",

--- a/crates/redact-verify/Cargo.toml
+++ b/crates/redact-verify/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
-base64 = "0.22"
+base64 = "0.23"
 clap = { workspace = true }
 ed25519-dalek = { version = "2.1", features = ["pkcs8"] }
 hex = "0.4"
@@ -29,7 +29,7 @@ sha2 = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = "2.2"
-base64 = "0.22"
+base64 = "0.23"
 hex = "0.4"
 predicates = "3.1"
 serde_json = { workspace = true }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- [x] I have read [CLA.md](../CLA.md) and will sign the Individual CLA via the bot comment (or I have already signed). A Corporate CLA, if required, does not replace the Individual CLA.
- [x] All commits are DCO-signed (`git commit -s`)
- [x] I have read [docs/PROJECT_SCOPE.md](../docs/PROJECT_SCOPE.md); this change is in scope

**Employer time or equipment**

- [x] No — this work was not done on employer time or equipment
- [ ] Yes — my employer has authorised the contribution, or a Corporate CLA is on file

## Summary

Consolidates the Dependabot PRs that can go green without raising MSRV or unpinning `ort`.

**Included (from Dependabot + shared CI blocker):**
- `docker/setup-qemu-action` v3 → v4 (#148)
- `docker/login-action` v3 → v4 (#149)
- `actions/github-script` 7.0.1 → 9.0.0 (#150)
- `softprops/action-gh-release` v1 → v3 (#152)
- `base64` 0.22 → 0.23 in `redact-verify` (safe subset of #153)
- Transitive `h2` 0.4.15 → 0.4.16 for [RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258) (this is why Security Audit failed on every open Dependabot PR)

**Not included, originals will be closed:**
- #151 `dtolnay/rust-toolchain` 1.88 → 1.100 — that ref is the MSRV pin, not an action version
- #153 remaining cargo group: `sqlx` 0.9 (MSRV 1.94), `ort` 2.0.0-rc.13 (pinned to rc.12 for ner-base v2 / ONNX Runtime 1.24.4), `ed25519-dalek` 3.0 (major / edition 2024)

Dependabot ignores were added so those three do not reopen until we choose to bump MSRV or the NER base image.

## Test plan

- [ ] CI on this PR is green (including Security Audit)
- [ ] Original Dependabot PRs #148–#153 are closed as superseded / incorrect
- [ ] After merge, `CI` and `CodeQL` on `main` are green
- [ ] Post-merge tag/release workflows do not fire (this is not a `release/v*` branch)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80e3710b-95f4-44ff-aae3-5134ceaaca29?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80e3710b-95f4-44ff-aae3-5134ceaaca29&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

