### PR TITLE
Do not re-detect identity inside existing vault tokens

### DIFF
--- a/crates/redact-ner/src/contextual_identity.rs
+++ b/crates/redact-ner/src/contextual_identity.rs
@@ -41,8 +41,10 @@ pub fn detect_contextual_identities(text: &str) -> Vec<RecognizerResult> {
     collect_locations(text, &tokens, &mut hits);
     collect_metro_areas(text, &tokens, &mut hits);
 
+    let sealed = vault_token_spans(text);
     merge_hits(hits)
         .into_iter()
+        .filter(|h| !sealed.iter().any(|(s, e)| h.start < *e && h.end > *s))
         .map(|h| {
             let ty = match h.kind {
                 Kind::Person => EntityType::Person,
@@ -51,6 +53,38 @@ pub fn detect_contextual_identities(text: &str) -> Vec<RecognizerResult> {
             RecognizerResult::new(ty, h.start, h.end, h.score, SOURCE)
         })
         .collect()
+}
+
+/// Spans of already-minted vault tokens such as `[PERSON_1]` or `[EMAIL_ADDRESS_2]`.
+pub(crate) fn vault_token_spans(text: &str) -> Vec<(usize, usize)> {
+    let bytes = text.as_bytes();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'[' {
+            if let Some(rel) = text[i + 1..].find(']') {
+                let inner = &text[i + 1..i + 1 + rel];
+                if is_vault_token_inner(inner) {
+                    let end = i + 1 + rel + 1;
+                    out.push((i, end));
+                    i = end;
+                    continue;
+                }
+            }
+        }
+        i += 1;
+    }
+    out
+}
+
+fn is_vault_token_inner(inner: &str) -> bool {
+    let Some((ty, num)) = inner.rsplit_once('_') else {
+        return false;
+    };
+    !ty.is_empty()
+        && ty.chars().all(|c| c.is_ascii_uppercase() || c == '_')
+        && !num.is_empty()
+        && num.chars().all(|c| c.is_ascii_digit())
 }
 
 fn tokenize(text: &str) -> Vec<Token<'_>> {
@@ -652,7 +686,12 @@ fn is_function_word(word: &str) -> bool {
 fn is_common_non_name(word: &str) -> bool {
     matches!(
         word.to_ascii_lowercase().as_str(),
-        "starts"
+        "person"
+            | "location"
+            | "organization"
+            | "email"
+            | "address"
+            | "starts"
             | "start"
             | "started"
             | "starting"

--- a/crates/redact-ner/src/identity.rs
+++ b/crates/redact-ner/src/identity.rs
@@ -147,7 +147,7 @@ impl Recognizer for IdentityRecognizer {
             Some(ner) if ner.is_available() => ner.analyze(text, language)?,
             _ => Vec::new(),
         };
-        Ok(merge_identity(contextual, ner))
+        Ok(merge_identity(text, contextual, ner))
     }
 
     fn supports_language(&self, language: &str) -> bool {
@@ -161,9 +161,11 @@ impl Recognizer for IdentityRecognizer {
 /// Context detections win on overlap. NER-only spans (ORG, uncovered names)
 /// are kept. DATE_TIME from NER is dropped here — pattern packs own dates.
 fn merge_identity(
+    text: &str,
     contextual: Vec<RecognizerResult>,
     ner: Vec<RecognizerResult>,
 ) -> Vec<RecognizerResult> {
+    let sealed = crate::contextual_identity::vault_token_spans(text);
     let mut out = contextual;
     for candidate in ner {
         match candidate.entity_type {
@@ -173,6 +175,12 @@ fn merge_identity(
         if out
             .iter()
             .any(|existing| existing.overlaps_with(&candidate))
+        {
+            continue;
+        }
+        if sealed
+            .iter()
+            .any(|(s, e)| candidate.start < *e && candidate.end > *s)
         {
             continue;
         }
@@ -228,7 +236,7 @@ mod tests {
             0.99,
             "ner",
         )];
-        let merged = merge_identity(contextual, ner);
+        let merged = merge_identity("we live in jordan", contextual, ner);
         assert_eq!(merged.len(), 1);
         assert_eq!(merged[0].entity_type, EntityType::Location);
         assert_eq!(merged[0].recognizer_name, "ctx");

--- a/crates/redact-ner/tests/identity_golden.rs
+++ b/crates/redact-ner/tests/identity_golden.rs
@@ -123,6 +123,18 @@ fn common_words_after_identity_cues_are_not_names() {
 }
 
 #[test]
+fn existing_vault_tokens_are_not_identity() {
+    let rec = IdentityRecognizer::contextual_only();
+    let text = "I have two female cats: [PERSON_1] ( black American short hair, 12 ) and [PERSON_2] ( ginger tabby, 3 ). We live in [LOCATION_1], [LOCATION_2] ( [LOCATION_3] metro area ).";
+    assert!(
+        spans(&rec, text).is_empty(),
+        "sealed tokens must not be re-detected as PERSON/LOCATION: {:?}",
+        spans(&rec, text)
+    );
+    assert!(spans(&rec, "[PERSON_6] lives in [LOCATION_4]").is_empty());
+}
+
+#[test]
 fn named_and_called_are_strong_person_context() {
     let rec = IdentityRecognizer::contextual_only();
     assert_eq!(


### PR DESCRIPTION
## Why

Re-analyzing already-tokenized text treated the labels `PERSON` and `LOCATION` inside placeholders such as `[PERSON_1]` as new names. A second pass turned `[PERSON_1]` into `[[PERSON_3]_1]` and a third into `[[[PERSON_6]_6]_2]`.

## What

- Ignore spans that already match a minted vault token (`[TYPE_n]`, including `[EMAIL_ADDRESS_2]`).
- Treat `person` / `location` / `organization` / `email` / `address` as non-names.
- Golden: the Nola/Pip/Cedar Hollow paragraph after tokenization produces no further identity spans.

## Test plan

`cargo test -p redact-ner --lib --test identity_golden`