### PR TITLE
Gate 3: span-only /v1/redact stages (0.11.1 behavior)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Standalone `POST /v1/redact` emits the same detect / policy / tokenmap
+  child spans as the proxy path, plus stage spans for patterns,
+  contextual identity, tokenizer, ONNX lock wait, ONNX exec, and decode.
+  No text attributes. Detection and token bytes are unchanged from 0.11.1.
+
 ## [0.11.1] - 2026-09-02
 
 ### Fixed

--- a/crates/redact-core/src/lib.rs
+++ b/crates/redact-core/src/lib.rs
@@ -47,12 +47,14 @@ pub mod anonymizers;
 pub mod engine;
 pub mod policy;
 pub mod recognizers;
+pub mod trace;
 pub mod types;
 
 // Re-export commonly used types
 pub use anonymizers::{AnonymizationStrategy, AnonymizerConfig, AnonymizerRegistry};
 pub use engine::AnalyzerEngine;
 pub use recognizers::{evaluate_generic_candidate, Recognizer, RecognizerRegistry};
+pub use trace::{operations_enabled, with_operation_spans};
 pub use types::{
     AnalysisMetadata, AnalysisResult, AnonymizedResult, EntityType, RecognizerResult, Token,
 };

--- a/crates/redact-core/src/recognizers/generic.rs
+++ b/crates/redact-core/src/recognizers/generic.rs
@@ -308,6 +308,7 @@ impl Recognizer for GenericSecretRecognizer {
     }
 
     fn analyze(&self, text: &str, _language: &str) -> Result<Vec<RecognizerResult>> {
+        let _span = tracing::info_span!("redact.gateway.detect.patterns").entered();
         let mut results = Vec::new();
         for caps in ASSIGNMENT.captures_iter(text) {
             let Some(key) = caps.name("key") else {

--- a/crates/redact-core/src/recognizers/generic.rs
+++ b/crates/redact-core/src/recognizers/generic.rs
@@ -308,7 +308,8 @@ impl Recognizer for GenericSecretRecognizer {
     }
 
     fn analyze(&self, text: &str, _language: &str) -> Result<Vec<RecognizerResult>> {
-        let _span = tracing::info_span!("redact.gateway.detect.patterns").entered();
+        let _span = crate::operations_enabled()
+            .then(|| tracing::info_span!("redact.gateway.detect.patterns").entered());
         let mut results = Vec::new();
         for caps in ASSIGNMENT.captures_iter(text) {
             let Some(key) = caps.name("key") else {

--- a/crates/redact-core/src/recognizers/pattern.rs
+++ b/crates/redact-core/src/recognizers/pattern.rs
@@ -714,6 +714,7 @@ impl Recognizer for PatternRecognizer {
     }
 
     fn analyze(&self, text: &str, _language: &str) -> Result<Vec<RecognizerResult>> {
+        let _span = tracing::info_span!("redact.gateway.detect.patterns").entered();
         let mut results = Vec::new();
 
         for (entity_type, patterns) in &self.patterns {

--- a/crates/redact-core/src/recognizers/pattern.rs
+++ b/crates/redact-core/src/recognizers/pattern.rs
@@ -714,7 +714,8 @@ impl Recognizer for PatternRecognizer {
     }
 
     fn analyze(&self, text: &str, _language: &str) -> Result<Vec<RecognizerResult>> {
-        let _span = tracing::info_span!("redact.gateway.detect.patterns").entered();
+        let _span = crate::operations_enabled()
+            .then(|| tracing::info_span!("redact.gateway.detect.patterns").entered());
         let mut results = Vec::new();
 
         for (entity_type, patterns) in &self.patterns {

--- a/crates/redact-core/src/trace.rs
+++ b/crates/redact-core/src/trace.rs
@@ -1,0 +1,49 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Stage-span gate for `/v1/redact` children.
+//!
+//! Recognizers live below the gateway crate, so they cannot see `TraceLevel`.
+//! The gateway enables this thread-local for the duration of a pass when
+//! operations tracing is on. Call sites still use `tracing::info_span!` with a
+//! literal name so the tracing macros stay valid.
+
+use std::cell::Cell;
+
+thread_local! {
+    static OPERATIONS: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Run `f` with stage spans enabled or disabled for this thread.
+pub fn with_operation_spans<R>(enabled: bool, f: impl FnOnce() -> R) -> R {
+    OPERATIONS.with(|flag| {
+        let prev = flag.replace(enabled);
+        let out = f();
+        flag.set(prev);
+        out
+    })
+}
+
+/// Whether the current pass should emit detect-stage child spans.
+pub fn operations_enabled() -> bool {
+    OPERATIONS.with(Cell::get)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn off_by_default() {
+        assert!(!operations_enabled());
+    }
+
+    #[test]
+    fn on_inside_scope() {
+        with_operation_spans(true, || {
+            assert!(operations_enabled());
+        });
+        assert!(!operations_enabled());
+    }
+}

--- a/crates/redact-core/src/trace.rs
+++ b/crates/redact-core/src/trace.rs
@@ -17,12 +17,15 @@ thread_local! {
 
 /// Run `f` with stage spans enabled or disabled for this thread.
 pub fn with_operation_spans<R>(enabled: bool, f: impl FnOnce() -> R) -> R {
-    OPERATIONS.with(|flag| {
-        let prev = flag.replace(enabled);
-        let out = f();
-        flag.set(prev);
-        out
-    })
+    struct Restore(bool);
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            OPERATIONS.with(|flag| flag.set(self.0));
+        }
+    }
+    let prev = OPERATIONS.with(|flag| flag.replace(enabled));
+    let _restore = Restore(prev);
+    f()
 }
 
 /// Whether the current pass should emit detect-stage child spans.
@@ -44,6 +47,14 @@ mod tests {
         with_operation_spans(true, || {
             assert!(operations_enabled());
         });
+        assert!(!operations_enabled());
+    }
+
+    #[test]
+    fn restores_after_panic() {
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            with_operation_spans(true, || panic!("boom"));
+        }));
         assert!(!operations_enabled());
     }
 }

--- a/crates/redact-gateway/src/redact/mod.rs
+++ b/crates/redact-gateway/src/redact/mod.rs
@@ -19,7 +19,9 @@ use redact_core::{AnalyzerEngine, EntityType, RecognizerResult};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 
+use crate::config::TraceLevel;
 use crate::policy::{EntityAction, MaskOptions, Profile};
+use crate::telemetry::spans;
 use token::{TokenError, TokenSession};
 
 /// Redaction failures.
@@ -137,6 +139,8 @@ pub struct RedactionContext<'a> {
     profile: &'a Profile,
     session: Option<&'a mut TokenSession>,
     tokenize_as_replace: bool,
+    /// When set, emit detect/policy child spans (standalone `/v1/redact`).
+    trace_level: Option<TraceLevel>,
     /// Accumulated result across every field touched by this context.
     pub outcome: RedactionOutcome,
 }
@@ -153,6 +157,7 @@ impl<'a> RedactionContext<'a> {
             profile,
             session: None,
             tokenize_as_replace: false,
+            trace_level: None,
             outcome: RedactionOutcome::default(),
         }
     }
@@ -169,6 +174,7 @@ impl<'a> RedactionContext<'a> {
             profile,
             session: None,
             tokenize_as_replace: true,
+            trace_level: None,
             outcome: RedactionOutcome::default(),
         }
     }
@@ -184,8 +190,15 @@ impl<'a> RedactionContext<'a> {
             profile,
             session: Some(session),
             tokenize_as_replace: false,
+            trace_level: None,
             outcome: RedactionOutcome::default(),
         }
+    }
+
+    /// Enable detect/policy child spans for this pass.
+    pub fn with_trace_level(mut self, level: TraceLevel) -> Self {
+        self.trace_level = Some(level);
+        self
     }
 
     /// The profile driving this pass.
@@ -204,13 +217,34 @@ impl<'a> RedactionContext<'a> {
             return Ok(text.to_string());
         }
 
-        let analysis = self
-            .engine
-            .analyze(text, None)
-            .map_err(|e| RedactError::Detection(e.to_string()))?;
+        let level = self.trace_level.unwrap_or(TraceLevel::Off);
+        let detect = spans::detect(level, text.len());
+        let analysis = {
+            let _enter = detect.as_ref().map(|s| s.enter());
+            self.engine
+                .analyze(text, None)
+                .map_err(|e| RedactError::Detection(e.to_string()))
+        };
+        let analysis = match analysis {
+            Ok(a) => {
+                if let Some(span) = &detect {
+                    spans::finish_detect(span, a.detected_entities.len(), level, None);
+                }
+                a
+            }
+            Err(err) => {
+                if let Some(span) = &detect {
+                    spans::finish_detect(span, 0, level, Some("detect_error"));
+                }
+                return Err(err);
+            }
+        };
         if analysis.detected_entities.is_empty() {
             return Ok(text.to_string());
         }
+
+        let policy = spans::policy_evaluate(level, &self.profile.name);
+        let _policy_enter = policy.as_ref().map(|s| s.enter());
 
         // Decide every span first: tokenization needs fallible work that
         // `apply_anonymization` cannot perform inside its closure.
@@ -228,7 +262,16 @@ impl<'a> RedactionContext<'a> {
                     let original = slice(text, &entity);
                     match self.session.as_deref_mut() {
                         Some(session) => Some(session.token_for(&entity.entity_type, original)?),
-                        None => return Err(RedactError::TokenizationUnavailable),
+                        None => {
+                            if let Some(span) = &policy {
+                                spans::finish_policy_evaluate(
+                                    span,
+                                    "error",
+                                    Some("tokenization_unavailable"),
+                                );
+                            }
+                            return Err(RedactError::TokenizationUnavailable);
+                        }
                     }
                 }
                 _ => None,
@@ -237,6 +280,9 @@ impl<'a> RedactionContext<'a> {
         }
 
         if self.outcome.is_blocked() {
+            if let Some(span) = &policy {
+                spans::finish_policy_evaluate(span, "block", None);
+            }
             // The caller refuses the request, so the rewritten text is never used.
             return Ok(text.to_string());
         }
@@ -247,6 +293,9 @@ impl<'a> RedactionContext<'a> {
             .map(|(entity, _, _)| entity.clone())
             .collect();
         if rewrites.is_empty() {
+            if let Some(span) = &policy {
+                spans::finish_policy_evaluate(span, "allow", None);
+            }
             return Ok(text.to_string());
         }
 
@@ -271,6 +320,9 @@ impl<'a> RedactionContext<'a> {
             }
         });
 
+        if let Some(span) = &policy {
+            spans::finish_policy_evaluate(span, "allow", None);
+        }
         Ok(redacted)
     }
 

--- a/crates/redact-gateway/src/redact/mod.rs
+++ b/crates/redact-gateway/src/redact/mod.rs
@@ -221,9 +221,11 @@ impl<'a> RedactionContext<'a> {
         let detect = spans::detect(level, text.len());
         let analysis = {
             let _enter = detect.as_ref().map(|s| s.enter());
-            self.engine
-                .analyze(text, None)
-                .map_err(|e| RedactError::Detection(e.to_string()))
+            redact_core::with_operation_spans(level.records_operations(), || {
+                self.engine
+                    .analyze(text, None)
+                    .map_err(|e| RedactError::Detection(e.to_string()))
+            })
         };
         let analysis = match analysis {
             Ok(a) => {

--- a/crates/redact-gateway/src/routes.rs
+++ b/crates/redact-gateway/src/routes.rs
@@ -1320,9 +1320,7 @@ async fn redact_endpoint(
             config.vault.address.as_deref(),
             None,
         );
-        let put_fut = state
-            .tokens
-            .put(&auth.tenant, &token_map_session, &minted);
+        let put_fut = state.tokens.put(&auth.tenant, &token_map_session, &minted);
         let put_result = if let Some(span) = put_span.clone() {
             put_fut.instrument(span).await
         } else {

--- a/crates/redact-gateway/src/routes.rs
+++ b/crates/redact-gateway/src/routes.rs
@@ -1254,23 +1254,48 @@ async fn redact_endpoint(
         Some(subject) => subject_bound_session_key(&session_id, subject),
         None => session_id.clone(),
     };
+    let level = config.telemetry.operations;
     // Resume prior mappings so sequential /v1/redact calls with one session
     // continue the counter instead of reminting `[ENTITY_1]` and clobbering.
     let mut session = if state.tokens.backend_name() != "off" {
-        match state.tokens.get(&auth.tenant, &token_map_session).await {
-            Ok(existing) => TokenSession::resume(
-                session_id.clone(),
-                &auth.tenant,
-                state.dek.clone(),
-                existing,
-            ),
+        let get_span = spans::tokenmap_get(
+            level,
+            state.tokens.backend_name(),
+            0,
+            config.vault.address.as_deref(),
+            None,
+        );
+        let get_fut = state.tokens.get(&auth.tenant, &token_map_session);
+        let got = if let Some(span) = get_span.clone() {
+            get_fut.instrument(span).await
+        } else {
+            get_fut.await
+        };
+        match got {
+            Ok(existing) => {
+                if let Some(span) = &get_span {
+                    spans::finish_tokenmap(span, existing.len(), None);
+                }
+                TokenSession::resume(
+                    session_id.clone(),
+                    &auth.tenant,
+                    state.dek.clone(),
+                    existing,
+                )
+            }
             Err(err) if profile.fail_closed => {
+                if let Some(span) = &get_span {
+                    spans::finish_tokenmap(span, 0, Some("token_map_error"));
+                }
                 return GatewayError::DependencyUnavailable(format!(
                     "token map read failed: {err}"
                 ))
                 .into_response();
             }
             Err(err) => {
+                if let Some(span) = &get_span {
+                    spans::finish_tokenmap(span, 0, Some("token_map_error"));
+                }
                 warn!(error = %err, "token map read failed; starting a fresh session");
                 TokenSession::new(session_id.clone(), &auth.tenant, state.dek.clone())
             }
@@ -1278,7 +1303,8 @@ async fn redact_endpoint(
     } else {
         TokenSession::new(session_id.clone(), &auth.tenant, state.dek.clone())
     };
-    let mut ctx = RedactionContext::with_session(&state.engine, &profile, &mut session);
+    let mut ctx = RedactionContext::with_session(&state.engine, &profile, &mut session)
+        .with_trace_level(level);
     let text = match ctx.redact(&request.text) {
         Ok(text) => text,
         Err(err) => return redaction_error(err).into_response(),
@@ -1287,11 +1313,25 @@ async fn redact_endpoint(
 
     let minted = session.take_new_mappings();
     if !minted.is_empty() && state.tokens.backend_name() != "off" {
-        if let Err(err) = state
+        let put_span = spans::tokenmap_put(
+            level,
+            state.tokens.backend_name(),
+            minted.len(),
+            config.vault.address.as_deref(),
+            None,
+        );
+        let put_fut = state
             .tokens
-            .put(&auth.tenant, &token_map_session, &minted)
-            .await
-        {
+            .put(&auth.tenant, &token_map_session, &minted);
+        let put_result = if let Some(span) = put_span.clone() {
+            put_fut.instrument(span).await
+        } else {
+            put_fut.await
+        };
+        if let Err(err) = put_result {
+            if let Some(span) = &put_span {
+                spans::finish_tokenmap(span, 0, Some("token_map_error"));
+            }
             use crate::vault::TokenMapError;
             // Conflicts are integrity failures even when fail_closed is off:
             // returning a colliding token that was not persisted is unsafe.
@@ -1302,6 +1342,8 @@ async fn redact_endpoint(
                 .into_response();
             }
             warn!(error = %err, "token map write failed");
+        } else if let Some(span) = &put_span {
+            spans::finish_tokenmap(span, minted.len(), None);
         }
     }
 

--- a/crates/redact-gateway/src/telemetry/semconv.rs
+++ b/crates/redact-gateway/src/telemetry/semconv.rs
@@ -166,6 +166,18 @@ pub mod span_name {
     pub const STREAM_REDACT: &str = "redact.gateway.stream.redact";
     /// Configuration reload.
     pub const CONFIG_RELOAD: &str = "redact.gateway.config.reload";
+    /// Regex / pack pattern pass (child of detect).
+    pub const DETECT_PATTERNS: &str = "redact.gateway.detect.patterns";
+    /// Contextual identity pass (child of detect).
+    pub const DETECT_CONTEXTUAL: &str = "redact.gateway.detect.contextual";
+    /// NER tokenizer + pad (child of detect).
+    pub const DETECT_TOKENIZER: &str = "redact.gateway.detect.tokenizer";
+    /// Time waiting for the ONNX session mutex.
+    pub const DETECT_ONNX_LOCK_WAIT: &str = "redact.gateway.detect.onnx.lock_wait";
+    /// ONNX session.run (lock held).
+    pub const DETECT_ONNX_EXEC: &str = "redact.gateway.detect.onnx.exec";
+    /// Softmax + BIO decode (child of detect).
+    pub const DETECT_DECODE: &str = "redact.gateway.detect.decode";
 }
 
 /// `tracing` targets so operators can filter per subsystem.

--- a/crates/redact-gateway/src/telemetry/spans.rs
+++ b/crates/redact-gateway/src/telemetry/spans.rs
@@ -464,3 +464,87 @@ pub fn finish_config_reload(span: &Span, outcome: &str, error_type: Option<&str>
         record_error(span, err);
     }
 }
+
+/// `redact.gateway.detect.patterns`.
+pub fn detect_patterns(level: TraceLevel) -> Option<Span> {
+    if !level.records_operations() {
+        return None;
+    }
+    Some(tracing::info_span!(
+        target: semconv::target::DETECT,
+        { semconv::span_name::DETECT_PATTERNS },
+        { semconv::ERROR_TYPE } = tracing::field::Empty,
+        otel.status_code = tracing::field::Empty,
+        otel.status_description = tracing::field::Empty,
+    ))
+}
+
+/// `redact.gateway.detect.contextual`.
+pub fn detect_contextual(level: TraceLevel) -> Option<Span> {
+    if !level.records_operations() {
+        return None;
+    }
+    Some(tracing::info_span!(
+        target: semconv::target::DETECT,
+        { semconv::span_name::DETECT_CONTEXTUAL },
+        { semconv::ERROR_TYPE } = tracing::field::Empty,
+        otel.status_code = tracing::field::Empty,
+        otel.status_description = tracing::field::Empty,
+    ))
+}
+
+/// `redact.gateway.detect.tokenizer`.
+pub fn detect_tokenizer(level: TraceLevel) -> Option<Span> {
+    if !level.records_operations() {
+        return None;
+    }
+    Some(tracing::info_span!(
+        target: semconv::target::DETECT,
+        { semconv::span_name::DETECT_TOKENIZER },
+        { semconv::ERROR_TYPE } = tracing::field::Empty,
+        otel.status_code = tracing::field::Empty,
+        otel.status_description = tracing::field::Empty,
+    ))
+}
+
+/// `redact.gateway.detect.onnx.lock_wait`.
+pub fn detect_onnx_lock_wait(level: TraceLevel) -> Option<Span> {
+    if !level.records_operations() {
+        return None;
+    }
+    Some(tracing::info_span!(
+        target: semconv::target::DETECT,
+        { semconv::span_name::DETECT_ONNX_LOCK_WAIT },
+        { semconv::ERROR_TYPE } = tracing::field::Empty,
+        otel.status_code = tracing::field::Empty,
+        otel.status_description = tracing::field::Empty,
+    ))
+}
+
+/// `redact.gateway.detect.onnx.exec`.
+pub fn detect_onnx_exec(level: TraceLevel) -> Option<Span> {
+    if !level.records_operations() {
+        return None;
+    }
+    Some(tracing::info_span!(
+        target: semconv::target::DETECT,
+        { semconv::span_name::DETECT_ONNX_EXEC },
+        { semconv::ERROR_TYPE } = tracing::field::Empty,
+        otel.status_code = tracing::field::Empty,
+        otel.status_description = tracing::field::Empty,
+    ))
+}
+
+/// `redact.gateway.detect.decode`.
+pub fn detect_decode(level: TraceLevel) -> Option<Span> {
+    if !level.records_operations() {
+        return None;
+    }
+    Some(tracing::info_span!(
+        target: semconv::target::DETECT,
+        { semconv::span_name::DETECT_DECODE },
+        { semconv::ERROR_TYPE } = tracing::field::Empty,
+        otel.status_code = tracing::field::Empty,
+        otel.status_description = tracing::field::Empty,
+    ))
+}

--- a/crates/redact-gateway/src/telemetry/testing.rs
+++ b/crates/redact-gateway/src/telemetry/testing.rs
@@ -330,7 +330,8 @@ pub struct TestTelemetry {
     pub telemetry: Telemetry,
     /// In-memory collectors.
     pub handles: TestHandles,
-    _guard: Option<tracing::subscriber::DefaultGuard>,
+    /// Thread-local subscriber guard; keep this alive for the test.
+    pub _guard: Option<tracing::subscriber::DefaultGuard>,
 }
 
 impl TestTelemetry {

--- a/crates/redact-gateway/tests/redact_endpoint_spans.rs
+++ b/crates/redact-gateway/tests/redact_endpoint_spans.rs
@@ -1,0 +1,79 @@
+// Copyright 2026 Censgate LLC.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file
+// in the project root for license information.
+
+//! Standalone `/v1/redact` must emit detect/policy/pattern child spans
+//! without changing the redacted bytes.
+
+mod support;
+
+use axum::http::StatusCode;
+use redact_gateway::config::TraceLevel;
+use redact_gateway::routes::create_router;
+use redact_gateway::telemetry::semconv;
+use redact_gateway::telemetry::testing::{init_test, test_settings};
+use redact_gateway::GatewayServer;
+use serde_json::json;
+use std::sync::{Arc, Mutex, OnceLock};
+use support::*;
+
+fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+}
+
+#[tokio::test]
+async fn standalone_redact_emits_detect_policy_and_patterns_without_changing_bytes() {
+    let _guard = env_lock();
+    let redact_gateway::telemetry::testing::TestTelemetry {
+        telemetry,
+        handles,
+        _guard,
+    } = init_test(&test_settings(TraceLevel::Basic)).expect("init");
+    let telemetry = Arc::new(telemetry);
+    let upstream = mock_json_upstream(chat_response("ok")).await;
+    let config = config_for(&upstream);
+    let server = GatewayServer::with_telemetry(config, telemetry.clone())
+        .await
+        .expect("server");
+    let router = create_router(server.state());
+
+    let response = post_json(
+        router,
+        "/v1/redact",
+        json!({"text": "mail alice@example.com", "profile": "default"}),
+    )
+    .await;
+
+    assert_eq!(response.status, StatusCode::OK);
+    assert_eq!(response.json()["text"], "mail [EMAIL_ADDRESS]");
+    assert!(upstream.captured.lock().unwrap().is_none());
+
+    if let Some(p) = telemetry.tracer_provider() {
+        let _ = p.force_flush();
+    }
+    let finished = handles.spans.finished();
+    let names: Vec<String> = finished.iter().map(|s| s.name.to_string()).collect();
+    for want in [
+        semconv::span_name::DETECT,
+        semconv::span_name::POLICY_EVALUATE,
+        semconv::span_name::DETECT_PATTERNS,
+    ] {
+        assert!(
+            names.iter().any(|n| n == want),
+            "missing span {want} in {names:?}"
+        );
+    }
+    for span in &finished {
+        for kv in &span.attributes {
+            let v = format!("{}", kv.value);
+            assert!(
+                !v.contains("alice@example.com"),
+                "PII leaked onto span {}",
+                span.name
+            );
+        }
+    }
+}

--- a/crates/redact-gateway/tests/redact_endpoint_spans.rs
+++ b/crates/redact-gateway/tests/redact_endpoint_spans.rs
@@ -77,3 +77,52 @@ async fn standalone_redact_emits_detect_policy_and_patterns_without_changing_byt
         }
     }
 }
+
+#[tokio::test]
+async fn standalone_redact_omits_stage_spans_when_operations_off() {
+    let _guard = env_lock();
+    let redact_gateway::telemetry::testing::TestTelemetry {
+        telemetry,
+        handles,
+        _guard,
+    } = init_test(&test_settings(TraceLevel::Off)).expect("init");
+    let telemetry = Arc::new(telemetry);
+    let upstream = mock_json_upstream(chat_response("ok")).await;
+    let mut config = config_for(&upstream);
+    config.telemetry.operations = TraceLevel::Off;
+    let server = GatewayServer::with_telemetry(config, telemetry.clone())
+        .await
+        .expect("server");
+    let router = create_router(server.state());
+
+    let response = post_json(
+        router,
+        "/v1/redact",
+        json!({"text": "mail alice@example.com", "profile": "default"}),
+    )
+    .await;
+
+    assert_eq!(response.status, StatusCode::OK);
+    assert_eq!(response.json()["text"], "mail [EMAIL_ADDRESS]");
+
+    if let Some(p) = telemetry.tracer_provider() {
+        let _ = p.force_flush();
+    }
+    let finished = handles.spans.finished();
+    let names: Vec<String> = finished.iter().map(|s| s.name.to_string()).collect();
+    for forbid in [
+        semconv::span_name::DETECT,
+        semconv::span_name::POLICY_EVALUATE,
+        semconv::span_name::DETECT_PATTERNS,
+        semconv::span_name::DETECT_ONNX_LOCK_WAIT,
+        semconv::span_name::DETECT_ONNX_EXEC,
+        semconv::span_name::DETECT_TOKENIZER,
+        semconv::span_name::DETECT_DECODE,
+        semconv::span_name::DETECT_CONTEXTUAL,
+    ] {
+        assert!(
+            names.iter().all(|n| n != forbid),
+            "operations-off still emitted {forbid} in {names:?}"
+        );
+    }
+}

--- a/crates/redact-gateway/tests/telemetry.rs
+++ b/crates/redact-gateway/tests/telemetry.rs
@@ -180,6 +180,12 @@ fn operation_spans_respect_trace_level_and_nest() {
         assert!(spans::detect(TraceLevel::Off, 10).is_none());
         assert!(spans::anonymize(TraceLevel::Off).is_none());
         assert!(spans::policy_evaluate(TraceLevel::Off, "default").is_none());
+        assert!(spans::detect_patterns(TraceLevel::Off).is_none());
+        assert!(spans::detect_contextual(TraceLevel::Off).is_none());
+        assert!(spans::detect_tokenizer(TraceLevel::Off).is_none());
+        assert!(spans::detect_onnx_lock_wait(TraceLevel::Off).is_none());
+        assert!(spans::detect_onnx_exec(TraceLevel::Off).is_none());
+        assert!(spans::detect_decode(TraceLevel::Off).is_none());
     }
 
     // Detailed: stream chunk attribute is recorded.

--- a/crates/redact-ner/src/identity.rs
+++ b/crates/redact-ner/src/identity.rs
@@ -142,7 +142,10 @@ impl Recognizer for IdentityRecognizer {
     }
 
     fn analyze(&self, text: &str, language: &str) -> Result<Vec<RecognizerResult>> {
-        let contextual = detect_contextual_identities(text);
+        let contextual = {
+            let _span = tracing::info_span!("redact.gateway.detect.contextual").entered();
+            detect_contextual_identities(text)
+        };
         let ner = match &self.ner {
             Some(ner) if ner.is_available() => ner.analyze(text, language)?,
             _ => Vec::new(),

--- a/crates/redact-ner/src/identity.rs
+++ b/crates/redact-ner/src/identity.rs
@@ -143,7 +143,8 @@ impl Recognizer for IdentityRecognizer {
 
     fn analyze(&self, text: &str, language: &str) -> Result<Vec<RecognizerResult>> {
         let contextual = {
-            let _span = tracing::info_span!("redact.gateway.detect.contextual").entered();
+            let _span = redact_core::operations_enabled()
+                .then(|| tracing::info_span!("redact.gateway.detect.contextual").entered());
             detect_contextual_identities(text)
         };
         let ner = match &self.ner {

--- a/crates/redact-ner/src/recognizer.rs
+++ b/crates/redact-ner/src/recognizer.rs
@@ -408,9 +408,12 @@ impl NerRecognizer {
             .as_ref()
             .ok_or_else(|| anyhow!("ONNX session not loaded"))?;
 
-        let mut session = session_mutex
-            .lock()
-            .map_err(|e| anyhow!("Failed to lock session: {}", e))?;
+        let mut session = {
+            let _wait = tracing::info_span!("redact.gateway.detect.onnx.lock_wait").entered();
+            session_mutex
+                .lock()
+                .map_err(|e| anyhow!("Failed to lock session: {}", e))?
+        };
 
         // Create 2D arrays with shape [1, seq_len]
         let seq_len = input_ids.len();
@@ -433,7 +436,10 @@ impl NerRecognizer {
             inputs.push(("token_type_ids".into(), token_type_ids_value.into()));
         }
 
-        let outputs = session.run(inputs)?;
+        let outputs = {
+            let _exec = tracing::info_span!("redact.gateway.detect.onnx.exec").entered();
+            session.run(inputs)?
+        };
 
         // Extract logits - shape should be [1, seq_len, num_labels]
         let (shape, logits_data) = outputs["logits"].try_extract_tensor::<f32>()?;
@@ -596,35 +602,35 @@ impl Recognizer for NerRecognizer {
 
         let tokenizer = self.tokenizer.as_ref().unwrap();
 
-        // Tokenize input
-        let mut encoding = tokenizer.encode(text, true)?;
-
-        // Get padding token ID
-        let pad_id = tokenizer.get_padding_id().unwrap_or(0);
-
-        // Pad/truncate to max sequence length
-        encoding.pad_to_length(self.config.max_seq_length, pad_id);
+        let encoding = {
+            let _tok = tracing::info_span!("redact.gateway.detect.tokenizer").entered();
+            let mut encoding = tokenizer.encode(text, true)?;
+            let pad_id = tokenizer.get_padding_id().unwrap_or(0);
+            encoding.pad_to_length(self.config.max_seq_length, pad_id);
+            encoding
+        };
 
         // Run inference
         let logits = self.infer(&encoding.ids, &encoding.attention_mask)?;
 
-        // Convert logits to predictions
-        let mut predictions = Vec::new();
-        let mut probabilities = Vec::new();
+        let results = {
+            let _decode = tracing::info_span!("redact.gateway.detect.decode").entered();
+            let mut predictions = Vec::new();
+            let mut probabilities = Vec::new();
 
-        for token_logits in &logits {
-            let probs = Self::softmax(token_logits);
-            let (pred_id, &max_prob) = probs
-                .iter()
-                .enumerate()
-                .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
-                .unwrap();
-            predictions.push(pred_id);
-            probabilities.push(max_prob);
-        }
+            for token_logits in &logits {
+                let probs = Self::softmax(token_logits);
+                let (pred_id, &max_prob) = probs
+                    .iter()
+                    .enumerate()
+                    .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
+                    .unwrap();
+                predictions.push(pred_id);
+                probabilities.push(max_prob);
+            }
 
-        // Parse BIO tags to extract entities
-        let results = self.parse_bio_tags(text, &predictions, &probabilities, &encoding.offsets);
+            self.parse_bio_tags(text, &predictions, &probabilities, &encoding.offsets)
+        };
 
         Ok(results)
     }

--- a/crates/redact-ner/src/recognizer.rs
+++ b/crates/redact-ner/src/recognizer.rs
@@ -409,7 +409,8 @@ impl NerRecognizer {
             .ok_or_else(|| anyhow!("ONNX session not loaded"))?;
 
         let mut session = {
-            let _wait = tracing::info_span!("redact.gateway.detect.onnx.lock_wait").entered();
+            let _wait = redact_core::operations_enabled()
+                .then(|| tracing::info_span!("redact.gateway.detect.onnx.lock_wait").entered());
             session_mutex
                 .lock()
                 .map_err(|e| anyhow!("Failed to lock session: {}", e))?
@@ -437,7 +438,8 @@ impl NerRecognizer {
         }
 
         let outputs = {
-            let _exec = tracing::info_span!("redact.gateway.detect.onnx.exec").entered();
+            let _exec = redact_core::operations_enabled()
+                .then(|| tracing::info_span!("redact.gateway.detect.onnx.exec").entered());
             session.run(inputs)?
         };
 
@@ -603,7 +605,8 @@ impl Recognizer for NerRecognizer {
         let tokenizer = self.tokenizer.as_ref().unwrap();
 
         let encoding = {
-            let _tok = tracing::info_span!("redact.gateway.detect.tokenizer").entered();
+            let _tok = redact_core::operations_enabled()
+                .then(|| tracing::info_span!("redact.gateway.detect.tokenizer").entered());
             let mut encoding = tokenizer.encode(text, true)?;
             let pad_id = tokenizer.get_padding_id().unwrap_or(0);
             encoding.pad_to_length(self.config.max_seq_length, pad_id);
@@ -614,7 +617,8 @@ impl Recognizer for NerRecognizer {
         let logits = self.infer(&encoding.ids, &encoding.attention_mask)?;
 
         let results = {
-            let _decode = tracing::info_span!("redact.gateway.detect.decode").entered();
+            let _decode = redact_core::operations_enabled()
+                .then(|| tracing::info_span!("redact.gateway.detect.decode").entered());
             let mut predictions = Vec::new();
             let mut probabilities = Vec::new();
 

--- a/scripts/bench-redact-concurrency.sh
+++ b/scripts/bench-redact-concurrency.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Opt-in wall-clock of POST /v1/redact at concurrency 1 vs 5.
+# Does not replace the platform latency harness. Skip if URL unset.
+#
+# Usage:
+#   PLATFORM_REDACT_GATEWAY_URL=http://127.0.0.1:8080 \
+#   PLATFORM_REDACT_GATEWAY_API_KEY=... \
+#   ./scripts/bench-redact-concurrency.sh
+set -euo pipefail
+
+BASE="${PLATFORM_REDACT_GATEWAY_URL:-}"
+if [[ -z "${BASE}" ]]; then
+  echo "skip: PLATFORM_REDACT_GATEWAY_URL unset"
+  exit 0
+fi
+BASE="${BASE%/}"
+KEY="${PLATFORM_REDACT_GATEWAY_API_KEY:-}"
+AUTH=()
+if [[ -n "${KEY}" ]]; then
+  AUTH=(-H "Authorization: Bearer ${KEY}")
+fi
+
+short='{"text":"Ada Lovelace","session_id":"bench-short"}'
+long_text
+long_text="$(python3 - <<'PY'
+print("Ada Lovelace " * 80)
+PY
+)"
+long="$(python3 -c 'import json,sys; print(json.dumps({"text": sys.argv[1], "session_id": "bench-long"}))' "${long_text}")"
+
+curl_one() {
+  local body="$1"
+  local start end
+  start="$(date +%s%N)"
+  curl -sS -o /dev/null -w '%{http_code}' \
+    -H 'Content-Type: application/json' \
+    "${AUTH[@]}" \
+    -d "${body}" \
+    "${BASE}/v1/redact" >/tmp/bench-redact-status
+  end="$(date +%s%N)"
+  python3 -c "print((${end}-${start})/1e6)"
+}
+
+run_conc() {
+  local n="$1"
+  local body="$2"
+  local pids=()
+  local i
+  local start end
+  start="$(date +%s%N)"
+  for ((i = 0; i < n; i++)); do
+    curl -sS -o /dev/null \
+      -H 'Content-Type: application/json' \
+      "${AUTH[@]}" \
+      -d "${body}" \
+      "${BASE}/v1/redact" &
+    pids+=("$!")
+  done
+  for pid in "${pids[@]}"; do
+    wait "${pid}"
+  done
+  end="$(date +%s%N)"
+  python3 -c "print((${end}-${start})/1e6)"
+}
+
+echo "gateway ${BASE}"
+echo "short conc1_ms=$(curl_one "${short}") conc5_ms=$(run_conc 5 "${short}")"
+echo "long  conc1_ms=$(curl_one "${long}") conc5_ms=$(run_conc 5 "${long}")"
+echo "If conc5 ≈ 5× conc1, the ONNX session mutex is serializing parallel /v1/redact."


### PR DESCRIPTION
## Summary

Span-only child stages on standalone `/v1/redact` (tokenmap get/put, patterns, contextual, tokenizer, ONNX lock wait, ONNX exec, decode, policy). No text attributes. Golden/byte parity with 0.11.1.

CI: rustfmt on the tokenmap `put` call (`17f63f5`).

## Test plan

- [x] Identity goldens + `standalone_redact_emits` + `the_redact_endpoint_applies`
- [x] Local `cargo fmt --all -- --check`
- [ ] CI Test Suite (ubuntu-latest, stable) after rustfmt push