### PR TITLE
chore(deps): bump upload-artifact to v7 and download-artifact to v8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
           7z a ../../../redact-${{ matrix.target }}.zip ${{ matrix.binary_name }} redact-gateway.exe
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: redact-${{ matrix.target }}
           path: redact-${{ matrix.target }}.*
@@ -119,7 +119,7 @@ jobs:
           ref: ${{ env.VERSION }}
 
       - name: Download binary artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- [x] I have read [CLA.md](../CLA.md) and will sign the Individual CLA via the bot comment (or I have already signed). A Corporate CLA, if required, does not replace the Individual CLA.
- [x] All commits are DCO-signed (`git commit -s`)
- [x] I have read [docs/PROJECT_SCOPE.md](../docs/PROJECT_SCOPE.md); this change is in scope

**Employer time or equipment**

- [x] No — this work was not done on employer time or equipment
- [ ] Yes — my employer has authorised the contribution, or a Corporate CLA is on file

## Summary

Consolidates Dependabot #155 (`actions/download-artifact` 4 → 8) and #156 (`actions/upload-artifact` 4 → 7) so the release matrix upload and Create Release download land together.

`merge-multiple` and `pattern: redact-*` are still supported on download-artifact v8. Existing inputs are unchanged.

## Test plan

- [ ] CI on this PR is green
- [ ] #155 and #156 closed as superseded
- [ ] After merge, `CI` and `CodeQL` on `main` are green
- [ ] Release / publish workflows do not fire (not a `release/v*` branch)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80e3710b-95f4-44ff-aae3-5134ceaaca29?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80e3710b-95f4-44ff-aae3-5134ceaaca29&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

