### PR TITLE
Hybrid identity detection: contextual parser + ONNX NER in gateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3401,6 +3401,7 @@ dependencies = [
  "prometheus",
  "rand 0.10.2",
  "redact-core",
+ "redact-ner",
  "regex",
  "reqwest",
  "serde",

--- a/Dockerfile.gateway
+++ b/Dockerfile.gateway
@@ -10,6 +10,13 @@
 # Distroless has no shell, so there is no HEALTHCHECK instruction. Probe
 # /livez (liveness) and /readyz (readiness) from the orchestrator instead —
 # the same approach as the main API image in ./Dockerfile.
+#
+# NER: the runtime stage copies ONNX Runtime + model from redact-ner-base
+# and fail-closes when they are missing (`CENSGATE_NER_REQUIRED=true`).
+
+# NER artifacts that change only when the model or ORT version is bumped.
+ARG NER_BASE=ghcr.io/censgate/redact-ner-base:v2
+FROM ${NER_BASE} AS ner-base
 
 # Stage 1: Build
 # Pin to bookworm so the linked glibc matches the distroless cc-debian12 runtime.
@@ -90,9 +97,16 @@ COPY patterns /app/patterns
 # Copy binary from builder
 COPY --from=builder /app/target/release/redact-gateway /usr/local/bin/redact-gateway
 
+# ONNX Runtime + NER model/tokenizer (same layout as Dockerfile.ner)
+COPY --from=ner-base /app/lib/libonnxruntime.so /app/lib/libonnxruntime.so
+COPY --from=ner-base /app/model/ /app/model/
+
 # Load reviewed compliance/PII packs only. patterns/security and
 # patterns/optional are opt-in (override with CENSGATE_PATTERN_PACKS).
 ENV CENSGATE_PATTERN_PACKS=/app/patterns/compliance:/app/patterns/pii
+ENV CENSGATE_NER_MODEL_PATH=/app/model/model.onnx
+ENV CENSGATE_NER_REQUIRED=true
+ENV ORT_DYLIB_PATH=/app/lib/libonnxruntime.so
 
 # Expose gateway port
 EXPOSE 8080

--- a/crates/redact-gateway/Cargo.toml
+++ b/crates/redact-gateway/Cargo.toml
@@ -26,6 +26,7 @@ prometheus = ["dep:opentelemetry-prometheus", "dep:prometheus"]
 
 [dependencies]
 redact-core = { path = "../redact-core", version = "0.10.0" }
+redact-ner = { path = "../redact-ner", version = "0.10.0" }
 axum = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true }

--- a/crates/redact-gateway/README.md
+++ b/crates/redact-gateway/README.md
@@ -203,6 +203,8 @@ Every gateway knob uses the `CENSGATE_` prefix (one name per setting). The only 
 | `CENSGATE_ALLOW_PROFILE_HEADER` | `false` | Honor the profile header |
 | `CENSGATE_PATTERN_PACKS` | unset | Pack files/dirs (`:` / `,` / `;` separated) |
 | `CENSGATE_DISABLE_BUILTIN_PATTERNS` | `false` | Skip patterns compiled into the engine |
+| `CENSGATE_NER_MODEL_PATH` | unset | Path to ONNX `model.onnx` |
+| `CENSGATE_NER_REQUIRED` | `false` | Fail startup if NER cannot load |
 | `CENSGATE_VAULT_BACKEND` | `off` | Token map backend: `off`, `memory`, or `vault_kv2` |
 | `CENSGATE_VAULT_ADDR` / `VAULT_ADDR` / `BAO_ADDR` | unset | KV v2 server address |
 | `CENSGATE_VAULT_TOKEN` / `VAULT_TOKEN` / `BAO_TOKEN` | unset | KV v2 auth token |
@@ -239,6 +241,7 @@ server:      # host, port, enable_http_trace, metrics_endpoint
 provider:    # name, base_url, api_key, timeouts, max_body_bytes, forward_client_authorization
 redaction:   # stream_mode, stream_holdback_bytes, session_header, profile_header, allow_profile_header
 packs:       # paths, disable_builtin
+ner:         # model_path, required
 vault:       # token map: backend, address, token, mount, path_prefix, namespace, ttl_secs, data_encryption_key
 auth:        # mode, api_keys, oidc: { … }
 audit:       # export, file_path, queue_capacity, include_entity_types

--- a/crates/redact-gateway/src/config/env.rs
+++ b/crates/redact-gateway/src/config/env.rs
@@ -73,6 +73,10 @@ pub const ALLOW_PROFILE_HEADER: &str = "CENSGATE_ALLOW_PROFILE_HEADER";
 pub const PATTERN_PACKS: &str = "CENSGATE_PATTERN_PACKS";
 /// Disable the patterns compiled into the engine.
 pub const DISABLE_BUILTIN_PATTERNS: &str = "CENSGATE_DISABLE_BUILTIN_PATTERNS";
+/// Path to the ONNX NER model (`model.onnx`).
+pub const NER_MODEL_PATH: &str = "CENSGATE_NER_MODEL_PATH";
+/// When true, a missing or unloadable NER model fails gateway startup.
+pub const NER_REQUIRED: &str = "CENSGATE_NER_REQUIRED";
 /// Token map backend.
 pub const VAULT_BACKEND: &str = "CENSGATE_VAULT_BACKEND";
 /// Token map server address.
@@ -277,6 +281,12 @@ pub fn overlay_env(config: &mut ResolvedConfig) -> Result<(), ConfigError> {
     }
     if let Some(value) = first(&[DISABLE_BUILTIN_PATTERNS]) {
         config.packs.disable_builtin = parse_bool(DISABLE_BUILTIN_PATTERNS, &value)?;
+    }
+    if let Some(value) = first(&[NER_MODEL_PATH]) {
+        config.ner.model_path = Some(PathBuf::from(value));
+    }
+    if let Some(value) = first(&[NER_REQUIRED]) {
+        config.ner.required = parse_bool(NER_REQUIRED, &value)?;
     }
 
     if let Some(value) = first(&[VAULT_BACKEND]) {

--- a/crates/redact-gateway/src/config/mod.rs
+++ b/crates/redact-gateway/src/config/mod.rs
@@ -412,6 +412,15 @@ pub struct PackSettings {
     pub disable_builtin: bool,
 }
 
+/// ONNX named-entity recognition loaded at startup.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct NerSettings {
+    /// Path to `model.onnx`. Tokenizer is discovered in the same directory.
+    pub model_path: Option<PathBuf>,
+    /// Fail startup when the model is missing or cannot be loaded.
+    pub required: bool,
+}
+
 /// Token map backend settings.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VaultSettings {
@@ -562,6 +571,8 @@ pub struct ResolvedConfig {
     pub redaction: RedactionSettings,
     /// Pattern pack loading.
     pub packs: PackSettings,
+    /// ONNX NER (optional locally; required in production images).
+    pub ner: NerSettings,
     /// Token map backend.
     pub vault: VaultSettings,
     /// Inbound authentication.
@@ -586,6 +597,7 @@ impl Default for ResolvedConfig {
             provider: ProviderSettings::default(),
             redaction: RedactionSettings::default(),
             packs: PackSettings::default(),
+            ner: NerSettings::default(),
             vault: VaultSettings::default(),
             auth: AuthSettings::default(),
             audit: AuditSettings::default(),
@@ -758,6 +770,7 @@ impl ResolvedConfig {
         next.provider.forward_client_authorization = self.provider.forward_client_authorization;
         next.provider.name = self.provider.name.clone();
         next.packs = self.packs.clone();
+        next.ner = self.ner.clone();
         next.vault = self.vault.clone();
         next.auth = self.auth.clone();
         next.audit.export = self.audit.export;
@@ -813,6 +826,9 @@ impl ResolvedConfig {
         }
         if self.packs.disable_builtin != next.packs.disable_builtin {
             changed.push("packs.disable_builtin");
+        }
+        if self.ner.model_path != next.ner.model_path || self.ner.required != next.ner.required {
+            changed.push("ner.*");
         }
         if self.vault.backend != next.vault.backend {
             changed.push("vault.backend");
@@ -896,6 +912,10 @@ impl ResolvedConfig {
             "packs": {
                 "paths": self.packs.paths,
                 "disable_builtin": self.packs.disable_builtin,
+            },
+            "ner": {
+                "model_path": self.ner.model_path,
+                "required": self.ner.required,
             },
             "vault": {
                 "backend": self.vault.backend.as_str(),

--- a/crates/redact-gateway/src/config/schema.rs
+++ b/crates/redact-gateway/src/config/schema.rs
@@ -33,6 +33,9 @@ pub struct GatewayDocument {
     /// Pattern pack loading.
     #[serde(default)]
     pub packs: Option<PacksDocument>,
+    /// ONNX NER.
+    #[serde(default)]
+    pub ner: Option<NerDocument>,
     /// Token map backend.
     #[serde(default)]
     pub vault: Option<VaultDocument>,
@@ -111,6 +114,16 @@ pub struct PacksDocument {
     pub paths: Option<Vec<PathBuf>>,
     /// Skip patterns compiled into the engine.
     pub disable_builtin: Option<bool>,
+}
+
+/// ONNX NER section.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NerDocument {
+    /// Path to `model.onnx`, relative to the document.
+    pub model_path: Option<PathBuf>,
+    /// Fail startup when the model cannot be loaded.
+    pub required: Option<bool>,
 }
 
 /// Token map section.
@@ -283,6 +296,13 @@ impl GatewayDocument {
                     .collect();
             }
             apply_opt(&mut config.packs.disable_builtin, packs.disable_builtin);
+        }
+
+        if let Some(ner) = self.ner {
+            if let Some(path) = ner.model_path {
+                config.ner.model_path = Some(resolve_path(base_dir, path));
+            }
+            apply_opt(&mut config.ner.required, ner.required);
         }
 
         if let Some(vault) = self.vault {

--- a/crates/redact-gateway/src/policy/default_policy.yaml
+++ b/crates/redact-gateway/src/policy/default_policy.yaml
@@ -54,6 +54,12 @@ profiles:
       UK_NINO: { action: mask, min_confidence: 0.7 }
       MEDICAL_RECORD_NUMBER: { action: mask, min_confidence: 0.7 }
 
+      # Identity: tokenize-or-replace via default_action. Named here so a
+      # future default_action change cannot silently allow names and places.
+      PERSON: { action: replace }
+      LOCATION: { action: replace }
+      ORGANIZATION: { action: replace }
+
       # Very common false positives stay untouched unless highly confident.
       DATE_TIME: { action: allow }
       AGE: { action: allow }
@@ -93,6 +99,9 @@ profiles:
       PERPLEXITY_API_KEY: { action: block }
       HTTP_BASIC_AUTH: { action: block }
       GENERIC_SECRET: { action: replace, min_confidence: 0.6 }
+      PERSON: { action: tokenize }
+      LOCATION: { action: tokenize }
+      ORGANIZATION: { action: tokenize }
       DATE_TIME: { action: allow }
       AGE: { action: allow }
       URL: { action: allow }

--- a/crates/redact-gateway/src/server.rs
+++ b/crates/redact-gateway/src/server.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use redact_core::AnalyzerEngine;
+use redact_ner::{IdentityNerOptions, IdentityRecognizer};
 use tower_http::trace::TraceLayer;
 use tracing::{info, warn};
 
@@ -224,6 +225,20 @@ fn build_engine(config: &ResolvedConfig) -> Result<AnalyzerEngine> {
         }
     }
 
+    let identity = IdentityRecognizer::from_options(IdentityNerOptions {
+        model_path: config.ner.model_path.clone(),
+        required: config.ner.required,
+    })
+    .context("could not initialize the identity recognizer")?;
+    info!(
+        ner = identity.ner_available(),
+        required = config.ner.required,
+        "registered identity recognizer"
+    );
+    engine
+        .recognizer_registry_mut()
+        .add_recognizer(Arc::new(identity));
+
     if config.packs.disable_builtin && engine.recognizer_registry().recognizers().is_empty() {
         anyhow::bail!(
             "built-in patterns are disabled and no pattern packs were loaded, so nothing would be detected"
@@ -378,14 +393,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn disabling_builtin_patterns_without_packs_fails_startup() {
+    async fn disabling_builtin_patterns_without_packs_still_has_identity() {
         let mut config = ResolvedConfig::default();
         config.packs.disable_builtin = true;
-        let err = match GatewayServer::new(config).await {
-            Ok(_) => panic!("expected startup to fail"),
-            Err(err) => err,
-        };
-        assert!(err.to_string().contains("nothing would be detected"));
+        let server = GatewayServer::new(config).await.unwrap();
+        let hits = server.state().engine.analyze("Hi Ada", Some("en")).unwrap();
+        assert!(
+            hits.detected_entities
+                .iter()
+                .any(|e| e.entity_type == redact_core::EntityType::Person
+                    && &"Hi Ada"[e.start..e.end] == "Ada"),
+            "expected Ada as PERSON, got {:?}",
+            hits.detected_entities
+        );
     }
 
     #[tokio::test]
@@ -418,5 +438,34 @@ mod tests {
         config.vault.backend = crate::config::VaultBackend::Memory;
         let server = GatewayServer::new(config).await.unwrap();
         assert_eq!(server.token_store().backend_name(), "memory");
+    }
+
+    #[tokio::test]
+    async fn required_ner_without_a_model_fails_startup() {
+        let mut config = ResolvedConfig::default();
+        config.ner.required = true;
+        let err = match GatewayServer::new(config).await {
+            Ok(_) => panic!("expected startup to fail"),
+            Err(err) => err,
+        };
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("CENSGATE_NER_REQUIRED") || msg.contains("identity recognizer"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn default_engine_registers_contextual_identity() {
+        let server = GatewayServer::new(ResolvedConfig::default()).await.unwrap();
+        let hits = server.state().engine.analyze("Hi Ada", Some("en")).unwrap();
+        assert!(
+            hits.detected_entities
+                .iter()
+                .any(|e| e.entity_type == redact_core::EntityType::Person
+                    && &"Hi Ada"[e.start..e.end] == "Ada"),
+            "expected Ada as PERSON, got {:?}",
+            hits.detected_entities
+        );
     }
 }

--- a/crates/redact-gateway/tests/gateway_e2e.rs
+++ b/crates/redact-gateway/tests/gateway_e2e.rs
@@ -1044,3 +1044,51 @@ async fn well_formed_and_malformed_traceparent_headers_both_succeed() {
     .await;
     assert_eq!(malformed.status, StatusCode::OK);
 }
+
+const CATS_PARAGRAPH: &str = "I have two female cats: Nola ( black American short hair, 12 ) and Pip ( ginger tabby, 3 ). We live in Cedar Hollow, Caledonia ( Riverton metro area ). I have a wife and a daughter ( 11 ).";
+
+#[tokio::test]
+async fn identity_redact_tokenizes_pet_and_place_names() {
+    let upstream = mock_json_upstream(chat_response("ok")).await;
+    let router = router_for(memory_tokenize_api_keys(&upstream, &["secret-key"])).await;
+    let auth = [("authorization", "Bearer secret-key")];
+
+    let response = post_json_with_headers(
+        router.clone(),
+        "/v1/redact",
+        json!({"text": CATS_PARAGRAPH, "session_id": "identity-cats"}),
+        &auth,
+    )
+    .await;
+
+    assert_eq!(response.status, StatusCode::OK);
+    let text = response.json()["text"].as_str().unwrap().to_string();
+    for leaked in ["Nola", "Pip", "Cedar Hollow", "Caledonia", "Riverton"] {
+        assert!(
+            !text.contains(leaked),
+            "plaintext {leaked:?} survived: {text}"
+        );
+    }
+    assert!(
+        text.contains("American"),
+        "breed adjective must stay plaintext: {text}"
+    );
+    assert!(
+        text.contains("[PERSON_") && text.contains("[LOCATION_"),
+        "expected PERSON and LOCATION tokens: {text}"
+    );
+    assert!(
+        upstream.captured.lock().unwrap().is_none(),
+        "standalone /v1/redact must not call the provider"
+    );
+
+    let restored = post_json_with_headers(
+        router,
+        "/v1/restore",
+        json!({"text": text, "session_id": "identity-cats"}),
+        &auth,
+    )
+    .await;
+    assert_eq!(restored.status, StatusCode::OK);
+    assert_eq!(restored.json()["text"], CATS_PARAGRAPH);
+}

--- a/crates/redact-gateway/tests/support/mod.rs
+++ b/crates/redact-gateway/tests/support/mod.rs
@@ -20,12 +20,10 @@ use axum::response::IntoResponse;
 use axum::routing::{get, post};
 use axum::Router;
 use http_body_util::BodyExt;
-use redact_core::AnalyzerEngine;
-use redact_gateway::config::{ConfigHandle, ResolvedConfig};
+use redact_gateway::config::ResolvedConfig;
 use redact_gateway::policy::{EntityAction, PolicySet, Profile};
-use redact_gateway::proxy::ProviderClient;
-use redact_gateway::redact::token::Dek;
 use redact_gateway::routes::{create_router, AppState};
+use redact_gateway::GatewayServer;
 use serde_json::{json, Value};
 use tower::ServiceExt;
 
@@ -217,30 +215,10 @@ pub fn config_for(upstream: &MockUpstream) -> ResolvedConfig {
 
 /// Build handler state for a configuration.
 pub async fn state_for(config: ResolvedConfig) -> AppState {
-    let provider = ProviderClient::from_settings(&config.provider).unwrap();
-    let telemetry =
-        Arc::new(redact_gateway::telemetry::init(&config.telemetry).expect("telemetry"));
-    let audit = Arc::new(
-        redact_gateway::audit::build_dispatcher(&config.audit, telemetry.logger_provider())
-            .expect("audit"),
-    );
-    let tokens = redact_gateway::vault::build_store(&config.vault)
+    GatewayServer::new(config)
         .await
-        .expect("token map");
-    let auth = redact_gateway::auth::build_authenticator(&config.auth)
-        .await
-        .expect("authenticator");
-
-    AppState {
-        config: ConfigHandle::new(config),
-        engine: Arc::new(AnalyzerEngine::new()),
-        provider,
-        dek: Arc::new(Dek::generate().unwrap()),
-        tokens,
-        auth,
-        audit,
-        telemetry,
-    }
+        .expect("gateway server")
+        .state()
 }
 
 /// Build a router for a configuration.

--- a/crates/redact-ner/src/contextual_identity.rs
+++ b/crates/redact-ner/src/contextual_identity.rs
@@ -733,6 +733,21 @@ fn is_common_non_name(word: &str) -> bool {
             | "sleep"
             | "sleeps"
             | "sleeping"
+            | "love"
+            | "loves"
+            | "loved"
+            | "loving"
+            | "like"
+            | "likes"
+            | "liked"
+            | "eat"
+            | "eats"
+            | "eating"
+            | "ate"
+            | "peace"
+            | "happy"
+            | "sad"
+            | "angry"
     )
 }
 

--- a/crates/redact-ner/src/contextual_identity.rs
+++ b/crates/redact-ner/src/contextual_identity.rs
@@ -1,0 +1,694 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Identity-context parser: names and places only when surrounding language
+//! says they are identity, never from capitalization alone.
+
+use redact_core::{EntityType, RecognizerResult};
+
+const SOURCE: &str = "ContextualIdentity";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Kind {
+    Person,
+    Location,
+}
+
+#[derive(Debug, Clone)]
+struct Hit {
+    kind: Kind,
+    start: usize,
+    end: usize,
+    score: f32,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Token<'a> {
+    start: usize,
+    end: usize,
+    text: &'a str,
+}
+
+pub fn detect_contextual_identities(text: &str) -> Vec<RecognizerResult> {
+    let tokens = tokenize(text);
+    let mut hits: Vec<Hit> = Vec::new();
+
+    collect_greetings(text, &tokens, &mut hits);
+    collect_relationships(text, &tokens, &mut hits);
+    collect_named_called(text, &tokens, &mut hits);
+    collect_pets(text, &tokens, &mut hits);
+    collect_locations(text, &tokens, &mut hits);
+    collect_metro_areas(text, &tokens, &mut hits);
+
+    merge_hits(hits)
+        .into_iter()
+        .map(|h| {
+            let ty = match h.kind {
+                Kind::Person => EntityType::Person,
+                Kind::Location => EntityType::Location,
+            };
+            RecognizerResult::new(ty, h.start, h.end, h.score, SOURCE)
+        })
+        .collect()
+}
+
+fn tokenize(text: &str) -> Vec<Token<'_>> {
+    let mut tokens = Vec::new();
+    let mut start: Option<usize> = None;
+    for (i, ch) in text.char_indices() {
+        if is_word_char(ch) {
+            if start.is_none() {
+                start = Some(i);
+            }
+        } else if let Some(s) = start.take() {
+            tokens.push(Token {
+                start: s,
+                end: i,
+                text: &text[s..i],
+            });
+        }
+    }
+    if let Some(s) = start {
+        tokens.push(Token {
+            start: s,
+            end: text.len(),
+            text: &text[s..],
+        });
+    }
+    tokens
+}
+
+fn is_word_char(ch: char) -> bool {
+    ch.is_alphabetic() || ch == '\'' || ch == '’' || ch == '-'
+}
+
+fn collect_greetings(text: &str, tokens: &[Token<'_>], hits: &mut Vec<Hit>) {
+    for (i, tok) in tokens.iter().enumerate() {
+        if !is_greeting(tok.text) {
+            continue;
+        }
+        if let Some(name) = tokens.get(i + 1) {
+            if accept_name(name.text, NameRule::strong_no_calendar()) {
+                push_hit(hits, Kind::Person, name.start, name.end, 0.93);
+            }
+        }
+        let _ = text;
+    }
+}
+
+fn collect_relationships(text: &str, tokens: &[Token<'_>], hits: &mut Vec<Hit>) {
+    for (i, tok) in tokens.iter().enumerate() {
+        if !is_relationship(tok.text) {
+            continue;
+        }
+        if i == 0 || !is_possessor(tokens[i - 1].text) {
+            continue;
+        }
+        if let Some(name) = next_name_after(text, tokens, i, NameRule::strong_with_calendar()) {
+            push_hit(hits, Kind::Person, name.start, name.end, 0.94);
+        }
+    }
+}
+
+fn collect_named_called(text: &str, tokens: &[Token<'_>], hits: &mut Vec<Hit>) {
+    for (i, tok) in tokens.iter().enumerate() {
+        let lower = tok.text.to_ascii_lowercase();
+        let name_tok = if matches!(lower.as_str(), "named" | "called") {
+            tokens.get(i + 1)
+        } else if lower == "name" {
+            match tokens.get(i + 1) {
+                Some(next)
+                    if next.text.eq_ignore_ascii_case("is")
+                        || next.text.eq_ignore_ascii_case("s") =>
+                {
+                    tokens.get(i + 2)
+                }
+                _ => None,
+            }
+        } else {
+            None
+        };
+        if let Some(name) = name_tok {
+            if accept_name(name.text, NameRule::strong_with_calendar())
+                && !is_inside_skip_parens(text, name.start)
+            {
+                push_hit(hits, Kind::Person, name.start, name.end, 0.94);
+            }
+        }
+    }
+}
+
+fn collect_pets(text: &str, tokens: &[Token<'_>], hits: &mut Vec<Hit>) {
+    for (i, tok) in tokens.iter().enumerate() {
+        if !is_pet(tok.text) {
+            continue;
+        }
+        if colon_after(text, tok.end) {
+            for name in names_in_list(text, tok.end) {
+                push_hit(hits, Kind::Person, name.0, name.1, 0.95);
+            }
+            continue;
+        }
+        let possessed = i > 0 && is_possessor(tokens[i - 1].text);
+        if !possessed {
+            continue;
+        }
+        if let Some(name) = next_name_after(text, tokens, i, NameRule::strong_with_calendar()) {
+            push_hit(hits, Kind::Person, name.start, name.end, 0.95);
+        }
+    }
+}
+
+fn collect_locations(text: &str, tokens: &[Token<'_>], hits: &mut Vec<Hit>) {
+    for (i, tok) in tokens.iter().enumerate() {
+        if !tok.text.eq_ignore_ascii_case("in") && !tok.text.eq_ignore_ascii_case("from") {
+            continue;
+        }
+        if !has_location_verb_before(tokens, i) {
+            continue;
+        }
+        for span in location_phrase(text, tokens, i + 1) {
+            push_hit(hits, Kind::Location, span.0, span.1, 0.93);
+        }
+    }
+}
+
+fn collect_metro_areas(text: &str, tokens: &[Token<'_>], hits: &mut Vec<Hit>) {
+    for (i, tok) in tokens.iter().enumerate() {
+        if !tok.text.eq_ignore_ascii_case("metro") {
+            continue;
+        }
+        let Some(area) = tokens.get(i + 1) else {
+            continue;
+        };
+        if !area.text.eq_ignore_ascii_case("area") {
+            continue;
+        }
+        let Some(name) = tokens.get(i.saturating_sub(1)).filter(|_| i > 0) else {
+            continue;
+        };
+        if accept_name(name.text, NameRule::strong_no_calendar()) {
+            push_hit(hits, Kind::Location, name.start, name.end, 0.92);
+        }
+        let _ = text;
+    }
+}
+
+fn has_location_verb_before(tokens: &[Token<'_>], in_idx: usize) -> bool {
+    let start = in_idx.saturating_sub(4);
+    tokens[start..in_idx]
+        .iter()
+        .any(|t| is_location_verb(t.text))
+}
+
+fn location_phrase(text: &str, tokens: &[Token<'_>], start: usize) -> Vec<(usize, usize)> {
+    let mut out = Vec::new();
+    let mut i = start;
+    while i < tokens.len() {
+        let tok = tokens[i];
+        if is_stop_after_location(tok.text) {
+            break;
+        }
+        if tok.text.eq_ignore_ascii_case("metro") || tok.text.eq_ignore_ascii_case("area") {
+            i += 1;
+            continue;
+        }
+        if !accept_name(tok.text, NameRule::strong_no_calendar()) {
+            // Parenthetical place: "( Riverton metro area )"
+            if text.get(tok.start.saturating_sub(2)..tok.start).is_some() {
+                i += 1;
+                continue;
+            }
+            break;
+        }
+        let mut end = tok.end;
+        let span_start = tok.start;
+        let mut j = i + 1;
+        while j < tokens.len() {
+            let nxt = tokens[j];
+            if between_is_space_only(text, end, nxt.start)
+                && accept_name(nxt.text, NameRule::strong_no_calendar())
+                && !nxt.text.eq_ignore_ascii_case("metro")
+                && !nxt.text.eq_ignore_ascii_case("area")
+            {
+                end = nxt.end;
+                j += 1;
+                continue;
+            }
+            break;
+        }
+        out.push((span_start, end));
+        i = j;
+        // comma-separated next place is allowed; other punctuation stops
+        if i < tokens.len() {
+            let gap = &text[end..tokens[i].start];
+            if gap.contains('.') || gap.contains(';') {
+                break;
+            }
+            if !gap.contains(',') && !gap.contains('(') && !gap.chars().all(|c| c.is_whitespace()) {
+                // leftover words like "I" after the phrase
+                if is_stop_after_location(tokens[i].text) {
+                    break;
+                }
+            }
+        }
+    }
+    out
+}
+
+fn between_is_space_only(text: &str, start: usize, end: usize) -> bool {
+    text.get(start..end)
+        .is_some_and(|g| !g.is_empty() && g.chars().all(|c| c.is_whitespace()))
+}
+
+fn next_name_after<'a>(
+    text: &str,
+    tokens: &'a [Token<'a>],
+    after_idx: usize,
+    rule: NameRule,
+) -> Option<Token<'a>> {
+    let name = tokens.get(after_idx + 1)?;
+    if is_inside_skip_parens(text, name.start) {
+        return None;
+    }
+    if accept_name(name.text, rule) {
+        Some(*name)
+    } else {
+        None
+    }
+}
+
+fn names_in_list(text: &str, after_pet_end: usize) -> Vec<(usize, usize)> {
+    let Some(colon) = text[after_pet_end..].find(':') else {
+        return Vec::new();
+    };
+    let mut idx = after_pet_end + colon + 1;
+    let mut out = Vec::new();
+    while idx < text.len() {
+        idx = skip_ws(text, idx);
+        if idx >= text.len() {
+            break;
+        }
+        if text[idx..].starts_with('(') {
+            idx = skip_parens(text, idx);
+            continue;
+        }
+        let rest = &text[idx..];
+        if rest.is_empty() {
+            break;
+        }
+        let ch = rest.chars().next().unwrap();
+        if !ch.is_alphabetic() {
+            if ch == '.' || ch == ';' {
+                break;
+            }
+            idx += ch.len_utf8();
+            continue;
+        }
+        let token_end = rest
+            .char_indices()
+            .find(|(_, c)| !is_word_char(*c))
+            .map(|(i, _)| idx + i)
+            .unwrap_or(text.len());
+        let word = &text[idx..token_end];
+        if word.eq_ignore_ascii_case("and") || word.eq_ignore_ascii_case("or") {
+            idx = token_end;
+            continue;
+        }
+        if accept_name(word, NameRule::strong_with_calendar()) {
+            out.push((idx, token_end));
+        }
+        idx = token_end;
+        idx = skip_ws(text, idx);
+        if text[idx..].starts_with('(') {
+            idx = skip_parens(text, idx);
+        }
+    }
+    out
+}
+
+fn colon_after(text: &str, end: usize) -> bool {
+    let rest = text[end..].trim_start();
+    rest.starts_with(':')
+}
+
+fn skip_ws(text: &str, mut idx: usize) -> usize {
+    while idx < text.len() {
+        let ch = text[idx..].chars().next().unwrap();
+        if !ch.is_whitespace() {
+            break;
+        }
+        idx += ch.len_utf8();
+    }
+    idx
+}
+
+fn skip_parens(text: &str, start: usize) -> usize {
+    if !text[start..].starts_with('(') {
+        return start;
+    }
+    let mut depth = 0;
+    for (i, ch) in text[start..].char_indices() {
+        if ch == '(' {
+            depth += 1;
+        } else if ch == ')' {
+            depth -= 1;
+            if depth == 0 {
+                return start + i + 1;
+            }
+        }
+    }
+    text.len()
+}
+
+fn is_inside_skip_parens(text: &str, pos: usize) -> bool {
+    let mut depth = 0;
+    for (i, ch) in text.char_indices() {
+        if i >= pos {
+            return depth > 0;
+        }
+        if ch == '(' {
+            depth += 1;
+        } else if ch == ')' && depth > 0 {
+            depth -= 1;
+        }
+    }
+    false
+}
+
+fn push_hit(hits: &mut Vec<Hit>, kind: Kind, start: usize, end: usize, score: f32) {
+    if start >= end {
+        return;
+    }
+    hits.push(Hit {
+        kind,
+        start,
+        end,
+        score,
+    });
+}
+
+fn merge_hits(mut hits: Vec<Hit>) -> Vec<Hit> {
+    hits.sort_by_key(|h| (h.start, h.end));
+    let mut out: Vec<Hit> = Vec::new();
+    for hit in hits {
+        if let Some(prev) = out.last_mut() {
+            if hit.start < prev.end {
+                // Overlap: explicit kind already stored wins; extend span if needed.
+                if hit.kind == prev.kind {
+                    prev.end = prev.end.max(hit.end);
+                    prev.score = prev.score.max(hit.score);
+                }
+                continue;
+            }
+        }
+        out.push(hit);
+    }
+    out
+}
+
+#[derive(Clone, Copy)]
+struct NameRule {
+    allow_calendar: bool,
+}
+
+impl NameRule {
+    fn strong_with_calendar() -> Self {
+        Self {
+            allow_calendar: true,
+        }
+    }
+    fn strong_no_calendar() -> Self {
+        Self {
+            allow_calendar: false,
+        }
+    }
+}
+
+fn accept_name(word: &str, rule: NameRule) -> bool {
+    if word.chars().count() < 2 {
+        return false;
+    }
+    if is_function_word(word) || is_name_keyword(word) {
+        return false;
+    }
+    if is_calendar(word) && !rule.allow_calendar {
+        return false;
+    }
+    word.chars()
+        .all(|c| c.is_alphabetic() || c == '\'' || c == '’' || c == '-')
+}
+
+fn is_greeting(word: &str) -> bool {
+    matches!(
+        word.to_ascii_lowercase().as_str(),
+        "hi" | "hello" | "hey" | "dear" | "hiya"
+    )
+}
+
+fn is_possessor(word: &str) -> bool {
+    matches!(
+        word.to_ascii_lowercase().as_str(),
+        "my" | "our" | "his" | "her" | "their" | "a" | "an" | "the"
+    )
+}
+
+fn is_relationship(word: &str) -> bool {
+    matches!(
+        word.to_ascii_lowercase().as_str(),
+        "wife"
+            | "husband"
+            | "daughter"
+            | "son"
+            | "mother"
+            | "father"
+            | "sister"
+            | "brother"
+            | "friend"
+            | "partner"
+            | "colleague"
+            | "child"
+            | "children"
+            | "kid"
+            | "kids"
+            | "parent"
+            | "parents"
+            | "mom"
+            | "dad"
+            | "mum"
+            | "mommy"
+            | "mummy"
+            | "aunt"
+            | "uncle"
+            | "niece"
+            | "nephew"
+            | "cousin"
+            | "grandmother"
+            | "grandfather"
+            | "grandma"
+            | "grandpa"
+            | "spouse"
+            | "girlfriend"
+            | "boyfriend"
+            | "roommate"
+            | "neighbor"
+            | "neighbour"
+            | "boss"
+            | "teacher"
+            | "student"
+            | "doctor"
+            | "lawyer"
+            | "client"
+            | "customer"
+            | "fiance"
+            | "fiancee"
+            | "fiancé"
+            | "fiancée"
+    )
+}
+
+fn is_pet(word: &str) -> bool {
+    matches!(
+        word.to_ascii_lowercase().as_str(),
+        "cat"
+            | "cats"
+            | "dog"
+            | "dogs"
+            | "puppy"
+            | "puppies"
+            | "kitten"
+            | "kittens"
+            | "pet"
+            | "pets"
+            | "horse"
+            | "horses"
+            | "bird"
+            | "birds"
+            | "fish"
+            | "hamster"
+            | "hamsters"
+            | "rabbit"
+            | "rabbits"
+            | "gerbil"
+            | "ferret"
+            | "parrot"
+            | "pony"
+            | "goldfish"
+    )
+}
+
+fn is_location_verb(word: &str) -> bool {
+    matches!(
+        word.to_ascii_lowercase().as_str(),
+        "live"
+            | "lives"
+            | "lived"
+            | "living"
+            | "based"
+            | "located"
+            | "stay"
+            | "staying"
+            | "stayed"
+            | "moved"
+            | "moving"
+            | "reside"
+            | "resides"
+            | "residing"
+            | "relocated"
+    )
+}
+
+fn is_stop_after_location(word: &str) -> bool {
+    matches!(
+        word.to_ascii_lowercase().as_str(),
+        "i" | "we"
+            | "you"
+            | "they"
+            | "he"
+            | "she"
+            | "it"
+            | "and"
+            | "but"
+            | "the"
+            | "a"
+            | "an"
+            | "my"
+            | "our"
+            | "with"
+            | "where"
+            | "when"
+            | "who"
+    )
+}
+
+fn is_name_keyword(word: &str) -> bool {
+    matches!(
+        word.to_ascii_lowercase().as_str(),
+        "named" | "called" | "name" | "names" | "call"
+    )
+}
+
+fn is_function_word(word: &str) -> bool {
+    matches!(
+        word.to_ascii_lowercase().as_str(),
+        "the"
+            | "a"
+            | "an"
+            | "and"
+            | "or"
+            | "of"
+            | "in"
+            | "on"
+            | "at"
+            | "to"
+            | "for"
+            | "with"
+            | "from"
+            | "by"
+            | "as"
+            | "is"
+            | "was"
+            | "are"
+            | "were"
+            | "be"
+            | "been"
+            | "this"
+            | "that"
+            | "these"
+            | "those"
+            | "it"
+            | "we"
+            | "you"
+            | "they"
+            | "he"
+            | "she"
+            | "i"
+            | "my"
+            | "our"
+            | "their"
+            | "his"
+            | "her"
+            | "me"
+            | "us"
+            | "them"
+            | "there"
+            | "here"
+            | "now"
+            | "then"
+            | "back"
+            | "all"
+            | "day"
+            | "earlier"
+            | "later"
+            | "today"
+            | "tomorrow"
+            | "yesterday"
+    )
+}
+
+fn is_calendar(word: &str) -> bool {
+    matches!(
+        word.to_ascii_lowercase().as_str(),
+        "monday"
+            | "tuesday"
+            | "wednesday"
+            | "thursday"
+            | "friday"
+            | "saturday"
+            | "sunday"
+            | "mondays"
+            | "tuesdays"
+            | "wednesdays"
+            | "thursdays"
+            | "fridays"
+            | "saturdays"
+            | "sundays"
+            | "january"
+            | "february"
+            | "march"
+            | "april"
+            | "may"
+            | "june"
+            | "july"
+            | "august"
+            | "september"
+            | "october"
+            | "november"
+            | "december"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tokenize_keeps_offsets() {
+        let text = "Hi Ada";
+        let toks = tokenize(text);
+        assert_eq!(toks[0].text, "Hi");
+        assert_eq!(toks[1].text, "Ada");
+        assert_eq!(&text[toks[1].start..toks[1].end], "Ada");
+    }
+}

--- a/crates/redact-ner/src/contextual_identity.rs
+++ b/crates/redact-ner/src/contextual_identity.rs
@@ -316,9 +316,10 @@ fn names_in_list(text: &str, after_pet_end: usize) -> Vec<(usize, usize)> {
             idx = token_end;
             continue;
         }
-        if accept_name(word, NameRule::strong_with_calendar()) {
-            out.push((idx, token_end));
+        if !accept_name(word, NameRule::strong_with_calendar()) {
+            break;
         }
+        out.push((idx, token_end));
         idx = token_end;
         idx = skip_ws(text, idx);
         if text[idx..].starts_with('(') {
@@ -430,7 +431,7 @@ fn accept_name(word: &str, rule: NameRule) -> bool {
     if word.chars().count() < 2 {
         return false;
     }
-    if is_function_word(word) || is_name_keyword(word) {
+    if is_function_word(word) || is_name_keyword(word) || is_common_non_name(word) {
         return false;
     }
     if is_calendar(word) && !rule.allow_calendar {
@@ -644,6 +645,94 @@ fn is_function_word(word: &str) -> bool {
             | "today"
             | "tomorrow"
             | "yesterday"
+    )
+}
+
+/// Ordinary English that identity cues must not treat as a name or place.
+fn is_common_non_name(word: &str) -> bool {
+    matches!(
+        word.to_ascii_lowercase().as_str(),
+        "starts"
+            | "start"
+            | "started"
+            | "starting"
+            | "school"
+            | "schools"
+            | "constant"
+            | "fear"
+            | "fears"
+            | "loud"
+            | "quiet"
+            | "quietly"
+            | "always"
+            | "never"
+            | "still"
+            | "also"
+            | "very"
+            | "just"
+            | "only"
+            | "even"
+            | "really"
+            | "about"
+            | "into"
+            | "over"
+            | "under"
+            | "after"
+            | "before"
+            | "because"
+            | "while"
+            | "though"
+            | "although"
+            | "unless"
+            | "until"
+            | "since"
+            | "during"
+            | "without"
+            | "within"
+            | "between"
+            | "through"
+            | "across"
+            | "around"
+            | "against"
+            | "along"
+            | "behind"
+            | "go"
+            | "goes"
+            | "going"
+            | "went"
+            | "come"
+            | "comes"
+            | "coming"
+            | "came"
+            | "get"
+            | "gets"
+            | "getting"
+            | "got"
+            | "make"
+            | "makes"
+            | "made"
+            | "take"
+            | "takes"
+            | "took"
+            | "see"
+            | "sees"
+            | "saw"
+            | "know"
+            | "knows"
+            | "think"
+            | "thinks"
+            | "want"
+            | "wants"
+            | "need"
+            | "needs"
+            | "work"
+            | "works"
+            | "working"
+            | "play"
+            | "plays"
+            | "sleep"
+            | "sleeps"
+            | "sleeping"
     )
 }
 

--- a/crates/redact-ner/src/identity.rs
+++ b/crates/redact-ner/src/identity.rs
@@ -72,7 +72,18 @@ impl IdentityRecognizer {
             return Ok(Self::contextual_only());
         }
 
-        let ner = NerRecognizer::from_file(&path)?;
+        let ner = match NerRecognizer::from_file(&path) {
+            Ok(ner) => ner,
+            Err(err) if !opts.required => {
+                warn!(
+                    path = %path.display(),
+                    error = %err,
+                    "ONNX NER failed to load; identity recognizer is contextual only"
+                );
+                return Ok(Self::contextual_only());
+            }
+            Err(err) => return Err(err),
+        };
         if !ner.is_available() {
             if opts.required {
                 bail!(

--- a/crates/redact-ner/src/identity.rs
+++ b/crates/redact-ner/src/identity.rs
@@ -1,0 +1,225 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Hybrid identity recognizer: identity-context parser plus optional ONNX NER.
+//!
+//! Explicit relationship / location / pet context wins over NER. NER fills
+//! ORGANIZATION and bare proper names the parser will not invent from
+//! capitalization. Production gateways set `required=true` so a missing model
+//! fails startup instead of silently dropping NER.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Result};
+use redact_core::{EntityType, Recognizer, RecognizerResult};
+use tracing::{info, warn};
+
+use crate::contextual_identity::detect_contextual_identities;
+use crate::recognizer::NerRecognizer;
+
+/// How ONNX NER is loaded for [`IdentityRecognizer`].
+#[derive(Debug, Clone, Default)]
+pub struct IdentityNerOptions {
+    /// Path to `model.onnx`. Tokenizer is discovered beside it.
+    pub model_path: Option<PathBuf>,
+    /// When true, missing or unloadable NER fails construction.
+    pub required: bool,
+}
+
+/// PERSON / LOCATION / ORGANIZATION recognizer used by redact-gateway.
+pub struct IdentityRecognizer {
+    ner: Option<NerRecognizer>,
+}
+
+impl std::fmt::Debug for IdentityRecognizer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IdentityRecognizer")
+            .field(
+                "ner_available",
+                &self.ner.as_ref().is_some_and(|n| n.is_available()),
+            )
+            .finish()
+    }
+}
+
+impl IdentityRecognizer {
+    /// Contextual parser only. Used by tests and local gateways without a model.
+    pub fn contextual_only() -> Self {
+        Self { ner: None }
+    }
+
+    /// Load NER from options. Contextual detection always runs.
+    pub fn from_options(opts: IdentityNerOptions) -> Result<Self> {
+        let Some(path) = opts.model_path.filter(|p| !p.as_os_str().is_empty()) else {
+            if opts.required {
+                bail!("CENSGATE_NER_REQUIRED is set but CENSGATE_NER_MODEL_PATH is empty");
+            }
+            info!("identity recognizer: contextual only (no NER model path)");
+            return Ok(Self::contextual_only());
+        };
+        if !path.exists() {
+            if opts.required {
+                bail!(
+                    "CENSGATE_NER_REQUIRED is set but NER model is missing: {}",
+                    path.display()
+                );
+            }
+            warn!(
+                path = %path.display(),
+                "NER model path does not exist; identity recognizer is contextual only"
+            );
+            return Ok(Self::contextual_only());
+        }
+
+        let ner = NerRecognizer::from_file(&path)?;
+        if !ner.is_available() {
+            if opts.required {
+                bail!(
+                    "CENSGATE_NER_REQUIRED is set but ONNX NER did not become available at {}",
+                    path.display()
+                );
+            }
+            warn!(
+                path = %path.display(),
+                "ONNX NER failed to load; identity recognizer is contextual only"
+            );
+            return Ok(Self::contextual_only());
+        }
+        info!(path = %path.display(), "identity recognizer: contextual + ONNX NER");
+        Ok(Self { ner: Some(ner) })
+    }
+
+    /// Optional load from `CENSGATE_NER_MODEL_PATH` (never required).
+    pub fn from_env_optional() -> Option<Self> {
+        let path = std::env::var("CENSGATE_NER_MODEL_PATH").ok()?;
+        if path.trim().is_empty() {
+            return None;
+        }
+        Self::from_options(IdentityNerOptions {
+            model_path: Some(PathBuf::from(path)),
+            required: false,
+        })
+        .ok()
+    }
+
+    /// True when an ONNX session is ready.
+    pub fn ner_available(&self) -> bool {
+        self.ner.as_ref().is_some_and(|n| n.is_available())
+    }
+
+    /// Convenience wrapper around [`Self::from_options`].
+    pub fn from_model_path(path: impl AsRef<Path>, required: bool) -> Result<Self> {
+        Self::from_options(IdentityNerOptions {
+            model_path: Some(path.as_ref().to_path_buf()),
+            required,
+        })
+    }
+}
+
+impl Recognizer for IdentityRecognizer {
+    fn name(&self) -> &str {
+        "IdentityRecognizer"
+    }
+
+    fn supported_entities(&self) -> &[EntityType] {
+        &[
+            EntityType::Person,
+            EntityType::Location,
+            EntityType::Organization,
+        ]
+    }
+
+    fn analyze(&self, text: &str, language: &str) -> Result<Vec<RecognizerResult>> {
+        let contextual = detect_contextual_identities(text);
+        let ner = match &self.ner {
+            Some(ner) if ner.is_available() => ner.analyze(text, language)?,
+            _ => Vec::new(),
+        };
+        Ok(merge_identity(contextual, ner))
+    }
+
+    fn supports_language(&self, language: &str) -> bool {
+        matches!(
+            language,
+            "en" | "es" | "fr" | "de" | "it" | "pt" | "nl" | "pl" | "ru" | "zh" | "ja" | "ko"
+        )
+    }
+}
+
+/// Context detections win on overlap. NER-only spans (ORG, uncovered names)
+/// are kept. DATE_TIME from NER is dropped here — pattern packs own dates.
+fn merge_identity(
+    contextual: Vec<RecognizerResult>,
+    ner: Vec<RecognizerResult>,
+) -> Vec<RecognizerResult> {
+    let mut out = contextual;
+    for candidate in ner {
+        match candidate.entity_type {
+            EntityType::Person | EntityType::Location | EntityType::Organization => {}
+            _ => continue,
+        }
+        if out
+            .iter()
+            .any(|existing| existing.overlaps_with(&candidate))
+        {
+            continue;
+        }
+        out.push(candidate);
+    }
+    out.sort_by_key(|r| (r.start, r.end));
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn required_without_path_fails() {
+        let err = IdentityRecognizer::from_options(IdentityNerOptions {
+            model_path: None,
+            required: true,
+        })
+        .unwrap_err();
+        assert!(err.to_string().contains("CENSGATE_NER_REQUIRED"));
+    }
+
+    #[test]
+    fn required_missing_file_fails() {
+        let err = IdentityRecognizer::from_model_path("/nonexistent/model.onnx", true).unwrap_err();
+        assert!(err.to_string().contains("missing"));
+    }
+
+    #[test]
+    fn optional_missing_file_is_contextual() {
+        let rec = IdentityRecognizer::from_model_path("/nonexistent/model.onnx", false).unwrap();
+        assert!(!rec.ner_available());
+        assert_eq!(
+            rec.analyze("Hi Ada", "en").unwrap()[0].entity_type,
+            EntityType::Person
+        );
+    }
+
+    #[test]
+    fn context_wins_over_conflicting_ner_span() {
+        let contextual = vec![RecognizerResult::new(
+            EntityType::Location,
+            12,
+            18,
+            0.9,
+            "ctx",
+        )];
+        let ner = vec![RecognizerResult::new(
+            EntityType::Person,
+            12,
+            18,
+            0.99,
+            "ner",
+        )];
+        let merged = merge_identity(contextual, ner);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].entity_type, EntityType::Location);
+        assert_eq!(merged[0].recognizer_name, "ctx");
+    }
+}

--- a/crates/redact-ner/src/lib.rs
+++ b/crates/redact-ner/src/lib.rs
@@ -32,9 +32,12 @@
 //! }
 //! ```
 
+mod contextual_identity;
+mod identity;
 mod recognizer;
 mod tokenizer_wrapper;
 
+pub use identity::{IdentityNerOptions, IdentityRecognizer};
 pub use recognizer::{NerConfig, NerRecognizer};
 
 #[cfg(test)]

--- a/crates/redact-ner/tests/identity_golden.rs
+++ b/crates/redact-ner/tests/identity_golden.rs
@@ -109,6 +109,17 @@ fn capitalization_alone_never_creates_an_entity() {
 }
 
 #[test]
+fn common_words_after_identity_cues_are_not_names() {
+    let rec = IdentityRecognizer::contextual_only();
+    assert!(spans(&rec, "my daughter starts school").is_empty());
+    assert!(spans(&rec, "we live in constant fear").is_empty());
+    assert_eq!(
+        types_of(&rec, "my pets: Nola and Pip are loud", EntityType::Person),
+        vec!["Nola".to_string(), "Pip".to_string()]
+    );
+}
+
+#[test]
 fn named_and_called_are_strong_person_context() {
     let rec = IdentityRecognizer::contextual_only();
     assert_eq!(

--- a/crates/redact-ner/tests/identity_golden.rs
+++ b/crates/redact-ner/tests/identity_golden.rs
@@ -112,7 +112,10 @@ fn capitalization_alone_never_creates_an_entity() {
 fn common_words_after_identity_cues_are_not_names() {
     let rec = IdentityRecognizer::contextual_only();
     assert!(spans(&rec, "my daughter starts school").is_empty());
+    assert!(spans(&rec, "my daughter loves school").is_empty());
     assert!(spans(&rec, "we live in constant fear").is_empty());
+    assert!(spans(&rec, "we live in peace now").is_empty());
+    assert!(spans(&rec, "my cat eats tuna").is_empty());
     assert_eq!(
         types_of(&rec, "my pets: Nola and Pip are loud", EntityType::Person),
         vec!["Nola".to_string(), "Pip".to_string()]

--- a/crates/redact-ner/tests/identity_golden.rs
+++ b/crates/redact-ner/tests/identity_golden.rs
@@ -1,0 +1,149 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Golden cases for hybrid identity detection (contextual + optional ONNX NER).
+//!
+//! Contextual-only covers the household-identity paragraph and the
+//! adversarial table. ONNX cases run only when `CENSGATE_NER_MODEL_PATH`
+//! points at a loadable model so CI without the artifact still stays green.
+
+use redact_core::{EntityType, Recognizer};
+use redact_ner::IdentityRecognizer;
+
+const CATS_PARAGRAPH: &str = "I have two female cats: Nola ( black American short hair, 12 ) and Pip ( ginger tabby, 3 ). We live in Cedar Hollow, Caledonia ( Riverton metro area ). I have a wife and a daughter ( 11 ).";
+
+fn spans(rec: &IdentityRecognizer, text: &str) -> Vec<(EntityType, String)> {
+    rec.analyze(text, "en")
+        .unwrap()
+        .into_iter()
+        .map(|r| (r.entity_type, text[r.start..r.end].to_string()))
+        .collect()
+}
+
+fn types_of(rec: &IdentityRecognizer, text: &str, ty: EntityType) -> Vec<String> {
+    spans(rec, text)
+        .into_iter()
+        .filter(|(t, _)| *t == ty)
+        .map(|(_, s)| s)
+        .collect()
+}
+
+#[test]
+fn cats_paragraph_tokenizes_pets_and_places_not_american() {
+    let rec = IdentityRecognizer::contextual_only();
+    let people = types_of(&rec, CATS_PARAGRAPH, EntityType::Person);
+    let places = types_of(&rec, CATS_PARAGRAPH, EntityType::Location);
+
+    assert_eq!(people, vec!["Nola".to_string(), "Pip".to_string()]);
+    assert_eq!(
+        places,
+        vec![
+            "Cedar Hollow".to_string(),
+            "Caledonia".to_string(),
+            "Riverton".to_string()
+        ]
+    );
+    assert!(!spans(&rec, CATS_PARAGRAPH)
+        .iter()
+        .any(|(_, t)| t == "American"));
+}
+
+#[test]
+fn weekdays_without_identity_context_are_left_alone() {
+    let rec = IdentityRecognizer::contextual_only();
+    assert!(spans(&rec, "I work Mondays and Fridays.").is_empty());
+}
+
+#[test]
+fn greeting_and_relationship_yield_person() {
+    let rec = IdentityRecognizer::contextual_only();
+    assert_eq!(
+        types_of(&rec, "Hi Ada, welcome back.", EntityType::Person),
+        vec!["Ada".to_string()]
+    );
+    assert_eq!(
+        types_of(&rec, "my daughter Ada called earlier", EntityType::Person),
+        vec!["Ada".to_string()]
+    );
+}
+
+#[test]
+fn pet_context_emits_person_including_calendar_words() {
+    let rec = IdentityRecognizer::contextual_only();
+    assert_eq!(
+        types_of(&rec, "my cat pip is loud", EntityType::Person),
+        vec!["pip".to_string()]
+    );
+    assert_eq!(
+        types_of(&rec, "my cat Monday sleeps all day", EntityType::Person),
+        vec!["Monday".to_string()]
+    );
+}
+
+#[test]
+fn jordan_type_follows_local_context_not_a_global_rank() {
+    let rec = IdentityRecognizer::contextual_only();
+    assert_eq!(
+        types_of(&rec, "we live in jordan now", EntityType::Location),
+        vec!["jordan".to_string()]
+    );
+    assert_eq!(
+        types_of(&rec, "my daughter Jordan starts school", EntityType::Person),
+        vec!["Jordan".to_string()]
+    );
+    assert!(types_of(&rec, "we live in jordan now", EntityType::Person).is_empty());
+    assert!(types_of(
+        &rec,
+        "my daughter Jordan starts school",
+        EntityType::Location
+    )
+    .is_empty());
+}
+
+#[test]
+fn capitalization_alone_never_creates_an_entity() {
+    let rec = IdentityRecognizer::contextual_only();
+    assert!(spans(&rec, "Please review the Quarterly Report on Mondays.").is_empty());
+    assert!(spans(&rec, "ada").is_empty());
+}
+
+#[test]
+fn named_and_called_are_strong_person_context() {
+    let rec = IdentityRecognizer::contextual_only();
+    assert_eq!(
+        types_of(&rec, "a colleague named Ada joined", EntityType::Person),
+        vec!["Ada".to_string()]
+    );
+    assert_eq!(
+        types_of(&rec, "the stray is called pip", EntityType::Person),
+        vec!["pip".to_string()]
+    );
+}
+
+#[test]
+fn onnx_org_and_bare_apple_when_model_present() {
+    let Some(rec) = IdentityRecognizer::from_env_optional() else {
+        return;
+    };
+    if !rec.ner_available() {
+        return;
+    }
+
+    let org = types_of(
+        &rec,
+        "Apple released iOS last week",
+        EntityType::Organization,
+    );
+    assert!(
+        org.iter().any(|s| s.eq_ignore_ascii_case("Apple")),
+        "expected ONNX to tag Apple as ORGANIZATION, got {org:?}"
+    );
+
+    let ate = spans(&rec, "I ate an apple");
+    assert!(
+        !ate.iter()
+            .any(|(ty, s)| *ty == EntityType::Organization && s.eq_ignore_ascii_case("apple")),
+        "food apple must not become ORGANIZATION: {ate:?}"
+    );
+}

--- a/data/facts.json
+++ b/data/facts.json
@@ -70,8 +70,8 @@
     "patterns/pii/global_pii.yaml",
     "patterns/security/credentials.yaml"
   ],
-  "pattern_count": 82,
-  "pattern_count_enabled": 71,
+  "pattern_count": 81,
+  "pattern_count_enabled": 70,
   "optional_pack_rule_count": 25,
   "optional_pack_rule_count_enabled": 25
 }

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -188,6 +188,8 @@ Each setting has exactly one environment name under the `CENSGATE_` prefix. The 
 | `CENSGATE_ALLOW_PROFILE_HEADER` | `false` | Honor profile header |
 | `CENSGATE_PATTERN_PACKS` | unset | Pack paths (`:` / `,` / `;`) |
 | `CENSGATE_DISABLE_BUILTIN_PATTERNS` | `false` | Skip built-in patterns |
+| `CENSGATE_NER_MODEL_PATH` | unset | Path to ONNX `model.onnx` (tokenizer beside it) |
+| `CENSGATE_NER_REQUIRED` | `false` | Fail startup if NER cannot load |
 | `CENSGATE_VAULT_BACKEND` | `off` | Token map backend (`off`, `memory`, `vault_kv2`) |
 | `CENSGATE_VAULT_ADDR` / `VAULT_ADDR` / `BAO_ADDR` | unset | KV v2 address |
 | `CENSGATE_VAULT_TOKEN` / `VAULT_TOKEN` / `BAO_TOKEN` | unset | KV v2 token |

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -65,6 +65,7 @@ On Unix, the binary listens for `SIGHUP` and reloads configuration from the same
 | `audit.include_entity_types` | All auth settings (`auth.mode`, `auth.api_keys`, `auth.oidc.*`) |
 | | Audit sink and queue (`audit.export`, `audit.file_path`, `audit.queue_capacity`) |
 | | Telemetry span filter (`telemetry.filter`) |
+| | NER model load (`ner.model_path`, `ner.required`, `CENSGATE_NER_MODEL_PATH`, `CENSGATE_NER_REQUIRED`) |
 
 Reload installs an **effective** snapshot: hot fields from the new document, startup-only fields forced from the running process. That keeps `/readyz` auth mode and `forward_client_authorization` aligned with the frozen authenticator and provider client. Treat sealing-key rotation and token-map address changes as a rolling restart when you need a hard cutover.
 
@@ -133,6 +134,10 @@ telemetry:
   operations: basic                # off | basic | detailed
   filter: null
   genai_attributes: false
+
+ner:
+  model_path: null                 # or CENSGATE_NER_MODEL_PATH; restart-required
+  required: false                  # CENSGATE_NER_REQUIRED; fail startup if model missing
 
 # Choose one of:
 policy:                            # inline PolicySet

--- a/patterns/pii/global_pii.yaml
+++ b/patterns/pii/global_pii.yaml
@@ -7,19 +7,10 @@ description: "Universal patterns for detecting common personally identifiable in
 last_updated: "2024-01-15"
 
 patterns:
-  # Names
-  - id: "global_full_name"
-    name: "Full Name"
-    category: "personal_name"
-    regex: '\b[A-Z][a-z]{1,20}\s+[A-Z][a-z]{1,20}(?:\s+[A-Z][a-z]{1,20})?\b'
-    confidence: 0.7
-    description: "Detects full names (first and last, optionally middle)"
-    examples:
-      - "John Smith"
-      - "Mary Jane Watson"
-      - "José García"
-    replacement: "[NAME_REDACTED]"
-    enabled: true
+  # Personal names are detected by the gateway IdentityRecognizer
+  # (contextual cues + ONNX NER). A Title-case regex is not used: it
+  # false-positives on "Cedar Hollow" / "Mondays and Fridays" and misses
+  # single-token names such as Nola.
 
   - id: "global_email"
     name: "Email Address"
@@ -261,10 +252,10 @@ metadata:
     - "identifier"
     - "security"
   risk_levels:
-    high: ["global_full_name", "global_email", "global_credit_card", "global_iban"]
+    high: ["global_email", "global_credit_card", "global_iban"]
     medium: ["global_phone_intl", "global_phone_common", "global_coordinates", "global_api_key"]
     low: ["global_date_iso", "global_ipv4", "global_mac_address", "global_uuid", "global_hash_md5"]
   validation:
-    pattern_count: 17
+    pattern_count: 16
     categories_covered: 8
     compliance_score: 0.94

--- a/scripts/ci/smoke-gateway.sh
+++ b/scripts/ci/smoke-gateway.sh
@@ -100,4 +100,21 @@ if '[PERSON' not in text or '[LOCATION' not in text:
 print('OK: identity names and places replaced')
 "
 
+echo "--- Organization (ONNX when baked in) ---"
+ORG_BODY="$(curl -sf "${BASE}/v1/redact" \
+  -H 'content-type: application/json' \
+  -d '{"text":"Apple released iOS last week"}')"
+echo "${ORG_BODY}" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+text = data.get('text', '')
+if 'Apple' in text and '[ORGANIZATION' not in text and '[PERSON' not in text:
+    # Contextual-only builds skip this; NER-baked images must tokenize Apple.
+    print('SKIP: no NER organization hit (contextual-only image)')
+    raise SystemExit(0)
+if 'Apple' in text:
+    raise SystemExit('ERROR: plaintext Apple still present: %s' % text)
+print('OK: organization tokenized')
+"
+
 echo "OK: gateway smoke passed (${IMAGE})"

--- a/scripts/ci/smoke-gateway.sh
+++ b/scripts/ci/smoke-gateway.sh
@@ -108,13 +108,13 @@ echo "${ORG_BODY}" | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
 text = data.get('text', '')
+if '[ORGANIZATION' in text and 'Apple' not in text:
+    print('OK: organization tokenized')
+    raise SystemExit(0)
 if 'Apple' in text and '[ORGANIZATION' not in text and '[PERSON' not in text:
-    # Contextual-only builds skip this; NER-baked images must tokenize Apple.
     print('SKIP: no NER organization hit (contextual-only image)')
     raise SystemExit(0)
-if 'Apple' in text:
-    raise SystemExit('ERROR: plaintext Apple still present: %s' % text)
-print('OK: organization tokenized')
+raise SystemExit('ERROR: expected Apple as ORGANIZATION, got: %s' % text)
 "
 
 echo "OK: gateway smoke passed (${IMAGE})"

--- a/scripts/ci/smoke-gateway.sh
+++ b/scripts/ci/smoke-gateway.sh
@@ -81,4 +81,23 @@ if email_replace < 1:
 print('OK: blocked=true, original text preserved, email counted as replace')
 "
 
+echo "--- Identity (contextual; ONNX when baked in) ---"
+IDENTITY_BODY="$(curl -sf "${BASE}/v1/redact" \
+  -H 'content-type: application/json' \
+  -d '{"text":"Hi Ada. I have two female cats: Nola and Pip. We live in Cedar Hollow, Caledonia."}')"
+echo "${IDENTITY_BODY}" | python3 -m json.tool
+echo "${IDENTITY_BODY}" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+text = data.get('text', '')
+if data.get('blocked') is not False:
+    raise SystemExit('ERROR: identity request must set blocked=false, got ' + repr(data.get('blocked')))
+for leaked in ('Ada', 'Nola', 'Pip', 'Cedar Hollow', 'Caledonia'):
+    if leaked in text:
+        raise SystemExit('ERROR: plaintext %s still present: %s' % (leaked, text))
+if '[PERSON' not in text or '[LOCATION' not in text:
+    raise SystemExit('ERROR: expected PERSON and LOCATION placeholders, got: ' + text)
+print('OK: identity names and places replaced')
+"
+
 echo "OK: gateway smoke passed (${IMAGE})"


### PR DESCRIPTION
- [x] I have read [CLA.md](../CLA.md) and will sign the Individual CLA via the bot comment (or I have already signed). A Corporate CLA, if required, does not replace the Individual CLA.
- [ ] All commits are DCO-signed (`git commit -s`)
- [x] I have read [docs/PROJECT_SCOPE.md](../docs/PROJECT_SCOPE.md); this change is in scope

**Employer time or equipment**

- [x] No — this work was not done on employer time or equipment
- [ ] Yes — my employer has authorised the contribution, or a Corporate CLA is on file

## Summary

The Title-case `global_full_name` regex labeled multi-word place names such as `Cedar Hollow` as `PERSON` and missed single-token given names. This PR replaces that regex with hybrid identity detection.

- Removes `global_full_name`. Capitalization alone never creates an entity.
- Adds `IdentityRecognizer`: an identity-context parser plus optional ONNX NER.
- Pet-context names (`my cat Pip`, `two female cats: Nola and Pip`) emit **PERSON**. There is no `PET_NAME` type; existing PERSON policy applies.
- Location context (`live in Cedar Hollow, Caledonia ( Riverton metro area )`) emits LOCATION. Ambiguous tokens such as `Jordan` follow local context, not a global LOCATION>PERSON rank.
- Production image (`Dockerfile.gateway`) bakes NER + ORT and sets `CENSGATE_NER_REQUIRED=true`. Local/tests stay contextual-only when no model is present.
- Config: `CENSGATE_NER_MODEL_PATH`, `CENSGATE_NER_REQUIRED`, YAML `ner:`.

## Test plan

- `rustup run 1.88.0 cargo test -p redact-ner -p redact-gateway -p redact-core`
  - identity goldens: household paragraph (Nola / Pip + Cedar Hollow / Caledonia / Riverton), weekdays, Hi Ada, my cat Monday, jordan by context
  - gateway e2e: tokenize + restore of the household paragraph
  - required NER without a model fails startup
- ONNX ORG cases run only when `CENSGATE_NER_MODEL_PATH` is set
- `scripts/ci/smoke-gateway.sh` asserts PERSON/LOCATION on a short identity prompt

## Roll

Build and push the NER-enabled `redact-gateway` image and record the digest before depending on PERSON/LOCATION tokenization for given names.
