### PR TITLE
NER serving path, Kubernetes auth, and n-replica OpenBao tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `vault_kv2` Kubernetes auth (`CENSGATE_VAULT_AUTH=kubernetes`) against
+  `openbao-tokens`, with in-process token cache/renew. Static
+  `CENSGATE_VAULT_TOKEN` is local-dev only. Role `external-secrets` is
+  refused. CAS retries are jittered (8 attempts); empty puts are skipped;
+  `/readyz` caches OpenBao health for 2s.
+- Sample `deploy/kubernetes/redact-gateway.yaml`: min 2 replicas, HPA,
+  PDB, startupProbe, ServiceAccount, Guaranteed 4 CPU / 4Gi, NetworkPolicy
+  to `openbao-tokens`, ESO ExternalSecret for `CENSGATE_TOKEN_DEK`.
+- `scripts/bench-gateway-ner.sh` and `docs/gateway/openbao-tokens-spike.md`
+  (do not quote the 32× Presidio redact-api number on the NER gateway).
+- `scripts/validate-distilbert-ner.sh` (gated; default model unchanged).
+- `export_ner_model.py --quantize` now runs dynamic INT8.
+- `CENSGATE_NER_INTRA_THREADS` (default 1). Gateway/API analyze uses the
+  tokio blocking pool.
+
+### Added
+
 - Standalone `POST /v1/redact` emits the same detect / policy / tokenmap
   child spans as the proxy path, plus stage spans for patterns,
   contextual identity, tokenizer, ONNX lock wait, ONNX exec, and decode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,19 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `openbao-tokens`, with in-process token cache/renew. Static
   `CENSGATE_VAULT_TOKEN` is local-dev only. Role `external-secrets` is
   refused. CAS retries are jittered (8 attempts); empty puts are skipped;
-  `/readyz` caches OpenBao health for 2s.
+  `/readyz` caches OpenBao health for 2s. Kubernetes-auth KV calls share a
+  read lock so login refresh does not serialize every OpenBao request.
 - Sample `deploy/kubernetes/redact-gateway.yaml`: min 2 replicas, HPA,
-  PDB, startupProbe, ServiceAccount, Guaranteed 4 CPU / 4Gi, NetworkPolicy
-  to `openbao-tokens`, ESO ExternalSecret for `CENSGATE_TOKEN_DEK`.
+  PDB, startupProbe, ServiceAccount, Guaranteed 2 CPU / 4Gi, NetworkPolicy
+  to `openbao-tokens`. ESO ExternalSecret owns `redact-gateway-dek`; API
+  keys live in a separately provisioned Secret this manifest never applies.
 - `scripts/bench-gateway-ner.sh` and `docs/gateway/openbao-tokens-spike.md`
   (do not quote the 32× Presidio redact-api number on the NER gateway).
 - `scripts/validate-distilbert-ner.sh` (gated; default model unchanged).
 - `export_ner_model.py --quantize` now runs dynamic INT8.
-- `CENSGATE_NER_INTRA_THREADS` (default 1). Gateway/API analyze uses the
-  tokio blocking pool.
-
-### Added
-
+- `CENSGATE_NER_INTRA_THREADS` (default 1). Gateway/API analyze and
+  anonymize use `block_in_place` on multi-thread tokio.
 - Standalone `POST /v1/redact` emits the same detect / policy / tokenmap
   child spans as the proxy path, plus stage spans for patterns,
   contextual identity, tokenizer, ONNX lock wait, ONNX exec, and decode.

--- a/Dockerfile.ner-base
+++ b/Dockerfile.ner-base
@@ -43,6 +43,8 @@ RUN case "$TARGETARCH" in \
 # Stage 1: Export NER model to ONNX
 # -----------------------------------------------------------------------------
 FROM python:3.11-slim AS model-exporter
+# Gated: do not change this default to dslim/distilbert-NER without CoNLL
+# PER/ORG/LOC F1 + fixture numbers (scripts/validate-distilbert-ner.sh).
 ARG NER_MODEL=dslim/bert-base-NER
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/crates/redact-api/src/handlers.rs
+++ b/crates/redact-api/src/handlers.rs
@@ -70,25 +70,33 @@ pub async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
     })
 }
 
-fn analyze_off_async_worker(
-    engine: &AnalyzerEngine,
-    request: &AnalyzeRequest,
-    entity_types: Option<&Vec<EntityType>>,
-) -> Result<redact_core::AnalysisResult, ApiError> {
-    let run = || {
-        if let Some(entities) = entity_types {
-            engine.analyze_with_entities(&request.text, entities, Some(&request.language))
-        } else {
-            engine.analyze(&request.text, Some(&request.language))
-        }
-        .map_err(ApiError::from)
-    };
+/// Run CPU/ONNX work off the multi-thread tokio worker.
+///
+/// `block_in_place` parks the current worker in blocking mode; Tokio may
+/// spawn a replacement worker. It is not the `spawn_blocking` thread pool.
+/// Current-thread tests stay in-place (block_in_place panics there).
+fn run_off_async_worker<T>(run: impl FnOnce() -> Result<T, ApiError>) -> Result<T, ApiError> {
     match tokio::runtime::Handle::try_current() {
         Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
             tokio::task::block_in_place(run)
         }
         _ => run(),
     }
+}
+
+fn analyze_off_async_worker(
+    engine: &AnalyzerEngine,
+    request: &AnalyzeRequest,
+    entity_types: Option<&Vec<EntityType>>,
+) -> Result<redact_core::AnalysisResult, ApiError> {
+    run_off_async_worker(|| {
+        if let Some(entities) = entity_types {
+            engine.analyze_with_entities(&request.text, entities, Some(&request.language))
+        } else {
+            engine.analyze(&request.text, Some(&request.language))
+        }
+        .map_err(ApiError::from)
+    })
 }
 
 /// Analyze endpoint - detect PII entities
@@ -124,7 +132,7 @@ async fn analyze_request(
             .collect()
     });
 
-    // Analyze text off the tokio worker (same blocking pool as spawn_blocking).
+    // Analyze text off the multi-thread tokio worker.
     let result = analyze_off_async_worker(&state.engine, &request, entity_types.as_ref())?;
 
     // Filter by min_score if provided
@@ -206,38 +214,34 @@ async fn anonymize_request(
             .collect()
     });
 
-    // Analyze and anonymize
-    let result = if let Some(entities) = entity_types.as_ref() {
-        // First analyze with specific entities
-        let analysis = state
-            .engine
-            .analyze_with_entities(&request.text, entities, Some(&request.language))
-            .map_err(ApiError::from)?;
-
-        // Then anonymize
-        let anonymized = state
-            .engine
-            .anonymizer_registry()
-            .anonymize(
-                &request.text,
-                analysis.detected_entities.clone(),
-                &core_config,
-            )
-            .map_err(ApiError::from)?;
-
-        (analysis.detected_entities, anonymized, analysis.metadata)
-    } else {
-        let analysis = state
-            .engine
-            .analyze_and_anonymize(&request.text, Some(&request.language), &core_config)
-            .map_err(ApiError::from)?;
-
-        let anonymized = analysis
-            .anonymized
-            .ok_or_else(|| ApiError::internal_error("Anonymization failed"))?;
-
-        (analysis.detected_entities, anonymized, analysis.metadata)
-    };
+    // Analyze and anonymize off the tokio worker (NER is synchronous).
+    let result = run_off_async_worker(|| {
+        if let Some(entities) = entity_types.as_ref() {
+            let analysis = state
+                .engine
+                .analyze_with_entities(&request.text, entities, Some(&request.language))
+                .map_err(ApiError::from)?;
+            let anonymized = state
+                .engine
+                .anonymizer_registry()
+                .anonymize(
+                    &request.text,
+                    analysis.detected_entities.clone(),
+                    &core_config,
+                )
+                .map_err(ApiError::from)?;
+            Ok((analysis.detected_entities, anonymized, analysis.metadata))
+        } else {
+            let analysis = state
+                .engine
+                .analyze_and_anonymize(&request.text, Some(&request.language), &core_config)
+                .map_err(ApiError::from)?;
+            let anonymized = analysis
+                .anonymized
+                .ok_or_else(|| ApiError::internal_error("Anonymization failed"))?;
+            Ok((analysis.detected_entities, anonymized, analysis.metadata))
+        }
+    })?;
 
     let (detected_entities, anonymized, metadata) = result;
 

--- a/crates/redact-api/src/handlers.rs
+++ b/crates/redact-api/src/handlers.rs
@@ -70,6 +70,27 @@ pub async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
     })
 }
 
+fn analyze_off_async_worker(
+    engine: &AnalyzerEngine,
+    request: &AnalyzeRequest,
+    entity_types: Option<&Vec<EntityType>>,
+) -> Result<redact_core::AnalysisResult, ApiError> {
+    let run = || {
+        if let Some(entities) = entity_types {
+            engine.analyze_with_entities(&request.text, entities, Some(&request.language))
+        } else {
+            engine.analyze(&request.text, Some(&request.language))
+        }
+        .map_err(ApiError::from)
+    };
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
+            tokio::task::block_in_place(run)
+        }
+        _ => run(),
+    }
+}
+
 /// Analyze endpoint - detect PII entities
 pub async fn analyze(
     State(state): State<AppState>,
@@ -103,18 +124,8 @@ async fn analyze_request(
             .collect()
     });
 
-    // Analyze text
-    let result = if let Some(entities) = entity_types.as_ref() {
-        state
-            .engine
-            .analyze_with_entities(&request.text, entities, Some(&request.language))
-            .map_err(ApiError::from)?
-    } else {
-        state
-            .engine
-            .analyze(&request.text, Some(&request.language))
-            .map_err(ApiError::from)?
-    };
+    // Analyze text off the tokio worker (same blocking pool as spawn_blocking).
+    let result = analyze_off_async_worker(&state.engine, &request, entity_types.as_ref())?;
 
     // Filter by min_score if provided
     let mut results: Vec<EntityResult> = result

--- a/crates/redact-gateway/README.md
+++ b/crates/redact-gateway/README.md
@@ -206,9 +206,14 @@ Every gateway knob uses the `CENSGATE_` prefix (one name per setting). The only 
 | `CENSGATE_NER_MODEL_PATH` | unset | Path to ONNX `model.onnx` |
 | `CENSGATE_NER_REQUIRED` | `false` | Fail startup if NER cannot load |
 | `CENSGATE_NER_SESSION_POOL` | `2` | Bounded ONNX session pool (cap 4). Same exported model; `try_lock` then block. |
+| `CENSGATE_NER_INTRA_THREADS` | `1` | ORT intra-op threads per session (cap 8) |
 | `CENSGATE_VAULT_BACKEND` | `off` | Token map backend: `off`, `memory`, or `vault_kv2` |
 | `CENSGATE_VAULT_ADDR` / `VAULT_ADDR` / `BAO_ADDR` | unset | KV v2 server address |
-| `CENSGATE_VAULT_TOKEN` / `VAULT_TOKEN` / `BAO_TOKEN` | unset | KV v2 auth token |
+| `CENSGATE_VAULT_AUTH` | `token` | `token` (local-dev) or `kubernetes` (openbao-tokens / HPA) |
+| `CENSGATE_VAULT_TOKEN` / `VAULT_TOKEN` / `BAO_TOKEN` | unset | Static KV token (local-dev only) |
+| `CENSGATE_VAULT_K8S_ROLE` | unset | Kubernetes auth role (`redact-gateway`) |
+| `CENSGATE_VAULT_K8S_MOUNT` | `kubernetes` | Kubernetes auth mount |
+| `CENSGATE_VAULT_JWT_PATH` | SA token path | Projected ServiceAccount JWT |
 | `CENSGATE_VAULT_MOUNT` | `secret` | KV v2 mount |
 | `CENSGATE_VAULT_PATH_PREFIX` | `redact-gateway` | Path prefix under the mount |
 | `CENSGATE_VAULT_NAMESPACE` / `VAULT_NAMESPACE` | unset | Enterprise namespace header |

--- a/crates/redact-gateway/src/config/env.rs
+++ b/crates/redact-gateway/src/config/env.rs
@@ -25,7 +25,7 @@ use std::str::FromStr;
 use super::schema::GatewayDocument;
 use super::{
     AuditExport, AuthMode, ConfigError, ConfigSourceKind, ResolvedConfig, StreamMode, TraceLevel,
-    VaultBackend,
+    VaultAuthMethod, VaultBackend,
 };
 use crate::policy::PolicySet;
 
@@ -85,6 +85,16 @@ pub const VAULT_BACKEND: &str = "CENSGATE_VAULT_BACKEND";
 pub const VAULT_ADDR: &str = "CENSGATE_VAULT_ADDR";
 /// Token map authentication token.
 pub const VAULT_TOKEN: &str = "CENSGATE_VAULT_TOKEN";
+/// KV v2 auth method: `token` (local-dev) or `kubernetes` (HPA).
+pub const VAULT_AUTH: &str = "CENSGATE_VAULT_AUTH";
+/// Kubernetes auth role on openbao-tokens (never `external-secrets`).
+pub const VAULT_K8S_ROLE: &str = "CENSGATE_VAULT_K8S_ROLE";
+/// Kubernetes auth mount (default `kubernetes`).
+pub const VAULT_K8S_MOUNT: &str = "CENSGATE_VAULT_K8S_MOUNT";
+/// Path to the projected ServiceAccount JWT.
+pub const VAULT_JWT_PATH: &str = "CENSGATE_VAULT_JWT_PATH";
+/// Bounded ONNX intra-op threads per session (read by redact-ner).
+pub const NER_INTRA_THREADS: &str = "CENSGATE_NER_INTRA_THREADS";
 /// KV v2 mount point.
 pub const VAULT_MOUNT: &str = "CENSGATE_VAULT_MOUNT";
 /// Path prefix under the mount.
@@ -290,8 +300,9 @@ pub fn overlay_env(config: &mut ResolvedConfig) -> Result<(), ConfigError> {
     if let Some(value) = first(&[NER_REQUIRED]) {
         config.ner.required = parse_bool(NER_REQUIRED, &value)?;
     }
-    // Pool size is consumed by redact-ner at ONNX load (not a gateway schema field).
+    // Pool size and intra threads are consumed by redact-ner at ONNX load.
     let _ = first(&[NER_SESSION_POOL]);
+    let _ = first(&[NER_INTRA_THREADS]);
 
     if let Some(value) = first(&[VAULT_BACKEND]) {
         config.vault.backend = VaultBackend::from_str(&value)?;
@@ -301,6 +312,18 @@ pub fn overlay_env(config: &mut ResolvedConfig) -> Result<(), ConfigError> {
     }
     if let Some(value) = first(&[VAULT_TOKEN, "VAULT_TOKEN", "BAO_TOKEN"]) {
         config.vault.token = Some(value);
+    }
+    if let Some(value) = first(&[VAULT_AUTH]) {
+        config.vault.auth = VaultAuthMethod::from_str(&value)?;
+    }
+    if let Some(value) = first(&[VAULT_K8S_ROLE]) {
+        config.vault.kubernetes_role = Some(value);
+    }
+    if let Some(value) = first(&[VAULT_K8S_MOUNT]) {
+        config.vault.kubernetes_mount = value;
+    }
+    if let Some(value) = first(&[VAULT_JWT_PATH]) {
+        config.vault.jwt_path = PathBuf::from(value);
     }
     if let Some(value) = first(&[VAULT_MOUNT]) {
         config.vault.mount = value;

--- a/crates/redact-gateway/src/config/mod.rs
+++ b/crates/redact-gateway/src/config/mod.rs
@@ -175,6 +175,41 @@ impl std::str::FromStr for VaultBackend {
     }
 }
 
+/// How the gateway authenticates to a KV v2 server.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VaultAuthMethod {
+    /// Static `X-Vault-Token`. Local-dev and compose only.
+    Token,
+    /// Kubernetes auth against `openbao-tokens`. Required for HPA.
+    Kubernetes,
+}
+
+impl VaultAuthMethod {
+    /// Stable name for telemetry and `print-config`.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Token => "token",
+            Self::Kubernetes => "kubernetes",
+        }
+    }
+}
+
+impl std::str::FromStr for VaultAuthMethod {
+    type Err = ConfigError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "token" | "static" => Ok(Self::Token),
+            "kubernetes" | "k8s" => Ok(Self::Kubernetes),
+            other => Err(ConfigError::InvalidValue {
+                key: env::VAULT_AUTH.to_string(),
+                message: format!("expected token or kubernetes, got `{other}`"),
+            }),
+        }
+    }
+}
+
 /// Inbound authentication mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -431,6 +466,14 @@ pub struct VaultSettings {
     /// Authentication token. Never logged or exported.
     #[serde(skip_serializing)]
     pub token: Option<String>,
+    /// How to obtain the KV v2 token. `token` is local-dev only.
+    pub auth: VaultAuthMethod,
+    /// Kubernetes auth role on the tokens cluster (never `external-secrets`).
+    pub kubernetes_role: Option<String>,
+    /// Kubernetes auth mount (default `kubernetes`).
+    pub kubernetes_mount: String,
+    /// Projected ServiceAccount JWT path.
+    pub jwt_path: PathBuf,
     /// KV v2 mount point.
     pub mount: String,
     /// Path prefix under the mount.
@@ -450,6 +493,10 @@ impl Default for VaultSettings {
             backend: VaultBackend::Off,
             address: None,
             token: None,
+            auth: VaultAuthMethod::Token,
+            kubernetes_role: None,
+            kubernetes_mount: "kubernetes".to_string(),
+            jwt_path: PathBuf::from("/var/run/secrets/kubernetes.io/serviceaccount/token"),
             mount: "secret".to_string(),
             path_prefix: "redact-gateway".to_string(),
             namespace: None,
@@ -666,6 +713,21 @@ impl ResolvedConfig {
                 "token map backend is vault_kv2 but no address is configured".to_string(),
             ));
         }
+        if self.vault.backend == VaultBackend::VaultKv2
+            && self.vault.auth == VaultAuthMethod::Kubernetes
+            && self
+                .vault
+                .kubernetes_role
+                .as_deref()
+                .map(str::trim)
+                .is_none_or(str::is_empty)
+        {
+            return Err(ConfigError::Invalid(
+                "vault_kv2 kubernetes auth requires vault.kubernetes_role \
+                 (dedicated redact-gateway role on openbao-tokens; never external-secrets)"
+                    .to_string(),
+            ));
+        }
         if self.audit.export == AuditExport::File && self.audit.file_path.is_none() {
             return Err(ConfigError::Invalid(
                 "audit export is file but no path is configured".to_string(),
@@ -835,6 +897,10 @@ impl ResolvedConfig {
         }
         if self.vault.address != next.vault.address
             || self.vault.token != next.vault.token
+            || self.vault.auth != next.vault.auth
+            || self.vault.kubernetes_role != next.vault.kubernetes_role
+            || self.vault.kubernetes_mount != next.vault.kubernetes_mount
+            || self.vault.jwt_path != next.vault.jwt_path
             || self.vault.mount != next.vault.mount
             || self.vault.path_prefix != next.vault.path_prefix
             || self.vault.namespace != next.vault.namespace
@@ -920,6 +986,9 @@ impl ResolvedConfig {
             "vault": {
                 "backend": self.vault.backend.as_str(),
                 "address": self.vault.address,
+                "auth": self.vault.auth.as_str(),
+                "kubernetes_role": self.vault.kubernetes_role,
+                "kubernetes_mount": self.vault.kubernetes_mount,
                 "mount": self.vault.mount,
                 "path_prefix": self.vault.path_prefix,
                 "ttl_secs": self.vault.ttl_secs,
@@ -1011,6 +1080,18 @@ mod tests {
         config.vault.backend = VaultBackend::VaultKv2;
         assert!(config.validate().is_err());
         config.vault.address = Some("http://127.0.0.1:8200".to_string());
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn vault_kv2_kubernetes_auth_requires_a_role() {
+        let mut config = ResolvedConfig::default();
+        config.vault.backend = VaultBackend::VaultKv2;
+        config.vault.address = Some("http://openbao-tokens.openbao-tokens.svc:8200".into());
+        config.vault.auth = VaultAuthMethod::Kubernetes;
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("kubernetes_role"), "{err}");
+        config.vault.kubernetes_role = Some("redact-gateway".into());
         assert!(config.validate().is_ok());
     }
 

--- a/crates/redact-gateway/src/config/schema.rs
+++ b/crates/redact-gateway/src/config/schema.rs
@@ -13,7 +13,9 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
-use super::{AuditExport, ConfigError, ResolvedConfig, StreamMode, TraceLevel, VaultBackend};
+use super::{
+    AuditExport, ConfigError, ResolvedConfig, StreamMode, TraceLevel, VaultAuthMethod, VaultBackend,
+};
 use crate::config::AuthMode;
 use crate::policy::PolicySet;
 
@@ -136,6 +138,14 @@ pub struct VaultDocument {
     pub address: Option<String>,
     /// Authentication token.
     pub token: Option<String>,
+    /// `token` (local-dev) or `kubernetes` (HPA / openbao-tokens).
+    pub auth: Option<VaultAuthMethod>,
+    /// Kubernetes auth role. Never `external-secrets`.
+    pub kubernetes_role: Option<String>,
+    /// Kubernetes auth mount.
+    pub kubernetes_mount: Option<String>,
+    /// Projected ServiceAccount JWT path.
+    pub jwt_path: Option<PathBuf>,
     /// KV v2 mount point.
     pub mount: Option<String>,
     /// Path prefix under the mount.
@@ -312,6 +322,14 @@ impl GatewayDocument {
             }
             if vault.token.is_some() {
                 config.vault.token = vault.token.filter(|v| !v.is_empty());
+            }
+            apply_opt(&mut config.vault.auth, vault.auth);
+            if vault.kubernetes_role.is_some() {
+                config.vault.kubernetes_role = vault.kubernetes_role.filter(|v| !v.is_empty());
+            }
+            apply_opt(&mut config.vault.kubernetes_mount, vault.kubernetes_mount);
+            if let Some(path) = vault.jwt_path {
+                config.vault.jwt_path = resolve_path(base_dir, path);
             }
             apply_opt(&mut config.vault.mount, vault.mount);
             apply_opt(&mut config.vault.path_prefix, vault.path_prefix);

--- a/crates/redact-gateway/src/redact/mod.rs
+++ b/crates/redact-gateway/src/redact/mod.rs
@@ -24,9 +24,11 @@ use crate::policy::{EntityAction, MaskOptions, Profile};
 use crate::telemetry::spans;
 use token::{TokenError, TokenSession};
 
-/// Run engine analyze off the tokio worker when we are on a multi-thread
-/// runtime (same blocking pool as `spawn_blocking`). Current-thread tests
-/// and non-tokio callers stay in-place.
+/// Run engine analyze off the multi-thread tokio worker.
+///
+/// `block_in_place` parks the current worker in blocking mode; Tokio may
+/// spawn a replacement worker. It is not the `spawn_blocking` thread pool.
+/// Current-thread tests and non-tokio callers stay in-place.
 fn analyze_off_async_worker(
     engine: &AnalyzerEngine,
     text: &str,

--- a/crates/redact-gateway/src/redact/mod.rs
+++ b/crates/redact-gateway/src/redact/mod.rs
@@ -24,6 +24,26 @@ use crate::policy::{EntityAction, MaskOptions, Profile};
 use crate::telemetry::spans;
 use token::{TokenError, TokenSession};
 
+/// Run engine analyze off the tokio worker when we are on a multi-thread
+/// runtime (same blocking pool as `spawn_blocking`). Current-thread tests
+/// and non-tokio callers stay in-place.
+fn analyze_off_async_worker(
+    engine: &AnalyzerEngine,
+    text: &str,
+) -> Result<redact_core::AnalysisResult, RedactError> {
+    let run = || {
+        engine
+            .analyze(text, None)
+            .map_err(|e| RedactError::Detection(e.to_string()))
+    };
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
+            tokio::task::block_in_place(run)
+        }
+        _ => run(),
+    }
+}
+
 /// Redaction failures.
 #[derive(Debug, thiserror::Error)]
 pub enum RedactError {
@@ -222,9 +242,7 @@ impl<'a> RedactionContext<'a> {
         let analysis = {
             let _enter = detect.as_ref().map(|s| s.enter());
             redact_core::with_operation_spans(level.records_operations(), || {
-                self.engine
-                    .analyze(text, None)
-                    .map_err(|e| RedactError::Detection(e.to_string()))
+                analyze_off_async_worker(self.engine, text)
             })
         };
         let analysis = match analysis {
@@ -344,10 +362,7 @@ impl<'a> RedactionContext<'a> {
             return Ok((String::new(), text.to_string()));
         }
 
-        let analysis = self
-            .engine
-            .analyze(text, None)
-            .map_err(|e| RedactError::Detection(e.to_string()))?;
+        let analysis = analyze_off_async_worker(self.engine, text)?;
 
         let mut cut = text.len() - holdback;
         // Never split a detected entity: move the cut back to its start.

--- a/crates/redact-gateway/src/vault/kv2.rs
+++ b/crates/redact-gateway/src/vault/kv2.rs
@@ -19,7 +19,7 @@ use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 use vaultrs::api::kv2::requests::{ReadSecretRequest, SetSecretRequestOptions};
 use vaultrs::api::{self, kv2::responses::ReadSecretResponse};
 use vaultrs::client::{Client, VaultClient, VaultClientSettingsBuilder};
@@ -60,7 +60,7 @@ struct Inner {
 
 /// Token map backed by a Vault / OpenBao KV v2 mount.
 pub struct Kv2Store {
-    inner: Mutex<Inner>,
+    inner: RwLock<Inner>,
     auth: AuthMode,
     mount: String,
     path_prefix: String,
@@ -135,7 +135,7 @@ impl Kv2Store {
         })?;
 
         Ok(Self {
-            inner: Mutex::new(Inner {
+            inner: RwLock::new(Inner {
                 client,
                 token_expires_at: None,
             }),
@@ -151,10 +151,21 @@ impl Kv2Store {
         session_path(&self.path_prefix, tenant, session)
     }
 
-    async fn lock_ready(&self) -> Result<tokio::sync::MutexGuard<'_, Inner>, TokenMapError> {
-        let mut inner = self.inner.lock().await;
-        self.ensure_token(&mut inner).await?;
-        Ok(inner)
+    fn token_still_valid(inner: &Inner) -> bool {
+        inner
+            .token_expires_at
+            .is_some_and(|deadline| Instant::now() < deadline)
+    }
+
+    async fn ensure_fresh_token(&self) -> Result<(), TokenMapError> {
+        {
+            let inner = self.inner.read().await;
+            if matches!(self.auth, AuthMode::Static) || Self::token_still_valid(&inner) {
+                return Ok(());
+            }
+        }
+        let mut inner = self.inner.write().await;
+        self.ensure_token(&mut inner).await
     }
 
     async fn ensure_token(&self, inner: &mut Inner) -> Result<(), TokenMapError> {
@@ -168,10 +179,7 @@ impl Kv2Store {
         else {
             return Ok(());
         };
-        if inner
-            .token_expires_at
-            .is_some_and(|deadline| Instant::now() < deadline)
-        {
+        if Self::token_still_valid(inner) {
             return Ok(());
         }
         let jwt = std::fs::read_to_string(jwt_path).map_err(|e| {
@@ -183,14 +191,13 @@ impl Kv2Store {
         let (token, lease_secs) =
             kubernetes_login(address, namespace.as_deref(), mount, role, jwt.trim()).await?;
         inner.client.set_token(&token);
-        let usable =
-            Duration::from_secs(lease_secs.saturating_mul(80) / 100).max(Duration::from_secs(30));
-        inner.token_expires_at = Some(Instant::now() + usable);
+        inner.token_expires_at = Some(Instant::now() + kubernetes_token_cache_ttl(lease_secs));
         Ok(())
     }
 
     async fn read_entry(&self, path: &str) -> Result<Option<StoredSession>, TokenMapError> {
-        let inner = self.lock_ready().await?;
+        self.ensure_fresh_token().await?;
+        let inner = self.inner.read().await;
         match kv2::read::<StoredSession>(&inner.client, &self.mount, path).await {
             Ok(entry) => {
                 if entry.expires_at <= Utc::now() {
@@ -215,7 +222,8 @@ impl Kv2Store {
     /// yields `cas = 0` ("create only"). Expired entries contribute no mappings
     /// but retain their version so the subsequent write still CAS-protects.
     async fn read_for_cas(&self, path: &str) -> Result<(Vec<TokenMapping>, u32), TokenMapError> {
-        let inner = self.lock_ready().await?;
+        self.ensure_fresh_token().await?;
+        let inner = self.inner.read().await;
         let endpoint = ReadSecretRequest::builder()
             .mount(self.mount.as_str())
             .path(path)
@@ -271,7 +279,8 @@ impl TokenMapStore for Kv2Store {
             let options = SetSecretRequestOptions { cas };
 
             let result = {
-                let inner = self.lock_ready().await?;
+                self.ensure_fresh_token().await?;
+                let inner = self.inner.read().await;
                 kv2::set_with_options(&inner.client, &self.mount, &path, &payload, options).await
             };
 
@@ -305,7 +314,8 @@ impl TokenMapStore for Kv2Store {
 
     async fn delete(&self, tenant: &str, session: &str) -> Result<(), TokenMapError> {
         let path = self.path(tenant, session);
-        let inner = self.lock_ready().await?;
+        self.ensure_fresh_token().await?;
+        let inner = self.inner.read().await;
         match kv2::delete_latest(&inner.client, &self.mount, &path).await {
             Ok(()) => Ok(()),
             Err(ClientError::APIError { code: 404, .. }) => Ok(()),
@@ -324,7 +334,8 @@ impl TokenMapStore for Kv2Store {
         }
 
         let probed = {
-            let inner = self.lock_ready().await?;
+            self.ensure_fresh_token().await?;
+            let inner = self.inner.read().await;
             match inner.client.status().await {
                 Ok(_) => Ok(()),
                 Err(err) => Err(err.to_string()),
@@ -334,6 +345,20 @@ impl TokenMapStore for Kv2Store {
         *self.health.lock().await = Some((Instant::now(), probed.clone()));
         probed.map_err(TokenMapError::Unavailable)
     }
+}
+
+/// Cache a Kubernetes auth token strictly inside its lease.
+///
+/// `lease_duration == 0` means non-expiring; re-login hourly so a revoked
+/// token does not live forever in process. Never cache past a positive lease
+/// (the previous `max(80%, 30s)` floor reused expired sub-30s tokens).
+fn kubernetes_token_cache_ttl(lease_secs: u64) -> Duration {
+    if lease_secs == 0 {
+        return Duration::from_secs(3600);
+    }
+    let eighty_pct = lease_secs.saturating_mul(4) / 5;
+    let before_expiry = lease_secs.saturating_sub(1);
+    Duration::from_secs(eighty_pct.clamp(1, before_expiry.max(1)))
 }
 
 fn cas_backoff(attempt: u32) -> Duration {
@@ -431,6 +456,20 @@ mod tests {
             let d = cas_backoff(attempt);
             assert!(d >= Duration::from_millis(5));
             assert!(d < Duration::from_millis(200));
+        }
+    }
+
+    #[test]
+    fn kubernetes_token_cache_ttl_never_exceeds_a_positive_lease() {
+        assert_eq!(kubernetes_token_cache_ttl(3600), Duration::from_secs(2880));
+        assert_eq!(kubernetes_token_cache_ttl(20), Duration::from_secs(16));
+        assert_eq!(kubernetes_token_cache_ttl(1), Duration::from_secs(1));
+        assert_eq!(kubernetes_token_cache_ttl(0), Duration::from_secs(3600));
+        for lease in [1_u64, 5, 20, 30, 60, 3600] {
+            assert!(
+                kubernetes_token_cache_ttl(lease) <= Duration::from_secs(lease),
+                "cache ttl must be <= lease {lease}"
+            );
         }
     }
 

--- a/crates/redact-gateway/src/vault/kv2.rs
+++ b/crates/redact-gateway/src/vault/kv2.rs
@@ -5,16 +5,21 @@
 //! KV version 2 token-map backend.
 //!
 //! This backend speaks the HashiCorp Vault KV v2 HTTP API and therefore works
-//! with both HashiCorp Vault and OpenBao. The configured auth token is treated
-//! as an opaque bearer string (`X-Vault-Token`), so both `hvs.*` Vault tokens
-//! and OpenBao token formats are accepted without special handling.
+//! with both HashiCorp Vault and OpenBao. Auth is either a static bearer token
+//! (`X-Vault-Token`, local-dev) or Kubernetes auth against `openbao-tokens`
+//! (required for n-replica HPA). The ESO `external-secrets` role must never be
+//! used here.
 //!
 //! Concurrent `put` calls use KV v2 compare-and-set (`options.cas`) with a
-//! bounded retry loop so two writers merging into the same session cannot
-//! silently discard each other's mappings.
+//! bounded, jittered retry loop so two writers merging into the same session
+//! cannot silently discard each other's mappings.
+
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
 use vaultrs::api::kv2::requests::{ReadSecretRequest, SetSecretRequestOptions};
 use vaultrs::api::{self, kv2::responses::ReadSecretResponse};
 use vaultrs::client::{Client, VaultClient, VaultClientSettingsBuilder};
@@ -22,11 +27,13 @@ use vaultrs::error::ClientError;
 use vaultrs::kv2;
 
 use super::{merge_mappings, session_path, TokenMapError, TokenMapStore};
-use crate::config::VaultSettings;
+use crate::config::{VaultAuthMethod, VaultSettings};
 use crate::redact::token::TokenMapping;
 
 /// Maximum read→merge→CAS-write attempts before surfacing a conflict.
-const PUT_CAS_ATTEMPTS: u32 = 5;
+const PUT_CAS_ATTEMPTS: u32 = 8;
+/// Cache OpenBao reachability so `/readyz` does not serialize on the leader.
+const HEALTH_CACHE_TTL: Duration = Duration::from_secs(2);
 
 /// Payload written under each session path.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -35,12 +42,30 @@ struct StoredSession {
     expires_at: DateTime<Utc>,
 }
 
+enum AuthMode {
+    Static,
+    Kubernetes {
+        address: String,
+        namespace: Option<String>,
+        mount: String,
+        role: String,
+        jwt_path: PathBuf,
+    },
+}
+
+struct Inner {
+    client: VaultClient,
+    token_expires_at: Option<Instant>,
+}
+
 /// Token map backed by a Vault / OpenBao KV v2 mount.
 pub struct Kv2Store {
-    client: VaultClient,
+    inner: Mutex<Inner>,
+    auth: AuthMode,
     mount: String,
     path_prefix: String,
     ttl_secs: u64,
+    health: Mutex<Option<(Instant, Result<(), String>)>>,
 }
 
 impl std::fmt::Debug for Kv2Store {
@@ -59,7 +84,41 @@ impl Kv2Store {
         let address = settings.address.as_deref().ok_or_else(|| {
             TokenMapError::Unavailable("vault_kv2 backend requires an address".to_string())
         })?;
-        let token = settings.token.clone().unwrap_or_default();
+
+        let auth = match settings.auth {
+            VaultAuthMethod::Kubernetes => {
+                let role = settings
+                    .kubernetes_role
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .ok_or_else(|| {
+                        TokenMapError::Unavailable(
+                            "vault_kv2 kubernetes auth requires a role".to_string(),
+                        )
+                    })?;
+                if role == "external-secrets" {
+                    return Err(TokenMapError::Unavailable(
+                        "refusing Kubernetes auth role `external-secrets`; \
+                         bind a dedicated redact-gateway role on openbao-tokens"
+                            .to_string(),
+                    ));
+                }
+                AuthMode::Kubernetes {
+                    address: address.to_string(),
+                    namespace: settings.namespace.clone(),
+                    mount: settings.kubernetes_mount.clone(),
+                    role: role.to_string(),
+                    jwt_path: settings.jwt_path.clone(),
+                }
+            }
+            VaultAuthMethod::Token => AuthMode::Static,
+        };
+
+        let token = match &auth {
+            AuthMode::Static => settings.token.clone().unwrap_or_default(),
+            AuthMode::Kubernetes { .. } => String::new(),
+        };
 
         let mut builder = VaultClientSettingsBuilder::default();
         builder.address(address);
@@ -76,10 +135,15 @@ impl Kv2Store {
         })?;
 
         Ok(Self {
-            client,
+            inner: Mutex::new(Inner {
+                client,
+                token_expires_at: None,
+            }),
+            auth,
             mount: settings.mount.clone(),
             path_prefix: settings.path_prefix.clone(),
             ttl_secs: settings.ttl_secs,
+            health: Mutex::new(None),
         })
     }
 
@@ -87,8 +151,47 @@ impl Kv2Store {
         session_path(&self.path_prefix, tenant, session)
     }
 
+    async fn lock_ready(&self) -> Result<tokio::sync::MutexGuard<'_, Inner>, TokenMapError> {
+        let mut inner = self.inner.lock().await;
+        self.ensure_token(&mut inner).await?;
+        Ok(inner)
+    }
+
+    async fn ensure_token(&self, inner: &mut Inner) -> Result<(), TokenMapError> {
+        let AuthMode::Kubernetes {
+            address,
+            namespace,
+            mount,
+            role,
+            jwt_path,
+        } = &self.auth
+        else {
+            return Ok(());
+        };
+        if inner
+            .token_expires_at
+            .is_some_and(|deadline| Instant::now() < deadline)
+        {
+            return Ok(());
+        }
+        let jwt = std::fs::read_to_string(jwt_path).map_err(|e| {
+            TokenMapError::Unavailable(format!(
+                "could not read Kubernetes service account JWT at {}: {e}",
+                jwt_path.display()
+            ))
+        })?;
+        let (token, lease_secs) =
+            kubernetes_login(address, namespace.as_deref(), mount, role, jwt.trim()).await?;
+        inner.client.set_token(&token);
+        let usable =
+            Duration::from_secs(lease_secs.saturating_mul(80) / 100).max(Duration::from_secs(30));
+        inner.token_expires_at = Some(Instant::now() + usable);
+        Ok(())
+    }
+
     async fn read_entry(&self, path: &str) -> Result<Option<StoredSession>, TokenMapError> {
-        match kv2::read::<StoredSession>(&self.client, &self.mount, path).await {
+        let inner = self.lock_ready().await?;
+        match kv2::read::<StoredSession>(&inner.client, &self.mount, path).await {
             Ok(entry) => {
                 if entry.expires_at <= Utc::now() {
                     // Treat as absent without calling delete_latest: a concurrent
@@ -112,18 +215,19 @@ impl Kv2Store {
     /// yields `cas = 0` ("create only"). Expired entries contribute no mappings
     /// but retain their version so the subsequent write still CAS-protects.
     async fn read_for_cas(&self, path: &str) -> Result<(Vec<TokenMapping>, u32), TokenMapError> {
+        let inner = self.lock_ready().await?;
         let endpoint = ReadSecretRequest::builder()
             .mount(self.mount.as_str())
             .path(path)
             .build()
             .map_err(|e| TokenMapError::Backend(format!("invalid vault read request: {e}")))?;
 
-        let response: ReadSecretResponse = match api::exec_with_result(&self.client, endpoint).await
-        {
-            Ok(res) => res,
-            Err(ClientError::APIError { code: 404, .. }) => return Ok((Vec::new(), 0)),
-            Err(err) => return Err(map_client_error(err)),
-        };
+        let response: ReadSecretResponse =
+            match api::exec_with_result(&inner.client, endpoint).await {
+                Ok(res) => res,
+                Err(ClientError::APIError { code: 404, .. }) => return Ok((Vec::new(), 0)),
+                Err(err) => return Err(map_client_error(err)),
+            };
 
         let cas = version_to_cas(response.metadata.version)?;
         let entry: StoredSession = serde_json::value::from_value(response.data)
@@ -149,6 +253,11 @@ impl TokenMapStore for Kv2Store {
         session: &str,
         mappings: &[TokenMapping],
     ) -> Result<(), TokenMapError> {
+        // Empty incoming set is a no-op: do not CAS-write just to refresh TTL.
+        if mappings.is_empty() {
+            return Ok(());
+        }
+
         let path = self.path(tenant, session);
         let mut last_cas_error = None;
 
@@ -161,15 +270,19 @@ impl TokenMapStore for Kv2Store {
             };
             let options = SetSecretRequestOptions { cas };
 
-            match kv2::set_with_options(&self.client, &self.mount, &path, &payload, options).await {
+            let result = {
+                let inner = self.lock_ready().await?;
+                kv2::set_with_options(&inner.client, &self.mount, &path, &payload, options).await
+            };
+
+            match result {
                 Ok(_) => return Ok(()),
                 Err(err) if is_cas_conflict(&err) => {
                     last_cas_error = Some(err.to_string());
                     if attempt == PUT_CAS_ATTEMPTS {
                         break;
                     }
-                    // Another writer won the race; re-read and merge again.
-                    continue;
+                    tokio::time::sleep(cas_backoff(attempt)).await;
                 }
                 Err(err) => return Err(map_client_error(err)),
             }
@@ -192,7 +305,8 @@ impl TokenMapStore for Kv2Store {
 
     async fn delete(&self, tenant: &str, session: &str) -> Result<(), TokenMapError> {
         let path = self.path(tenant, session);
-        match kv2::delete_latest(&self.client, &self.mount, &path).await {
+        let inner = self.lock_ready().await?;
+        match kv2::delete_latest(&inner.client, &self.mount, &path).await {
             Ok(()) => Ok(()),
             Err(ClientError::APIError { code: 404, .. }) => Ok(()),
             Err(err) => Err(map_client_error(err)),
@@ -200,11 +314,81 @@ impl TokenMapStore for Kv2Store {
     }
 
     async fn health(&self) -> Result<(), TokenMapError> {
-        match self.client.status().await {
-            Ok(_) => Ok(()),
-            Err(err) => Err(TokenMapError::Unavailable(err.to_string())),
+        {
+            let cache = self.health.lock().await;
+            if let Some((at, result)) = cache.as_ref() {
+                if at.elapsed() < HEALTH_CACHE_TTL {
+                    return result.clone().map_err(TokenMapError::Unavailable);
+                }
+            }
         }
+
+        let probed = {
+            let inner = self.lock_ready().await?;
+            match inner.client.status().await {
+                Ok(_) => Ok(()),
+                Err(err) => Err(err.to_string()),
+            }
+        };
+
+        *self.health.lock().await = Some((Instant::now(), probed.clone()));
+        probed.map_err(TokenMapError::Unavailable)
     }
+}
+
+fn cas_backoff(attempt: u32) -> Duration {
+    let base_ms = 5u64.saturating_mul(u64::from(attempt));
+    let jitter_ms = u64::from(rand::random::<u8>() % 20);
+    Duration::from_millis(base_ms + jitter_ms)
+}
+
+async fn kubernetes_login(
+    address: &str,
+    namespace: Option<&str>,
+    mount: &str,
+    role: &str,
+    jwt: &str,
+) -> Result<(String, u64), TokenMapError> {
+    let url = format!(
+        "{}/v1/auth/{}/login",
+        address.trim_end_matches('/'),
+        mount.trim_matches('/')
+    );
+    let mut request = reqwest::Client::new()
+        .post(url)
+        .json(&serde_json::json!({ "role": role, "jwt": jwt }));
+    if let Some(ns) = namespace {
+        request = request.header("X-Vault-Namespace", ns);
+    }
+    let response = request
+        .send()
+        .await
+        .map_err(|e| TokenMapError::Unavailable(format!("kubernetes auth login failed: {e}")))?;
+    let status = response.status();
+    let body: serde_json::Value = response.json().await.map_err(|e| {
+        TokenMapError::Unavailable(format!("kubernetes auth login returned non-JSON: {e}"))
+    })?;
+    if !status.is_success() {
+        return Err(TokenMapError::Unavailable(format!(
+            "kubernetes auth login HTTP {status}: {}",
+            body.get("errors")
+                .cloned()
+                .unwrap_or_else(|| serde_json::json!([]))
+        )));
+    }
+    let token = body
+        .pointer("/auth/client_token")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            TokenMapError::Unavailable(
+                "kubernetes auth login missing auth.client_token".to_string(),
+            )
+        })?;
+    let lease = body
+        .pointer("/auth/lease_duration")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(3600);
+    Ok((token.to_string(), lease))
 }
 
 fn version_to_cas(version: u64) -> Result<u32, TokenMapError> {
@@ -234,5 +418,32 @@ fn map_client_error(err: ClientError) -> TokenMapError {
             TokenMapError::Unavailable("empty response from vault".to_string())
         }
         other => TokenMapError::Backend(other.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cas_backoff_grows_and_stays_small() {
+        for attempt in 1..=PUT_CAS_ATTEMPTS {
+            let d = cas_backoff(attempt);
+            assert!(d >= Duration::from_millis(5));
+            assert!(d < Duration::from_millis(200));
+        }
+    }
+
+    #[test]
+    fn refuses_external_secrets_role() {
+        let settings = VaultSettings {
+            backend: crate::config::VaultBackend::VaultKv2,
+            address: Some("http://127.0.0.1:8200".into()),
+            auth: VaultAuthMethod::Kubernetes,
+            kubernetes_role: Some("external-secrets".into()),
+            ..VaultSettings::default()
+        };
+        let err = Kv2Store::from_settings(&settings).unwrap_err();
+        assert!(err.to_string().contains("external-secrets"), "{err}");
     }
 }

--- a/crates/redact-gateway/tests/token_map.rs
+++ b/crates/redact-gateway/tests/token_map.rs
@@ -5,7 +5,7 @@
 //! Token map store backends: memory, disabled, and KV v2 against a mock Vault.
 
 use chrono::{Duration, Utc};
-use redact_gateway::config::{VaultBackend, VaultSettings};
+use redact_gateway::config::{VaultAuthMethod, VaultBackend, VaultSettings};
 use redact_gateway::redact::token::{Dek, TokenMapping};
 use redact_gateway::vault::{
     build_store, session_path, DisabledStore, MemoryStore, TokenMapError, TokenMapStore,
@@ -201,7 +201,7 @@ mod kv2_mock {
     use axum::extract::{Path, State};
     use axum::http::StatusCode;
     use axum::response::IntoResponse;
-    use axum::routing::get;
+    use axum::routing::{get, post};
     use axum::{Json, Router};
     use redact_gateway::vault::Kv2Store;
     use serde_json::{json, Value};
@@ -226,6 +226,8 @@ mod kv2_mock {
         concurrent_data_on_cas_fail: Arc<Mutex<Option<Value>>>,
         /// Counts POST attempts that reached the CAS check (for assertions).
         write_attempts: Arc<Mutex<u32>>,
+        /// Kubernetes auth logins recorded (role + jwt).
+        logins: Arc<Mutex<Vec<(String, String)>>>,
     }
 
     impl MockVaultState {
@@ -242,6 +244,41 @@ mod kv2_mock {
                 "errors": [
                     "check-and-set parameter did not match the current version"
                 ]
+            })),
+        )
+            .into_response()
+    }
+
+    async fn mock_k8s_login(State(state): State<MockVaultState>, body: Bytes) -> impl IntoResponse {
+        let body: Value = match serde_json::from_slice(&body) {
+            Ok(v) => v,
+            Err(err) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({ "errors": [err.to_string()] })),
+                )
+                    .into_response();
+            }
+        };
+        let role = body
+            .get("role")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let jwt = body
+            .get("jwt")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        state.logins.lock().await.push((role, jwt));
+        (
+            StatusCode::OK,
+            Json(json!({
+                "auth": {
+                    "client_token": "k8s-issued-token",
+                    "lease_duration": 3600,
+                    "renewable": true
+                }
             })),
         )
             .into_response()
@@ -403,6 +440,7 @@ mod kv2_mock {
         let state = MockVaultState::default();
         let app = Router::new()
             .route("/v1/sys/health", get(mock_health))
+            .route("/v1/auth/{mount}/login", post(mock_k8s_login))
             .route(
                 "/v1/{mount}/data/{*path}",
                 get(mock_read_secret)
@@ -426,11 +464,7 @@ mod kv2_mock {
             backend: VaultBackend::VaultKv2,
             address: Some(format!("http://{addr}")),
             token: Some("test-token".to_string()),
-            mount: "secret".to_string(),
-            path_prefix: "redact-gateway".to_string(),
-            namespace: None,
-            ttl_secs: 3600,
-            data_encryption_key: None,
+            ..VaultSettings::default()
         }
     }
 
@@ -645,5 +679,44 @@ mod kv2_mock {
 
         assert!(store.get("../victim", "sess").await.unwrap().is_empty());
         assert_eq!(store.get("victim", "sess").await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn kv2_skips_put_when_mappings_are_empty() {
+        let (addr, state) = start_mock_vault().await;
+        let store = Kv2Store::from_settings(&kv2_settings(addr)).unwrap();
+        store.put("t", "s", &[]).await.unwrap();
+        assert_eq!(*state.write_attempts.lock().await, 0);
+        assert!(state.last_write.lock().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn kv2_kubernetes_auth_logins_and_caches_the_token() {
+        let (addr, state) = start_mock_vault().await;
+        let jwt_file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(jwt_file.path(), "projected-sa-jwt").unwrap();
+
+        let settings = VaultSettings {
+            backend: VaultBackend::VaultKv2,
+            address: Some(format!("http://{addr}")),
+            auth: VaultAuthMethod::Kubernetes,
+            kubernetes_role: Some("redact-gateway".into()),
+            jwt_path: jwt_file.path().to_path_buf(),
+            token: None,
+            ..VaultSettings::default()
+        };
+        let store = Kv2Store::from_settings(&settings).unwrap();
+        let (_dek, sealed) = sealed_email("k8s@example.com");
+        store
+            .put("t", "s", &[mapping("[EMAIL_ADDRESS_1]", &sealed)])
+            .await
+            .unwrap();
+        store.get("t", "s").await.unwrap();
+
+        let logins = state.logins.lock().await.clone();
+        assert_eq!(logins.len(), 1, "login should be cached across put+get");
+        assert_eq!(logins[0].0, "redact-gateway");
+        assert_eq!(logins[0].1, "projected-sa-jwt");
+        assert_eq!(store.get("t", "s").await.unwrap().len(), 1);
     }
 }

--- a/crates/redact-ner/src/recognizer.rs
+++ b/crates/redact-ner/src/recognizer.rs
@@ -44,6 +44,24 @@ impl SessionPool {
     }
 }
 
+/// Parse `CENSGATE_NER_INTRA_THREADS` (default 1, cap 8).
+///
+/// Default is 1 so `pool × intra` stays near pod CPUs. The old hardcoded 4
+/// oversubscribed a 2-CPU sample and a 4-CPU Guaranteed pod with pool=2.
+pub(crate) fn clamp_intra_threads(raw: Option<&str>) -> usize {
+    match raw {
+        None => 1,
+        Some(s) => match s.trim().parse::<usize>() {
+            Ok(n) if n >= 1 => n.min(8),
+            _ => 1,
+        },
+    }
+}
+
+fn intra_threads() -> usize {
+    clamp_intra_threads(std::env::var("CENSGATE_NER_INTRA_THREADS").ok().as_deref())
+}
+
 /// Parse `CENSGATE_NER_SESSION_POOL` (default 2, cap 4).
 pub(crate) fn clamp_session_pool_size(raw: Option<&str>) -> usize {
     match raw {
@@ -464,7 +482,7 @@ impl NerRecognizer {
         Session::builder()?
             .with_optimization_level(GraphOptimizationLevel::Level3)
             .map_err(|e| anyhow::anyhow!("{e}"))?
-            .with_intra_threads(4)
+            .with_intra_threads(intra_threads())
             .map_err(|e| anyhow::anyhow!("{e}"))?
             .commit_from_file(model_path)
             .map_err(|e| anyhow::anyhow!("{e}"))
@@ -885,6 +903,18 @@ mod tests {
         assert_eq!(clamp_session_pool_size(Some("4")), 4);
         assert_eq!(clamp_session_pool_size(Some("8")), 4);
         assert_eq!(clamp_session_pool_size(Some("nope")), 2);
+    }
+
+    #[test]
+    fn test_intra_threads_default_and_cap() {
+        assert_eq!(clamp_intra_threads(None), 1);
+        assert_eq!(clamp_intra_threads(Some("")), 1);
+        assert_eq!(clamp_intra_threads(Some("0")), 1);
+        assert_eq!(clamp_intra_threads(Some("1")), 1);
+        assert_eq!(clamp_intra_threads(Some("4")), 4);
+        assert_eq!(clamp_intra_threads(Some("8")), 8);
+        assert_eq!(clamp_intra_threads(Some("16")), 8);
+        assert_eq!(clamp_intra_threads(Some("nope")), 1);
     }
 
     // ---- load_config_from_file tests ----

--- a/crates/redact-ner/tests/ner_e2e.rs
+++ b/crates/redact-ner/tests/ner_e2e.rs
@@ -629,3 +629,60 @@ fn test_bucketed_pad_matches_fixed_512() -> Result<()> {
     }
     Ok(())
 }
+
+/// Fail-closed DistilBERT / alternate-model gate.
+///
+/// Ignored fixtures that hardcode `tests/fixtures/models/bert-base-ner` can
+/// pass without loading the model under `CENSGATE_NER_MODEL_PATH`. This test
+/// requires that path when set, loads it, and runs the prose fixtures.
+#[test]
+fn test_ner_honors_censgate_ner_model_path() -> Result<()> {
+    let Ok(model_path) = std::env::var("CENSGATE_NER_MODEL_PATH") else {
+        eprintln!("skip: CENSGATE_NER_MODEL_PATH unset");
+        return Ok(());
+    };
+    let model_path = model_path.trim();
+    anyhow::ensure!(
+        !model_path.is_empty() && Path::new(model_path).is_file(),
+        "CENSGATE_NER_MODEL_PATH={model_path} is missing or not a file"
+    );
+    let model_dir = Path::new(model_path)
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("CENSGATE_NER_MODEL_PATH has no parent directory"))?;
+    let tokenizer = model_dir.join("tokenizer.json");
+    anyhow::ensure!(
+        tokenizer.is_file(),
+        "tokenizer.json missing next to {}",
+        model_path
+    );
+
+    let recognizer = NerRecognizer::from_config(NerConfig {
+        model_path: model_path.to_string(),
+        tokenizer_path: Some(tokenizer.to_string_lossy().into_owned()),
+        min_confidence: 0.7,
+        ..Default::default()
+    })?;
+    anyhow::ensure!(
+        recognizer.is_available(),
+        "NER did not load from {model_path}"
+    );
+
+    for test_case in get_test_cases() {
+        let results = recognizer.analyze(test_case.text, "en")?;
+        for (expected_type, expected_text) in &test_case.expected_entities {
+            let found = results.iter().any(|r| {
+                r.entity_type == *expected_type && r.text.as_deref() == Some(*expected_text)
+            });
+            anyhow::ensure!(
+                found,
+                "expected {:?} '{}' in '{}' via {}; got {:?}",
+                expected_type,
+                expected_text,
+                test_case.text,
+                model_path,
+                results
+            );
+        }
+    }
+    Ok(())
+}

--- a/deploy/kubernetes/redact-gateway.yaml
+++ b/deploy/kubernetes/redact-gateway.yaml
@@ -1,24 +1,31 @@
-# Kubernetes manifests for redact-gateway.
+# Kubernetes manifests for redact-gateway (production / beta shape).
 #
-# This sample is deliberately single-replica and authenticated-by-default-off,
-# because those two choices interact. Read the checklist before exposing it
-# beyond a trusted network:
+# Required topology: n replicas + HPA + vault_kv2 against **openbao-tokens**
+# (not the ESO secrets OpenBao) + a shared CENSGATE_TOKEN_DEK from the secrets
+# OpenBao via ESO. replica=1 / vault.backend=off is local-dev only.
 #
-#   1. auth.mode below is `none`, which accepts any caller that can reach the
-#      Service. Set it to `api_key` or `oidc` before the gateway is reachable
-#      by anything you do not control. See docs/gateway/authentication.md.
-#   2. replicas is 1. Token mappings live in the gateway process unless
-#      vault.backend is vault_kv2, so a second replica cannot restore a token
-#      the first one minted. Scale out only after configuring a shared token
-#      map, and give every replica the same CENSGATE_TOKEN_DEK.
-#   3. The Secret below contains placeholders that the gateway REFUSES to
-#      start with. Create the real Secret yourself; do not apply the template.
+# Checklist:
+#   1. auth.mode is api_key. Replace the Secret keys before the Service is
+#      reachable by callers you do not control. OIDC is also fine.
+#   2. Token maps live in openbao-tokens. Any replica must restore any token.
+#      Service has no session affinity.
+#   3. CENSGATE_TOKEN_DEK is a secret (ESO from openbao / ClusterSecretStore
+#      censgate-openbao). Token **blobs** never land on the secrets cluster.
+#   4. Kubernetes auth role is `redact-gateway`. Never `external-secrets`.
 #
-# Apply (after creating secrets):
-#   kubectl apply -f deploy/kubernetes/
+# Apply (after creating secrets / ESO):
+#   kubectl apply -f deploy/kubernetes/redact-gateway.yaml
 #
 # Image naming matches release.yml: ghcr.io/<org>/redact-gateway:<tag>
-# (suffix form, same pattern as ghcr.io/<org>/redact-ner-base).
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redact-gateway
+  labels:
+    app.kubernetes.io/name: redact-gateway
+automountServiceAccountToken: true
 
 ---
 # Non-secret gateway configuration. Mounted read-only at /etc/redact-gateway.
@@ -45,14 +52,16 @@ data:
       paths:
         - /app/patterns
     vault:
-      # "off" keeps token mappings inside the request that minted them. Use
-      # vault_kv2 (with vault.address) for tokens that survive a restart or
-      # need to be restored by another replica.
-      backend: "off"
+      backend: vault_kv2
+      address: http://openbao-tokens.openbao-tokens.svc.cluster.local:8200
+      auth: kubernetes
+      kubernetes_role: redact-gateway
+      kubernetes_mount: kubernetes
+      mount: tokens
+      path_prefix: redact-gateway
     auth:
-      # LOCAL / TRUSTED-NETWORK ONLY. Change to api_key or oidc before this
-      # Service is reachable by callers you do not control.
-      mode: none
+      # Internet-facing Services must not use none.
+      mode: api_key
     audit:
       export: otlp
       queue_capacity: 1024
@@ -62,15 +71,15 @@ data:
       genai_attributes: false
 
 ---
-# Secret TEMPLATE — the values below are placeholders and will NOT start the
-# gateway. Create the real Secret out of band instead of applying this:
+# Secret TEMPLATE — placeholders will NOT start the gateway. Prefer ESO for
+# CENSGATE_TOKEN_DEK (see ExternalSecret below). Create the provider key
+# out of band:
 #
 #   kubectl create secret generic redact-gateway-secrets \
 #     --from-literal=CENSGATE_PROVIDER_API_KEY='sk-...' \
-#     --from-literal=CENSGATE_TOKEN_DEK="$(openssl rand -base64 32)"
+#     --from-literal=CENSGATE_API_KEYS='gw-...'
 #
-# A sealing key of all zero bytes is rejected at startup precisely so a
-# copied template cannot become a production key.
+# A sealing key of all zero bytes is rejected at startup.
 apiVersion: v1
 kind: Secret
 metadata:
@@ -79,13 +88,33 @@ metadata:
     app.kubernetes.io/name: redact-gateway
 type: Opaque
 stringData:
-  # Bearer token sent to the OpenAI-compatible provider.
   CENSGATE_PROVIDER_API_KEY: "REPLACE_ME"
-  # Base64-encoded 32-byte key sealing reversible token mappings, shared by
-  # every replica. Generate with: openssl rand -base64 32
-  # Leaving this unset is safer than leaving it wrong: the gateway then
-  # generates an ephemeral key and logs that tokens will not outlive the pod.
+  CENSGATE_API_KEYS: "REPLACE_ME"
+  # Prefer ExternalSecret from secrets OpenBao. Leave unset rather than zeros.
   CENSGATE_TOKEN_DEK: "REPLACE_ME_openssl_rand_base64_32"
+
+---
+# DEK from the **secrets** OpenBao via ESO. Token blobs stay on openbao-tokens.
+# Requires ClusterSecretStore/censgate-openbao. Path must exist before apply.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: redact-gateway-dek
+  labels:
+    app.kubernetes.io/name: redact-gateway
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: censgate-openbao
+    kind: ClusterSecretStore
+  target:
+    name: redact-gateway-secrets
+    creationPolicy: Merge
+  data:
+    - secretKey: CENSGATE_TOKEN_DEK
+      remoteRef:
+        key: censgate/aks-censgate-beta/redact-gateway/dek
+        property: CENSGATE_TOKEN_DEK
 
 ---
 apiVersion: apps/v1
@@ -95,9 +124,7 @@ metadata:
   labels:
     app.kubernetes.io/name: redact-gateway
 spec:
-  # Keep at 1 unless vault.backend is vault_kv2: without a shared token map a
-  # second replica cannot restore tokens minted by the first.
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app.kubernetes.io/name: redact-gateway
@@ -106,7 +133,15 @@ spec:
       labels:
         app.kubernetes.io/name: redact-gateway
     spec:
-      # Distroless nonroot UID (matches USER nonroot:nonroot in Dockerfile.gateway)
+      serviceAccountName: redact-gateway
+      automountServiceAccountToken: true
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: redact-gateway
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532
@@ -127,10 +162,22 @@ spec:
               containerPort: 8080
               protocol: TCP
           env:
-            # Reviewed compliance/PII packs only; security/optional are opt-in.
             - name: CENSGATE_PATTERN_PACKS
               value: /app/patterns/compliance:/app/patterns/pii
-            # OTLP transport (not part of the YAML schema — use OTEL_* vars).
+            - name: CENSGATE_NER_SESSION_POOL
+              value: "2"
+            - name: CENSGATE_NER_INTRA_THREADS
+              value: "2"
+            - name: CENSGATE_VAULT_BACKEND
+              value: vault_kv2
+            - name: CENSGATE_VAULT_ADDR
+              value: http://openbao-tokens.openbao-tokens.svc.cluster.local:8200
+            - name: CENSGATE_VAULT_AUTH
+              value: kubernetes
+            - name: CENSGATE_VAULT_K8S_ROLE
+              value: redact-gateway
+            - name: CENSGATE_VAULT_MOUNT
+              value: tokens
             - name: OTEL_SERVICE_NAME
               value: redact-gateway
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -142,32 +189,38 @@ spec:
                 secretKeyRef:
                   name: redact-gateway-secrets
                   key: CENSGATE_PROVIDER_API_KEY
-            # Optional: omit entirely to run with an ephemeral per-pod key.
+            - name: CENSGATE_API_KEYS
+              valueFrom:
+                secretKeyRef:
+                  name: redact-gateway-secrets
+                  key: CENSGATE_API_KEYS
             - name: CENSGATE_TOKEN_DEK
               valueFrom:
                 secretKeyRef:
                   name: redact-gateway-secrets
                   key: CENSGATE_TOKEN_DEK
-                  optional: true
           resources:
             requests:
-              cpu: 100m
-              memory: 256Mi
+              cpu: "4"
+              memory: 4Gi
             limits:
-              cpu: "2"
-              memory: 1Gi
-          # Distroless has no shell — use HTTP probes against the binary.
+              cpu: "4"
+              memory: 4Gi
+          startupProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            periodSeconds: 5
+            failureThreshold: 24
           livenessProbe:
             httpGet:
               path: /livez
               port: http
-            initialDelaySeconds: 5
             periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /readyz
               port: http
-            initialDelaySeconds: 3
             periodSeconds: 5
           securityContext:
             allowPrivilegeEscalation: false
@@ -178,7 +231,6 @@ spec:
             - name: config
               mountPath: /etc/redact-gateway
               readOnly: true
-            # Writable scratch for any temporary needs under a read-only root.
             - name: tmp
               mountPath: /tmp
       volumes:
@@ -197,6 +249,8 @@ metadata:
     app.kubernetes.io/name: redact-gateway
 spec:
   type: ClusterIP
+  # Any replica must restore any token (maps live in openbao-tokens).
+  sessionAffinity: None
   selector:
     app.kubernetes.io/name: redact-gateway
   ports:
@@ -204,3 +258,88 @@ spec:
       port: 8080
       targetPort: http
       protocol: TCP
+
+---
+# HPA on CPU only after the ONNX mutex is gone and requests are realistic.
+# Prefer queue / onnx.lock_wait / p99 when those metrics are scraped.
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: redact-gateway
+  labels:
+    app.kubernetes.io/name: redact-gateway
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: redact-gateway
+  minReplicas: 2
+  maxReplicas: 8
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redact-gateway
+  labels:
+    app.kubernetes.io/name: redact-gateway
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redact-gateway
+
+---
+# Gateway talks to openbao-tokens only. ESO stays on the secrets OpenBao.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: redact-gateway
+  labels:
+    app.kubernetes.io/name: redact-gateway
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: redact-gateway
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 8080
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openbao-tokens
+      ports:
+        - protocol: TCP
+          port: 8200
+    - to: {}
+      ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 11434
+        - protocol: TCP
+          port: 4317

--- a/deploy/kubernetes/redact-gateway.yaml
+++ b/deploy/kubernetes/redact-gateway.yaml
@@ -13,7 +13,8 @@
 #      censgate-openbao). Token **blobs** never land on the secrets cluster.
 #   4. Kubernetes auth role is `redact-gateway`. Never `external-secrets`.
 #
-# Apply (after creating secrets / ESO):
+# Apply (after creating operator secrets / ESO). This file does **not**
+# contain a Secret — `kubectl apply` must not overwrite live API keys.
 #   kubectl apply -f deploy/kubernetes/redact-gateway.yaml
 #
 # Image naming matches release.yml: ghcr.io/<org>/redact-gateway:<tag>
@@ -71,31 +72,14 @@ data:
       genai_attributes: false
 
 ---
-# Secret TEMPLATE — placeholders will NOT start the gateway. Prefer ESO for
-# CENSGATE_TOKEN_DEK (see ExternalSecret below). Create the provider key
-# out of band:
+# DEK from the **secrets** OpenBao via ESO. Token blobs stay on openbao-tokens.
+# Own target Secret — never merge into the operator-owned API-key Secret.
+# Requires ClusterSecretStore/censgate-openbao. Path must exist before apply.
 #
+# Create provider + inbound keys out of band (this manifest never owns them):
 #   kubectl create secret generic redact-gateway-secrets \
 #     --from-literal=CENSGATE_PROVIDER_API_KEY='sk-...' \
 #     --from-literal=CENSGATE_API_KEYS='gw-...'
-#
-# A sealing key of all zero bytes is rejected at startup.
-apiVersion: v1
-kind: Secret
-metadata:
-  name: redact-gateway-secrets
-  labels:
-    app.kubernetes.io/name: redact-gateway
-type: Opaque
-stringData:
-  CENSGATE_PROVIDER_API_KEY: "REPLACE_ME"
-  CENSGATE_API_KEYS: "REPLACE_ME"
-  # Prefer ExternalSecret from secrets OpenBao. Leave unset rather than zeros.
-  CENSGATE_TOKEN_DEK: "REPLACE_ME_openssl_rand_base64_32"
-
----
-# DEK from the **secrets** OpenBao via ESO. Token blobs stay on openbao-tokens.
-# Requires ClusterSecretStore/censgate-openbao. Path must exist before apply.
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -108,8 +92,8 @@ spec:
     name: censgate-openbao
     kind: ClusterSecretStore
   target:
-    name: redact-gateway-secrets
-    creationPolicy: Merge
+    name: redact-gateway-dek
+    creationPolicy: Owner
   data:
     - secretKey: CENSGATE_TOKEN_DEK
       remoteRef:
@@ -167,7 +151,7 @@ spec:
             - name: CENSGATE_NER_SESSION_POOL
               value: "2"
             - name: CENSGATE_NER_INTRA_THREADS
-              value: "2"
+              value: "1"
             - name: CENSGATE_VAULT_BACKEND
               value: vault_kv2
             - name: CENSGATE_VAULT_ADDR
@@ -197,14 +181,16 @@ spec:
             - name: CENSGATE_TOKEN_DEK
               valueFrom:
                 secretKeyRef:
-                  name: redact-gateway-secrets
+                  name: redact-gateway-dek
                   key: CENSGATE_TOKEN_DEK
           resources:
             requests:
-              cpu: "4"
+              # 2 CPU Guaranteed schedules on D4+ (D2 allocatable is <2).
+              # 4/4 needs a D8 pool. pool × intra_threads ≈ these cores.
+              cpu: "2"
               memory: 4Gi
             limits:
-              cpu: "4"
+              cpu: "2"
               memory: 4Gi
           startupProbe:
             httpGet:

--- a/docs/entity-types.md
+++ b/docs/entity-types.md
@@ -49,9 +49,17 @@ Further provider coverage belongs in a pack PR, not in `redact-core`.
 | `PERSON` | Person names in prose |
 | `ORGANIZATION` | Organization names in prose |
 | `LOCATION` | Location names in prose |
-| `DATE_TIME` | Date/time expressions in context (also a compiled pattern type) |
 
 Requires an ONNX model. See [NER](ner.md).
+
+`DATE_TIME` is a **compiled pattern type**, not a NER product. The default
+CoNLL model does not annotate dates. `IdentityRecognizer` drops NER
+`DATE_TIME` / `MISC` date-like spans — “pattern packs own dates.” The
+compiled pattern is ISO-only (`YYYY-MM-DD` with optional time); pack
+`global_date_common` adds slash dates. Relative phrases (“next Friday”,
+“January 15”, “3pm”) are **not** redacted by default. The gateway default
+policy allows `DATE_TIME` because date NER is a known FP firehose. Do not
+map `B-MISC` → `DATE_TIME`.
 
 ## Anonymization strategies
 

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -102,9 +102,13 @@ packs:
 
 vault:                             # token map settings (name is historical)
   backend: "off"                   # off | memory | vault_kv2  (quote "off")
-  address: null
-  token: null
-  mount: secret
+  address: null                    # openbao-tokens SVC in AKS
+  auth: token                      # token (local-dev) | kubernetes (HPA)
+  token: null                      # static token; local-dev only
+  kubernetes_role: null            # redact-gateway; never external-secrets
+  kubernetes_mount: kubernetes
+  jwt_path: /var/run/secrets/kubernetes.io/serviceaccount/token
+  mount: secret                    # tokens on openbao-tokens
   path_prefix: redact-gateway
   namespace: null
   ttl_secs: 3600
@@ -195,10 +199,16 @@ Each setting has exactly one environment name under the `CENSGATE_` prefix. The 
 | `CENSGATE_DISABLE_BUILTIN_PATTERNS` | `false` | Skip built-in patterns |
 | `CENSGATE_NER_MODEL_PATH` | unset | Path to ONNX `model.onnx` (tokenizer beside it) |
 | `CENSGATE_NER_REQUIRED` | `false` | Fail startup if NER cannot load |
+| `CENSGATE_NER_SESSION_POOL` | `2` | ONNX session pool (cap 4) |
+| `CENSGATE_NER_INTRA_THREADS` | `1` | ORT intra-op threads per session (cap 8). `pool × intra ≈` pod CPUs |
 | `CENSGATE_VAULT_BACKEND` | `off` | Token map backend (`off`, `memory`, `vault_kv2`) |
-| `CENSGATE_VAULT_ADDR` / `VAULT_ADDR` / `BAO_ADDR` | unset | KV v2 address |
-| `CENSGATE_VAULT_TOKEN` / `VAULT_TOKEN` / `BAO_TOKEN` | unset | KV v2 token |
-| `CENSGATE_VAULT_MOUNT` | `secret` | KV v2 mount |
+| `CENSGATE_VAULT_ADDR` / `VAULT_ADDR` / `BAO_ADDR` | unset | KV v2 address (`openbao-tokens` SVC in AKS) |
+| `CENSGATE_VAULT_AUTH` | `token` | `token` (local-dev) or `kubernetes` (HPA) |
+| `CENSGATE_VAULT_TOKEN` / `VAULT_TOKEN` / `BAO_TOKEN` | unset | Static KV token (local-dev only) |
+| `CENSGATE_VAULT_K8S_ROLE` | unset | Kubernetes auth role (`redact-gateway`; never `external-secrets`) |
+| `CENSGATE_VAULT_K8S_MOUNT` | `kubernetes` | Kubernetes auth mount |
+| `CENSGATE_VAULT_JWT_PATH` | SA token path | Projected ServiceAccount JWT |
+| `CENSGATE_VAULT_MOUNT` | `secret` | KV v2 mount (`tokens` on openbao-tokens) |
 | `CENSGATE_VAULT_PATH_PREFIX` | `redact-gateway` | Path prefix |
 | `CENSGATE_VAULT_NAMESPACE` / `VAULT_NAMESPACE` | unset | Namespace header |
 | `CENSGATE_TOKEN_TTL_SECS` | `3600` | Mapping TTL |

--- a/docs/gateway/deployment.md
+++ b/docs/gateway/deployment.md
@@ -76,11 +76,15 @@ production topology.
 
 ```bash
 # Provider key + inbound API keys (do not commit real values).
-# CENSGATE_TOKEN_DEK should come from the secrets OpenBao via ESO
-# (ExternalSecret in the sample). For a local cluster without ESO:
+# This Secret is operator-owned. The sample manifest does not include it,
+# so `kubectl apply -f` cannot overwrite live keys with placeholders.
 kubectl create secret generic redact-gateway-secrets \
   --from-literal=CENSGATE_PROVIDER_API_KEY='…' \
-  --from-literal=CENSGATE_API_KEYS='…' \
+  --from-literal=CENSGATE_API_KEYS='…'
+
+# CENSGATE_TOKEN_DEK comes from the secrets OpenBao via ESO
+# (ExternalSecret target `redact-gateway-dek`). For a local cluster without ESO:
+kubectl create secret generic redact-gateway-dek \
   --from-literal=CENSGATE_TOKEN_DEK="$(openssl rand -base64 32)"
 
 kubectl apply -f deploy/kubernetes/redact-gateway.yaml
@@ -92,10 +96,12 @@ The sample:
 - ConfigMap: `vault.backend=vault_kv2`, address
   `http://openbao-tokens.openbao-tokens.svc.cluster.local:8200`,
   `auth=kubernetes`, role `redact-gateway` (never `external-secrets`)
-- ExternalSecret merges `CENSGATE_TOKEN_DEK` from secrets OpenBao path
-  `censgate/aks-censgate-beta/redact-gateway/dek`
-- Deployment `replicas: 2`, Guaranteed QoS 4 CPU / 4Gi, startupProbe on
-  `/readyz` (NER load + OpenBao health), topology spread
+- ExternalSecret owns `redact-gateway-dek` (`CENSGATE_TOKEN_DEK`) from
+  secrets OpenBao path `censgate/aks-censgate-beta/redact-gateway/dek`.
+  Companion Flux/Helm for the tokens cluster is
+  [cloud-infrastructure#111](https://github.com/censgate/cloud-infrastructure/pull/111).
+- Deployment `replicas: 2`, Guaranteed QoS 2 CPU / 4Gi (D4+; 4/4 needs D8),
+  startupProbe on `/readyz` (NER load + OpenBao health), topology spread
 - HPA minReplicas 2 / maxReplicas 8; ClusterIP **without** session affinity
 - NetworkPolicy: egress to `openbao-tokens:8200` only for KV
 - `auth.mode: api_key` (not `none`)
@@ -109,7 +115,7 @@ The sample:
 | Shared token map | Production must use `vault_kv2` against **openbao-tokens** plus a shared `CENSGATE_TOKEN_DEK` from the secrets OpenBao via ESO. `off` / `memory` are local-dev only. Do not point the gateway at `openbao.openbao.svc`. |
 | Fail-closed profiles | Keep `fail_closed: true` on production profiles so dependency failures reject rather than forward unprotected content. |
 | Audit sink | Set `CENSGATE_AUDIT_EXPORT` to `otlp` (preferred) or `file`, and retain records in a collector / object store with your retention policy. |
-| Resource limits | Guaranteed QoS: integer CPU request = limit (sample is 4/4 CPU, 4Gi). Cap bodies with `CENSGATE_PROVIDER_MAX_BODY_BYTES`. Set `CENSGATE_NER_SESSION_POOL` × `CENSGATE_NER_INTRA_THREADS` to match those cores. |
+| Resource limits | Guaranteed QoS: integer CPU request = limit (sample is 2/2 CPU, 4Gi; needs D4+ allocatable). Cap bodies with `CENSGATE_PROVIDER_MAX_BODY_BYTES`. Set `CENSGATE_NER_SESSION_POOL` × `CENSGATE_NER_INTRA_THREADS` to match those cores. |
 | Upstream TLS | Prefer `https://` upstream URLs. Inject provider keys via secrets, not ConfigMaps. |
 | Profile selection | `allow_profile_header` defaults to `false`. Leave it off when profiles come from JWT claims; enabling it without inbound auth lets any caller choose any profile. |
 | Session restore | `/v1/restore` requires `api_key` or `oidc`. With `auth.mode = none`, chat-surface session resumption keys only on `x-censgate-session-id` — safe only on a trusted network. |

--- a/docs/gateway/deployment.md
+++ b/docs/gateway/deployment.md
@@ -62,29 +62,43 @@ curl -s http://localhost:8080/readyz
 
 Collector config: [`deploy/otel-collector.yaml`](../../deploy/otel-collector.yaml).
 
-With `vault_kv2`, concurrent writers to the same session use KV v2 check-and-set with up to five read-merge-write retries. Under sustained contention on a single session a write can still exhaust those retries and fail the request; each attempt costs a read plus a write.
+With `vault_kv2`, concurrent writers to the same session use KV v2 check-and-set with up to eight jittered read-merge-write retries. Empty incoming mapping sets skip the write. Under sustained contention on a single session a write can still exhaust those retries and fail the request; each attempt costs a read plus a write. Production maps belong on **`openbao-tokens`**, not the ESO secrets OpenBao. See [openbao-tokens SPIKE](openbao-tokens-spike.md).
+
+Compose `--profile vault` is OpenBao **dev mode** + a static token. Local only. It is neither AKS cluster.
 
 ## Kubernetes
 
 Manifests: [`deploy/kubernetes/redact-gateway.yaml`](../../deploy/kubernetes/redact-gateway.yaml).
 
+Production / beta shape is **n replicas + HPA + `vault_kv2` against
+`openbao-tokens`**. `replica=1` / `vault.backend=off` is not a supported
+production topology.
+
 ```bash
-# Create secrets (do not commit real values)
+# Provider key + inbound API keys (do not commit real values).
+# CENSGATE_TOKEN_DEK should come from the secrets OpenBao via ESO
+# (ExternalSecret in the sample). For a local cluster without ESO:
 kubectl create secret generic redact-gateway-secrets \
   --from-literal=CENSGATE_PROVIDER_API_KEY='…' \
+  --from-literal=CENSGATE_API_KEYS='…' \
   --from-literal=CENSGATE_TOKEN_DEK="$(openssl rand -base64 32)"
 
 kubectl apply -f deploy/kubernetes/redact-gateway.yaml
 ```
 
-The Deployment:
+The sample:
 
-- Mounts a ConfigMap gateway YAML at `/etc/redact-gateway`
-- Injects secrets via env
-- Sets OTLP exporter env vars toward a collector service
-- Uses HTTP liveness (`/livez`) and readiness (`/readyz`) probes
-- Runs non-root with a read-only root filesystem and dropped capabilities
-- Defaults to **one** replica. Scale out only after configuring `vault_kv2` and a shared `CENSGATE_TOKEN_DEK`
+- ServiceAccount `redact-gateway` with a projected JWT for Kubernetes auth
+- ConfigMap: `vault.backend=vault_kv2`, address
+  `http://openbao-tokens.openbao-tokens.svc.cluster.local:8200`,
+  `auth=kubernetes`, role `redact-gateway` (never `external-secrets`)
+- ExternalSecret merges `CENSGATE_TOKEN_DEK` from secrets OpenBao path
+  `censgate/aks-censgate-beta/redact-gateway/dek`
+- Deployment `replicas: 2`, Guaranteed QoS 4 CPU / 4Gi, startupProbe on
+  `/readyz` (NER load + OpenBao health), topology spread
+- HPA minReplicas 2 / maxReplicas 8; ClusterIP **without** session affinity
+- NetworkPolicy: egress to `openbao-tokens:8200` only for KV
+- `auth.mode: api_key` (not `none`)
 
 ## Hardening checklist
 
@@ -92,10 +106,10 @@ The Deployment:
 |------|----------|
 | Enable auth | Set `CENSGATE_AUTH_MODE` to `api_key` or `oidc` before any untrusted edge. Mode `none` is only for trusted networks. |
 | Sealing key | Set `CENSGATE_TOKEN_DEK` (base64 32 bytes) whenever tokenization is used. Share the same value across replicas. |
-| Shared token map | Use `vault_kv2` (Vault or OpenBao) for multi-replica deployments. The `memory` and `off` backends are not HashiCorp Vault; `memory` is process-local. |
+| Shared token map | Production must use `vault_kv2` against **openbao-tokens** plus a shared `CENSGATE_TOKEN_DEK` from the secrets OpenBao via ESO. `off` / `memory` are local-dev only. Do not point the gateway at `openbao.openbao.svc`. |
 | Fail-closed profiles | Keep `fail_closed: true` on production profiles so dependency failures reject rather than forward unprotected content. |
 | Audit sink | Set `CENSGATE_AUDIT_EXPORT` to `otlp` (preferred) or `file`, and retain records in a collector / object store with your retention policy. |
-| Resource limits | Set CPU/memory requests and limits (the sample Deployment uses 100m–2 CPU and 256Mi–1Gi as a starting point). Cap bodies with `CENSGATE_PROVIDER_MAX_BODY_BYTES`. |
+| Resource limits | Guaranteed QoS: integer CPU request = limit (sample is 4/4 CPU, 4Gi). Cap bodies with `CENSGATE_PROVIDER_MAX_BODY_BYTES`. Set `CENSGATE_NER_SESSION_POOL` × `CENSGATE_NER_INTRA_THREADS` to match those cores. |
 | Upstream TLS | Prefer `https://` upstream URLs. Inject provider keys via secrets, not ConfigMaps. |
 | Profile selection | `allow_profile_header` defaults to `false`. Leave it off when profiles come from JWT claims; enabling it without inbound auth lets any caller choose any profile. |
 | Session restore | `/v1/restore` requires `api_key` or `oidc`. With `auth.mode = none`, chat-surface session resumption keys only on `x-censgate-session-id` — safe only on a trusted network. |

--- a/docs/gateway/openbao-tokens-spike.md
+++ b/docs/gateway/openbao-tokens-spike.md
@@ -1,0 +1,78 @@
+# SPIKE: OpenBao tokens cluster (high concurrency / low latency)
+
+This is **not** a claim that OpenBao cannot scale. KV v2 + Raft is a proven
+write path when the cluster is sized for it. The claim is: the AKS **secrets**
+OpenBao (`100m`/`256Mi`, Raft multiplier 5, shared with ESO) will not meet
+gateway p99, and **must not** be retuned to try.
+
+Run this SPIKE only against **`openbao-tokens`**.
+
+Related: [`censgate/cloud-infrastructure` `infrastructure/openbao-tokens`](https://github.com/censgate/cloud-infrastructure/tree/main/infrastructure/openbao-tokens),
+[`scripts/bench-gateway-ner.sh`](../../scripts/bench-gateway-ner.sh).
+
+## Two deployments
+
+| Cluster | Workload | Tune for |
+|---|---|---|
+| `openbao` (secrets) | ESO, `CENSGATE_TOKEN_DEK`, JWT, Stripe | Read-mostly. Leave as-is. |
+| `openbao-tokens` | Gateway `vault_kv2` session maps | Write + CAS, Premium SSD, `performance_multiplier=1`, 2 CPU / 2Gi |
+
+Gateway `CENSGATE_VAULT_ADDR` →
+`http://openbao-tokens.openbao-tokens.svc.cluster.local:8200`.
+
+The DEK still comes from the **secrets** cluster via ESO. Token blobs never
+land there. Kubernetes auth role is `redact-gateway`, never `external-secrets`.
+
+## Hypotheses
+
+**A. Operator knobs** (cloud-infrastructure `openbao-tokens`) — own
+HelmRelease/namespace/PVCs, `max_versions=1`, `cas_required=true`, Raft
+multiplier 1, Guaranteed QoS, Premium SSD.
+
+**B. Client knobs** (this repo) — cache the Kubernetes-auth token and renew
+before lease expiry; jitter CAS backoff (8 attempts); skip `put` when
+`mappings` is empty; cache `/readyz` health for 2s so probes do not serialize
+on the Raft leader.
+
+**C. Key shape** — today one JSON blob per session (CAS domain = session).
+Alt: one key per token. Measure same-session conc 20 before changing.
+
+**D. OpenBao 2.5+ read standbys** — only if the running image actually serves
+KV reads on standbys. Chart `0.28.3` does not guarantee that.
+
+**E. Escape hatch** — Transit-on-tokens + Valkey for blobs **only** after A–C
+miss the bar on this cluster. Not the default. No plaintext in Redis. No
+session affinity.
+
+## Experiment design
+
+Hold NER weights fixed. Drive `POST /v1/redact` tokenize + `POST /v1/restore`.
+
+```bash
+GATEWAY_URL=http://127.0.0.1:8080 \
+GATEWAY_API_KEY=… \
+./scripts/bench-gateway-ner.sh
+```
+
+| Slice | What we learn |
+|---|---|
+| Unique sessions, conc 1/20/100 | Leader write / fsync floor |
+| Same session, conc 5/20 | CAS collision rate and retry tax |
+| Restore-only, n replicas | Read path; standby benefit if 2.5+ |
+| After each of A, then B, then C | Which knob moves p50/p99 |
+
+## Draft pass bar
+
+Refine after first numbers. Do **not** quote the 32× Presidio figure here
+(that number is `redact-api`, conc 1, pattern-only).
+
+- Unique-session tokenize OpenBao overhead: **p50 < 5 ms**, **p99 < 20 ms**
+- Same-session conc 20: **< 1%** fail-closed CAS exhaustion
+- Restore-after-scale: **100%** (pod B opens a token minted on pod A)
+
+## Go / no-go
+
+- **Go:** stay on KV v2 session blobs against `openbao-tokens`.
+- **No-go:** only after A–C miss the bar on that cluster. Then evaluate
+  Transit + Valkey. Document measured numbers in this file before changing
+  the default architecture.

--- a/docs/gateway/openbao-tokens-spike.md
+++ b/docs/gateway/openbao-tokens-spike.md
@@ -7,7 +7,9 @@ gateway p99, and **must not** be retuned to try.
 
 Run this SPIKE only against **`openbao-tokens`**.
 
-Related: [`censgate/cloud-infrastructure` `infrastructure/openbao-tokens`](https://github.com/censgate/cloud-infrastructure/tree/main/infrastructure/openbao-tokens),
+Related: cloud-infrastructure PR
+[#111](https://github.com/censgate/cloud-infrastructure/pull/111)
+(`infrastructure/openbao-tokens`),
 [`scripts/bench-gateway-ner.sh`](../../scripts/bench-gateway-ner.sh).
 
 ## Two deployments

--- a/docs/gateway/tokenization.md
+++ b/docs/gateway/tokenization.md
@@ -48,7 +48,7 @@ Startup refuses a key that is not valid base64, that does not decode to 32 bytes
 |---------|--------------------------|-----------|
 | Off | `off` (default) | No persistence. Tokens are minted and restored **within the request that created them**; they cannot be resumed by a later request, recovered through `/v1/restore`, or shared with another replica. |
 | Memory | `memory` | Process-local map with TTL. Tokens do not survive a restart or reach another replica. Suitable for development and single-node testing. |
-| KV v2 | `vault_kv2` | Speaks the HashiCorp Vault KV v2 HTTP API; works with both **HashiCorp Vault** and **OpenBao**. Auth token is an opaque `X-Vault-Token`. |
+| KV v2 | `vault_kv2` | Speaks the HashiCorp Vault KV v2 HTTP API; works with both **HashiCorp Vault** and **OpenBao**. Production authenticates with **Kubernetes auth** against `openbao-tokens`. A static token is local-dev only. |
 
 Sealed-mapping property: stores hold only `sealed_value` ciphertext plus metadata (`token`, `entity_type`, `created_at`). Opening always requires the gateway DEK.
 
@@ -65,9 +65,12 @@ export CENSGATE_DEFAULT_PROFILE=reversible
 
 ### Vault / OpenBao KV v2
 
+Local-dev (static token, compose OpenBao `-dev`):
+
 ```bash
 export CENSGATE_VAULT_BACKEND=vault_kv2
 export CENSGATE_VAULT_ADDR=http://127.0.0.1:8200   # or BAO_ADDR / VAULT_ADDR
+export CENSGATE_VAULT_AUTH=token
 export CENSGATE_VAULT_TOKEN=hvs.…                    # or BAO_TOKEN / VAULT_TOKEN
 export CENSGATE_VAULT_MOUNT=secret
 export CENSGATE_VAULT_PATH_PREFIX=redact-gateway
@@ -75,7 +78,20 @@ export CENSGATE_TOKEN_TTL_SECS=3600
 export CENSGATE_TOKEN_DEK="$(openssl rand -base64 32)"
 ```
 
-Paths are `{prefix}/{tenant}/{session}` with tenant and session percent-encoded so `/` and `..` cannot escape the prefix. Writes merge with existing mappings using KV v2 check-and-set (`options.cas`) with up to five read-merge-write retries, so concurrent writers do not silently lose mappings. Under sustained contention on a single session a write can still exhaust those retries and fail the request; each attempt costs a read plus a write. Expired sessions are treated as absent.
+AKS / beta (Kubernetes auth against **openbao-tokens**, DEK from secrets OpenBao):
+
+```bash
+export CENSGATE_VAULT_BACKEND=vault_kv2
+export CENSGATE_VAULT_ADDR=http://openbao-tokens.openbao-tokens.svc.cluster.local:8200
+export CENSGATE_VAULT_AUTH=kubernetes
+export CENSGATE_VAULT_K8S_ROLE=redact-gateway   # never external-secrets
+export CENSGATE_VAULT_MOUNT=tokens
+export CENSGATE_TOKEN_DEK   # projected by ESO from the secrets cluster
+```
+
+Paths are `{prefix}/{tenant}/{session}` with tenant and session percent-encoded so `/` and `..` cannot escape the prefix. Writes merge with existing mappings using KV v2 check-and-set (`options.cas`) with up to eight jittered read-merge-write retries. An empty incoming mapping set skips the write. Under sustained contention on a single session a write can still exhaust those retries and fail the request. Expired sessions are treated as absent. `/readyz` caches OpenBao health for two seconds.
+
+OSS gateway `vault_kv2` on `openbao-tokens` is the supported multi-replica path. Platform may still seal display names locally with its own DEK; that is a different contract.
 
 Requires the `vault` Cargo feature (enabled by default).
 

--- a/docs/ner.md
+++ b/docs/ner.md
@@ -1,8 +1,13 @@
 # ML-powered NER
 
 Optional ONNX Runtime integration for transformer-based named entity
-recognition (`PERSON`, `ORGANIZATION`, `LOCATION`, contextual `DATE_TIME`).
-The compiled pattern engine (61 types) does not require NER.
+recognition (`PERSON`, `ORGANIZATION`, `LOCATION`). The compiled pattern
+engine (61 types) does not require NER.
+
+**DATE_TIME is not a NER product.** The default CoNLL model has no date
+labels. `IdentityRecognizer` drops any NER `DATE_TIME` span — pattern packs
+own ISO / slash dates. Do not enable a DATE-capable NER to chase “next
+Friday” or “January 15”; those are high-FP. See [entity types](entity-types.md).
 
 ## Export a HuggingFace model
 
@@ -12,6 +17,10 @@ python scripts/export_ner_model.py \
     --model dslim/bert-base-NER \
     --output models/bert-base-ner
 ```
+
+`--quantize` runs dynamic INT8 via `onnxruntime.quantization`. It can move
+logits across the 0.7 confidence floor. Do not ship an INT8 graph without a
+CoNLL PER/ORG/LOC F1 floor versus the FP32 export.
 
 Required files for inference: `model.onnx` and `tokenizer.json`.
 
@@ -34,16 +43,50 @@ let mut engine = AnalyzerEngine::new();
 engine.recognizer_registry_mut().add_recognizer(Arc::new(ner));
 ```
 
+## Serving path (same weights)
+
+When the ONNX `input_ids` sequence dim is dynamic, pad to buckets
+`32 / 64 / 128 / 256 / 512` instead of always 512. A bounded session pool
+(`CENSGATE_NER_SESSION_POOL`, default 2, cap 4) plus
+`CENSGATE_NER_INTRA_THREADS` (default 1) should satisfy
+`pool × intra ≈` Guaranteed pod CPUs. Gateway analyze runs on the tokio
+blocking pool (`block_in_place` / `spawn_blocking`).
+
 ## Recommended models
 
-| Model | Size | Use Case |
+| Model | Size | Use case |
 |-------|------|----------|
-| `dslim/bert-base-NER` | ~420MB | Default accuracy/size balance |
-| `dbmdz/bert-large-cased-finetuned-conll03-english` | ~1.2GB | Highest accuracy |
+| `dslim/bert-base-NER` | ~420MB | **Default.** Image `NER_MODEL`. Do not swap without the gate below. |
+| `dslim/distilbert-NER` | ~250MB | Faster same-task candidate. **Gated.** See below. |
+| `dbmdz/bert-large-cased-finetuned-conll03-english` | ~1.2GB | Highest accuracy, slower |
 | `Davlan/distilbert-base-multilingual-cased-ner-hrl` | ~500MB | Multilingual |
-| `elastic/distilbert-base-cased-finetuned-conll03-english` | ~250MB | Smaller/faster |
 
-Models must use a CoNLL-2003-style BIO scheme (`B-PER`, `I-PER`, `B-ORG`, `I-ORG`, `B-LOC`, `I-LOC`).
+Models must use a CoNLL-2003-style BIO scheme (`B-PER`, `I-PER`, `B-ORG`,
+`I-ORG`, `B-LOC`, `I-LOC`). DistilBERT exports omit `token_type_ids`; the
+recognizer detects that at load.
 
-The published `ghcr.io/censgate/redact:full` image bakes in `dslim/bert-base-NER`.
-See [install](install.md).
+The published `ghcr.io/censgate/redact:full` image bakes in
+`dslim/bert-base-NER`. See [install](install.md).
+
+## Gated DistilBERT swap
+
+`dslim/distilbert-NER` (66M, Apache-2.0, published F1 ~0.922) is already
+loadable. Headline F1 is **not** feature parity. Distil can match aggregate
+F1 and still miss Censgate ORG / single-token names. `id2label` order
+differs from bert-base; `from_file` reads `config.json` from the export.
+
+Do **not** change `Dockerfile.ner-base` `ARG NER_MODEL` until
+[`scripts/validate-distilbert-ner.sh`](../scripts/validate-distilbert-ner.sh)
+records:
+
+1. CoNLL-2003 entity-level PER/ORG/LOC F1 within ~0.5–1 pt of bert-base
+2. The three prose fixtures in `crates/redact-ner/tests/ner_e2e.rs`
+3. A before/after [`scripts/bench-gateway-ner.sh`](../scripts/bench-gateway-ner.sh)
+
+```bash
+python scripts/export_ner_model.py \
+    --model dslim/distilbert-NER \
+    --output models/distilbert-ner
+export CENSGATE_NER_MODEL_PATH=$PWD/models/distilbert-ner/model.onnx
+./scripts/validate-distilbert-ner.sh
+```

--- a/docs/ner.md
+++ b/docs/ner.md
@@ -50,7 +50,8 @@ When the ONNX `input_ids` sequence dim is dynamic, pad to buckets
 (`CENSGATE_NER_SESSION_POOL`, default 2, cap 4) plus
 `CENSGATE_NER_INTRA_THREADS` (default 1) should satisfy
 `pool × intra ≈` Guaranteed pod CPUs. Gateway analyze runs on the tokio
-blocking pool (`block_in_place` / `spawn_blocking`).
+multi-thread worker via `block_in_place` (parks that worker; Tokio may
+spawn a replacement). Current-thread tests stay in-place.
 
 ## Recommended models
 

--- a/scripts/bench-gateway-ner.sh
+++ b/scripts/bench-gateway-ner.sh
@@ -67,7 +67,7 @@ curl_json() {
 redact_body() {
   local text="$1"
   local session="$2"
-  python3 -c 'import json,sys; print(json.dumps({"text": sys.argv[1], "session_id": sys.argv[2]}))' \
+  python3 -c 'import json,sys; print(json.dumps({"text": sys.argv[1], "session_id": sys.argv[2], "profile": "reversible"}))' \
     "${text}" "${session}"
 }
 
@@ -110,6 +110,7 @@ run_slice() {
   local start end
   start="$(date +%s%N)"
   for ((r = 0; r < rounds; r++)); do
+    pids=()
     for ((i = 0; i < conc; i++)); do
       (
         local session="${session_fixed}"
@@ -118,7 +119,7 @@ run_slice() {
         fi
         local payload="${text}"
         if [[ "${distinct_pii}" == "1" ]]; then
-          payload="$(python3 -c 'import sys; i=int(sys.argv[1]); print(f"Agent {i} emailed agent{i}@example{i}.com from Site{i}.")' "$((r * conc + i))")"
+          payload="$(python3 -c 'import sys; i=int(sys.argv[1]); base=sys.argv[2]; print(f"{base} Agent {i} emailed agent{i}@example{i}.com from Site{i}.")' "$((r * conc + i))" "${text}")"
         fi
         local body
         body="$(redact_body "${payload}" "${session}")"
@@ -127,7 +128,12 @@ run_slice() {
         read -r code out <<< "$(curl_json "${url}/v1/redact" "${body}")"
         t1="$(date +%s%N)"
         if [[ "${code}" == "200" ]]; then
-          python3 -c "print((${t1}-${t0})/1e6)" >> "${ms_file}"
+          if ! python3 -c 'import json,sys; t=json.load(open(sys.argv[1])).get("text",""); sys.exit(0 if "[" in t else 1)' "${out}"; then
+            echo "1" >> "${err_file}"
+            echo "  fail ${name} conc=${conc} no token placeholders in response" >&2
+          else
+            python3 -c "print((${t1}-${t0})/1e6)" >> "${ms_file}"
+          fi
         else
           echo "1" >> "${err_file}"
           echo "  fail ${name} conc=${conc} http=${code} body=$(head -c 160 "${out}")" >&2
@@ -136,10 +142,10 @@ run_slice() {
       ) &
       pids+=("$!")
     done
-  done
-  local pid
-  for pid in "${pids[@]}"; do
-    wait "${pid}" || true
+    local pid
+    for pid in "${pids[@]}"; do
+      wait "${pid}" || true
+    done
   done
   end="$(date +%s%N)"
   local wall errors ok
@@ -171,8 +177,10 @@ for conc in ${CONCS}; do
   fi
   if [[ "${SESSION_MODE}" == "same" || "${SESSION_MODE}" == "both" ]]; then
     # Distinct PII per writer so skip-empty-put does not hide CAS contention.
-    run_slice "short same-session" "${BASE}" "${short_text}" "${conc}" "bench-shared-${conc}" 1 "${ITERS}" || failed=1
-    run_slice "long same-session" "${BASE}" "${long_text}" "${conc}" "bench-shared-long-${conc}" 1 1 || failed=1
+    shared="bench-shared-$(python3 -c 'import uuid; print(uuid.uuid4())')-${conc}"
+    run_slice "short same-session" "${BASE}" "${short_text}" "${conc}" "${shared}" 1 "${ITERS}" || failed=1
+    shared_long="bench-shared-long-$(python3 -c 'import uuid; print(uuid.uuid4())')-${conc}"
+    run_slice "long same-session" "${BASE}" "${long_text}" "${conc}" "${shared_long}" 1 1 || failed=1
   fi
 done
 if [[ "${failed}" != "0" ]]; then

--- a/scripts/bench-gateway-ner.sh
+++ b/scripts/bench-gateway-ner.sh
@@ -39,6 +39,8 @@ if [[ -n "${KEY}" ]]; then
 fi
 CONCS="${BENCH_CONCURRENCY:-1 5 20}"
 SESSION_MODE="${BENCH_SESSION_MODE:-both}"
+ITERS="${BENCH_ITERS:-8}"
+ALLOW_ERRORS="${BENCH_ALLOW_ERRORS:-0}"
 
 short_text='Ada Lovelace emailed john.doe@example.com from London.'
 long_text="$(python3 - <<'PY'
@@ -99,59 +101,84 @@ run_slice() {
   local text="$3"
   local conc="$4"
   local session_fixed="$5"
-  local ms_file
+  local distinct_pii="${6:-0}"
+  local rounds="${7:-1}"
+  local ms_file err_file
   ms_file="$(mktemp)"
-  local i pids=()
+  err_file="$(mktemp)"
+  local i r pids=()
   local start end
   start="$(date +%s%N)"
-  for ((i = 0; i < conc; i++)); do
-    (
-      local session="${session_fixed}"
-      if [[ -z "${session}" ]]; then
-        session="bench-$(python3 -c 'import uuid; print(uuid.uuid4())')"
-      fi
-      local body
-      body="$(redact_body "${text}" "${session}")"
-      local t0 t1
-      t0="$(date +%s%N)"
-      read -r code out <<< "$(curl_json "${url}/v1/redact" "${body}")"
-      t1="$(date +%s%N)"
-      python3 -c "print((${t1}-${t0})/1e6)" >> "${ms_file}"
-      if [[ "${code}" != "200" ]]; then
-        echo "  warn ${name} conc=${conc} http=${code} body=$(head -c 160 "${out}")" >&2
-      fi
-      rm -f "${out}"
-    ) &
-    pids+=("$!")
+  for ((r = 0; r < rounds; r++)); do
+    for ((i = 0; i < conc; i++)); do
+      (
+        local session="${session_fixed}"
+        if [[ -z "${session}" ]]; then
+          session="bench-$(python3 -c 'import uuid; print(uuid.uuid4())')"
+        fi
+        local payload="${text}"
+        if [[ "${distinct_pii}" == "1" ]]; then
+          payload="$(python3 -c 'import sys; i=int(sys.argv[1]); print(f"Agent {i} emailed agent{i}@example{i}.com from Site{i}.")' "$((r * conc + i))")"
+        fi
+        local body
+        body="$(redact_body "${payload}" "${session}")"
+        local t0 t1
+        t0="$(date +%s%N)"
+        read -r code out <<< "$(curl_json "${url}/v1/redact" "${body}")"
+        t1="$(date +%s%N)"
+        if [[ "${code}" == "200" ]]; then
+          python3 -c "print((${t1}-${t0})/1e6)" >> "${ms_file}"
+        else
+          echo "1" >> "${err_file}"
+          echo "  fail ${name} conc=${conc} http=${code} body=$(head -c 160 "${out}")" >&2
+        fi
+        rm -f "${out}"
+      ) &
+      pids+=("$!")
+    done
   done
   local pid
   for pid in "${pids[@]}"; do
     wait "${pid}" || true
   done
   end="$(date +%s%N)"
-  local wall
+  local wall errors ok
   wall="$(python3 -c "print((${end}-${start})/1e6)")"
+  errors="$(wc -l < "${err_file}" | tr -d ' ')"
+  ok="$(wc -l < "${ms_file}" | tr -d ' ')"
   local stats
   stats="$(percentile < "${ms_file}")"
-  echo "${name} conc=${conc} wall_ms=${wall} ${stats}"
-  rm -f "${ms_file}"
+  local rps
+  rps="$(python3 -c "print(round(${ok} / max(${wall}/1000.0, 0.001), 2))")"
+  echo "${name} conc=${conc} rounds=${rounds} ok=${ok} errors=${errors} rps=${rps} wall_ms=${wall} ${stats}"
+  rm -f "${ms_file}" "${err_file}"
+  if [[ "${errors}" != "0" && "${ALLOW_ERRORS}" != "1" ]]; then
+    echo "FAIL ${name}: ${errors} unexpected HTTP responses" >&2
+    return 1
+  fi
 }
 
 echo "gateway ${BASE}"
 echo "NOTE: do not compare these numbers to the 32× Presidio redact-api result."
 echo "slice: pattern vs NER depends on whether the target loaded an ONNX model."
 
+failed=0
 for conc in ${CONCS}; do
   if [[ "${SESSION_MODE}" == "unique" || "${SESSION_MODE}" == "both" ]]; then
-    run_slice "pattern unique" "${BASE}" "${pattern_text}" "${conc}" ""
-    run_slice "short unique" "${BASE}" "${short_text}" "${conc}" ""
-    run_slice "long unique" "${BASE}" "${long_text}" "${conc}" ""
+    run_slice "pattern unique" "${BASE}" "${pattern_text}" "${conc}" "" 0 "${ITERS}" || failed=1
+    run_slice "short unique" "${BASE}" "${short_text}" "${conc}" "" 0 "${ITERS}" || failed=1
+    run_slice "long unique" "${BASE}" "${long_text}" "${conc}" "" 0 1 || failed=1
   fi
   if [[ "${SESSION_MODE}" == "same" || "${SESSION_MODE}" == "both" ]]; then
-    run_slice "short same-session" "${BASE}" "${short_text}" "${conc}" "bench-shared"
-    run_slice "long same-session" "${BASE}" "${long_text}" "${conc}" "bench-shared"
+    # Distinct PII per writer so skip-empty-put does not hide CAS contention.
+    run_slice "short same-session" "${BASE}" "${short_text}" "${conc}" "bench-shared-${conc}" 1 "${ITERS}" || failed=1
+    run_slice "long same-session" "${BASE}" "${long_text}" "${conc}" "bench-shared-long-${conc}" 1 1 || failed=1
   fi
 done
+if [[ "${failed}" != "0" ]]; then
+  echo "FAIL: one or more slices returned unexpected HTTP" >&2
+  exit 1
+fi
 
 if [[ -n "${BASE_B}" ]]; then
   echo "restore-after-scale: mint on ${BASE}, restore on ${BASE_B}"

--- a/scripts/bench-gateway-ner.sh
+++ b/scripts/bench-gateway-ner.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Opt-in redact-gateway bench. Not CI. Not the 32× Presidio number.
+#
+# The published 32× (docs/benchmarks/results-20260418-175909.md) is redact-api
+# vs Presidio, concurrency 1, pattern-only (email/phone/SSN). Do not quote it
+# for the NER-required gateway image.
+#
+# Matrix (minimum):
+#   - pattern-only vs NER-on (CENSGATE_NER_REQUIRED=true on the target)
+#   - short (~20 tokens) vs long (~400+)
+#   - concurrency 1 / 5 / 20
+#   - token map: vault_kv2 (required path); off only as a negative control
+#   - unique sessions vs same session_id (CAS)
+#   - restore-after-scale when GATEWAY_URL_B is set (pod B restores pod A)
+#
+# Usage:
+#   GATEWAY_URL=http://127.0.0.1:8080 \
+#   GATEWAY_API_KEY=dev-key \
+#   ./scripts/bench-gateway-ner.sh
+#
+# Optional:
+#   GATEWAY_URL_B=http://gateway-b:8080   # second replica for restore-after-scale
+#   BENCH_CONCURRENCY="1 5 20"
+#   BENCH_SESSION_MODE=unique|same|both   # default both
+set -euo pipefail
+
+BASE="${GATEWAY_URL:-${PLATFORM_REDACT_GATEWAY_URL:-}}"
+if [[ -z "${BASE}" ]]; then
+  echo "skip: GATEWAY_URL unset"
+  exit 0
+fi
+BASE="${BASE%/}"
+BASE_B="${GATEWAY_URL_B:-}"
+BASE_B="${BASE_B%/}"
+KEY="${GATEWAY_API_KEY:-${PLATFORM_REDACT_GATEWAY_API_KEY:-}}"
+AUTH=()
+if [[ -n "${KEY}" ]]; then
+  AUTH=(-H "Authorization: Bearer ${KEY}")
+fi
+CONCS="${BENCH_CONCURRENCY:-1 5 20}"
+SESSION_MODE="${BENCH_SESSION_MODE:-both}"
+
+short_text='Ada Lovelace emailed john.doe@example.com from London.'
+long_text="$(python3 - <<'PY'
+print(("Ada Lovelace met Alan Turing at Bletchley Park. " * 40).strip())
+PY
+)"
+
+pattern_text='Contact john.doe@example.com or +1-202-555-0188, SSN 078-05-1120.'
+
+curl_json() {
+  local url="$1"
+  local body="$2"
+  local out
+  out="$(mktemp)"
+  local code
+  code="$(curl -sS -o "${out}" -w '%{http_code}' \
+    -H 'Content-Type: application/json' \
+    "${AUTH[@]}" \
+    -d "${body}" \
+    "${url}" || true)"
+  echo "${code}" "${out}"
+}
+
+redact_body() {
+  local text="$1"
+  local session="$2"
+  python3 -c 'import json,sys; print(json.dumps({"text": sys.argv[1], "session_id": sys.argv[2]}))' \
+    "${text}" "${session}"
+}
+
+restore_body() {
+  local text="$1"
+  local session="$2"
+  python3 -c 'import json,sys; print(json.dumps({"text": sys.argv[1], "session_id": sys.argv[2]}))' \
+    "${text}" "${session}"
+}
+
+percentile() {
+  python3 -c '
+import sys
+vals=sorted(float(x) for x in sys.stdin if x.strip())
+if not vals:
+    print("nan")
+    raise SystemExit
+def pct(p):
+    if len(vals)==1:
+        return vals[0]
+    k=(len(vals)-1)*p/100.0
+    f=int(k); c=min(f+1,len(vals)-1)
+    return vals[f]+(vals[c]-vals[f])*(k-f)
+print(f"n={len(vals)} p50={pct(50):.1f} p99={pct(99):.1f} max={vals[-1]:.1f}")
+'
+}
+
+run_slice() {
+  local name="$1"
+  local url="$2"
+  local text="$3"
+  local conc="$4"
+  local session_fixed="$5"
+  local ms_file
+  ms_file="$(mktemp)"
+  local i pids=()
+  local start end
+  start="$(date +%s%N)"
+  for ((i = 0; i < conc; i++)); do
+    (
+      local session="${session_fixed}"
+      if [[ -z "${session}" ]]; then
+        session="bench-$(python3 -c 'import uuid; print(uuid.uuid4())')"
+      fi
+      local body
+      body="$(redact_body "${text}" "${session}")"
+      local t0 t1
+      t0="$(date +%s%N)"
+      read -r code out <<< "$(curl_json "${url}/v1/redact" "${body}")"
+      t1="$(date +%s%N)"
+      python3 -c "print((${t1}-${t0})/1e6)" >> "${ms_file}"
+      if [[ "${code}" != "200" ]]; then
+        echo "  warn ${name} conc=${conc} http=${code} body=$(head -c 160 "${out}")" >&2
+      fi
+      rm -f "${out}"
+    ) &
+    pids+=("$!")
+  done
+  local pid
+  for pid in "${pids[@]}"; do
+    wait "${pid}" || true
+  done
+  end="$(date +%s%N)"
+  local wall
+  wall="$(python3 -c "print((${end}-${start})/1e6)")"
+  local stats
+  stats="$(percentile < "${ms_file}")"
+  echo "${name} conc=${conc} wall_ms=${wall} ${stats}"
+  rm -f "${ms_file}"
+}
+
+echo "gateway ${BASE}"
+echo "NOTE: do not compare these numbers to the 32× Presidio redact-api result."
+echo "slice: pattern vs NER depends on whether the target loaded an ONNX model."
+
+for conc in ${CONCS}; do
+  if [[ "${SESSION_MODE}" == "unique" || "${SESSION_MODE}" == "both" ]]; then
+    run_slice "pattern unique" "${BASE}" "${pattern_text}" "${conc}" ""
+    run_slice "short unique" "${BASE}" "${short_text}" "${conc}" ""
+    run_slice "long unique" "${BASE}" "${long_text}" "${conc}" ""
+  fi
+  if [[ "${SESSION_MODE}" == "same" || "${SESSION_MODE}" == "both" ]]; then
+    run_slice "short same-session" "${BASE}" "${short_text}" "${conc}" "bench-shared"
+    run_slice "long same-session" "${BASE}" "${long_text}" "${conc}" "bench-shared"
+  fi
+done
+
+if [[ -n "${BASE_B}" ]]; then
+  echo "restore-after-scale: mint on ${BASE}, restore on ${BASE_B}"
+  session="bench-restore-$(python3 -c 'import uuid; print(uuid.uuid4())')"
+  body="$(redact_body "${short_text}" "${session}")"
+  read -r code out <<< "$(curl_json "${BASE}/v1/redact" "${body}")"
+  redacted="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("text",""))' "${out}" 2>/dev/null || cat "${out}")"
+  rm -f "${out}"
+  if [[ "${code}" != "200" ]]; then
+    echo "FAIL mint http=${code}"
+    exit 1
+  fi
+  rbody="$(restore_body "${redacted}" "${session}")"
+  read -r rcode rout <<< "$(curl_json "${BASE_B}/v1/restore" "${rbody}")"
+  restored="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("text",""))' "${rout}" 2>/dev/null || true)"
+  rm -f "${rout}"
+  if [[ "${rcode}" == "200" && "${restored}" == *Lovelace* ]]; then
+    echo "PASS restore-after-scale session=${session}"
+  else
+    echo "FAIL restore-after-scale http=${rcode} text=${restored:0:160}"
+    exit 1
+  fi
+fi

--- a/scripts/export_ner_model.py
+++ b/scripts/export_ner_model.py
@@ -78,9 +78,31 @@ def export_model(model_name: str, output_dir: str, quantize: bool = False):
         print(f"  - Tokenizer: {output_path / 'tokenizer.json'}")
         print(f"  - Config: {config_path}")
 
+        if quantize:
+            print("\n🔢 Dynamic INT8 quantization (onnxruntime.quantization)")
+            print("   Can move logits across the 0.7 confidence floor.")
+            print("   Do not ship without a CoNLL PER/ORG/LOC F1 floor vs FP32.")
+            try:
+                from onnxruntime.quantization import QuantType, quantize_dynamic
+            except ImportError as qe:
+                print(f"❌ onnxruntime is required for --quantize: {qe}")
+                print("Install with: pip install onnxruntime")
+                return False
+            quantized_path = output_path / "model.int8.onnx"
+            quantize_dynamic(
+                model_input=str(onnx_path),
+                model_output=str(quantized_path),
+                weight_type=QuantType.QInt8,
+            )
+            onnx_path.unlink()
+            quantized_path.rename(onnx_path)
+            print(f"  - Wrote quantized {onnx_path}")
+
         # Display size
         model_size = onnx_path.stat().st_size / (1024 * 1024)
         print(f"  - Model size: {model_size:.1f} MB")
+        if quantize:
+            print("  - Quantization: dynamic INT8 (ungated — validate F1 before shipping)")
 
         print(f"\n🧪 Test with:")
         print(f"  cargo test --package redact-ner --test ner_e2e -- --ignored")
@@ -137,7 +159,7 @@ def main():
     parser.add_argument(
         "--quantize",
         action="store_true",
-        help="Quantize model for smaller size (experimental)",
+        help="Dynamic INT8 quantization (experimental; requires a CoNLL F1 floor before shipping)",
     )
 
     args = parser.parse_args()

--- a/scripts/validate-distilbert-ner.sh
+++ b/scripts/validate-distilbert-ner.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Gated DistilBERT check. Does **not** change Dockerfile.ner-base NER_MODEL.
+#
+# Headline F1 (dslim/distilbert-NER ~0.922 vs bert-base-NER ~0.913–0.926) is
+# not feature parity. Gate a default swap on:
+#   1. CoNLL-2003 entity-level PER/ORG/LOC F1 within ~0.5–1 pt of bert-base
+#   2. The three prose fixtures in crates/redact-ner/tests/ner_e2e.rs
+#   3. A before/after run of scripts/bench-gateway-ner.sh
+#
+# Usage:
+#   CENSGATE_NER_MODEL_PATH=/path/to/distilbert/model.onnx \
+#   CONLL_EVAL=1 \
+#   ./scripts/validate-distilbert-ner.sh
+set -euo pipefail
+
+echo "DistilBERT validation (gated — default remains dslim/bert-base-NER)"
+echo
+
+if [[ -z "${CENSGATE_NER_MODEL_PATH:-}" ]]; then
+  echo "Export first (does not change the image default):"
+  echo "  python scripts/export_ner_model.py --model dslim/distilbert-NER --output models/distilbert-ner"
+  echo "  export CENSGATE_NER_MODEL_PATH=\$PWD/models/distilbert-ner/model.onnx"
+  echo
+  echo "Then re-run this script. Do not bump redact-ner-base or NER_MODEL"
+  echo "until CoNLL + fixture numbers are recorded below."
+  exit 0
+fi
+
+echo "==> e2e fixtures (ignored without a model; --ignored with a path)"
+cargo test --package redact-ner --test ner_e2e -- --ignored --nocapture
+
+echo
+echo "==> identity golden (ONNX cases skip if path unset — path is set)"
+cargo test --package redact-ner --test identity_golden -- --nocapture
+
+if [[ "${CONLL_EVAL:-}" == "1" ]]; then
+  echo
+  echo "==> CoNLL-2003 PER/ORG/LOC F1 is not automated in this repo yet."
+  echo "    Record entity-level F1 for bert-base-NER and distilbert-NER on the"
+  echo "    same split before changing Dockerfile.ner-base ARG NER_MODEL."
+  echo "    Reject the swap if ORG or single-token names regress."
+fi
+
+echo
+echo "Default image model is still dslim/bert-base-NER."
+echo "Do not treat a green fixture run as permission to swap NER_MODEL."

--- a/scripts/validate-distilbert-ner.sh
+++ b/scripts/validate-distilbert-ner.sh
@@ -9,7 +9,7 @@
 #
 # Usage:
 #   CENSGATE_NER_MODEL_PATH=/path/to/distilbert/model.onnx \
-#   CONLL_EVAL=1 \
+#   CONLL_EVAL=1 CONLL_F1_BERT=0.92 CONLL_F1_DISTIL=0.91 \
 #   ./scripts/validate-distilbert-ner.sh
 set -euo pipefail
 
@@ -17,30 +17,46 @@ echo "DistilBERT validation (gated — default remains dslim/bert-base-NER)"
 echo
 
 if [[ -z "${CENSGATE_NER_MODEL_PATH:-}" ]]; then
-  echo "Export first (does not change the image default):"
-  echo "  python scripts/export_ner_model.py --model dslim/distilbert-NER --output models/distilbert-ner"
-  echo "  export CENSGATE_NER_MODEL_PATH=\$PWD/models/distilbert-ner/model.onnx"
-  echo
-  echo "Then re-run this script. Do not bump redact-ner-base or NER_MODEL"
-  echo "until CoNLL + fixture numbers are recorded below."
-  exit 0
+  echo "FAIL: CENSGATE_NER_MODEL_PATH is required (does not change the image default)." >&2
+  echo "  python scripts/export_ner_model.py --model dslim/distilbert-NER --output models/distilbert-ner" >&2
+  echo "  export CENSGATE_NER_MODEL_PATH=\$PWD/models/distilbert-ner/model.onnx" >&2
+  exit 1
 fi
 
-echo "==> e2e fixtures (ignored without a model; --ignored with a path)"
-cargo test --package redact-ner --test ner_e2e -- --ignored --nocapture
+if [[ ! -f "${CENSGATE_NER_MODEL_PATH}" ]]; then
+  echo "FAIL: CENSGATE_NER_MODEL_PATH=${CENSGATE_NER_MODEL_PATH} is not a file" >&2
+  exit 1
+fi
+
+echo "==> e2e fixtures against the supplied model (fails if the model does not load)"
+cargo test --package redact-ner --test ner_e2e --test-threads=1 \
+  test_ner_honors_censgate_ner_model_path -- --nocapture
 
 echo
-echo "==> identity golden (ONNX cases skip if path unset — path is set)"
+echo "==> identity golden (ONNX cases skip only when the path is unset — path is set)"
 cargo test --package redact-ner --test identity_golden -- --nocapture
 
 if [[ "${CONLL_EVAL:-}" == "1" ]]; then
   echo
-  echo "==> CoNLL-2003 PER/ORG/LOC F1 is not automated in this repo yet."
-  echo "    Record entity-level F1 for bert-base-NER and distilbert-NER on the"
-  echo "    same split before changing Dockerfile.ner-base ARG NER_MODEL."
-  echo "    Reject the swap if ORG or single-token names regress."
+  echo "==> CoNLL-2003 PER/ORG/LOC F1 (operator-recorded; not automated in-repo yet)"
+  : "${CONLL_F1_BERT:?set CONLL_F1_BERT to measured entity-level F1 for bert-base-NER}"
+  : "${CONLL_F1_DISTIL:?set CONLL_F1_DISTIL to measured entity-level F1 for distilbert-NER}"
+  python3 - <<'PY'
+import os
+import sys
+bert = float(os.environ["CONLL_F1_BERT"])
+distil = float(os.environ["CONLL_F1_DISTIL"])
+# Plan floor: Distil within ~1 pt of bert-base on entity-level PER/ORG/LOC.
+if distil + 0.01 < bert:
+    print(f"FAIL: Distil F1 {distil} is more than 1 pt below bert-base {bert}", file=sys.stderr)
+    sys.exit(1)
+print(f"PASS: Distil F1 {distil} is within 1 pt of bert-base {bert}")
+PY
+else
+  echo
+  echo "CONLL_EVAL is not 1. Record entity-level F1 before changing NER_MODEL."
+  echo "A green fixture run is not permission to swap Dockerfile.ner-base."
 fi
 
 echo
 echo "Default image model is still dslim/bert-base-NER."
-echo "Do not treat a green fixture run as permission to swap NER_MODEL."

--- a/scripts/validate-distilbert-ner.sh
+++ b/scripts/validate-distilbert-ner.sh
@@ -29,8 +29,8 @@ if [[ ! -f "${CENSGATE_NER_MODEL_PATH}" ]]; then
 fi
 
 echo "==> e2e fixtures against the supplied model (fails if the model does not load)"
-cargo test --package redact-ner --test ner_e2e --test-threads=1 \
-  test_ner_honors_censgate_ner_model_path -- --nocapture
+cargo test --package redact-ner --test ner_e2e \
+  test_ner_honors_censgate_ner_model_path -- --test-threads=1 --nocapture
 
 echo
 echo "==> identity golden (ONNX cases skip only when the path is unset — path is set)"


### PR DESCRIPTION
Thank you for contributing to Redact. These checkboxes are acknowledgements;
the CLA bot enforces the Individual CLA signature.

- [x] I have read [CLA.md](../CLA.md) and will sign the Individual CLA via the bot comment (or I have already signed). A Corporate CLA, if required, does not replace the Individual CLA.
- [x] All commits are DCO-signed (`git commit -s`)
- [x] I have read [docs/PROJECT_SCOPE.md](../docs/PROJECT_SCOPE.md); this change is in scope

**Employer time or equipment**

- [x] No — this work was not done on employer time or equipment
- [ ] Yes — my employer has authorised the contribution, or a Corporate CLA is on file

## Summary

Production gateway scale path: **n replicas + HPA + `vault_kv2` against a dedicated `openbao-tokens` cluster**, not `replica=1` / `vault.backend=off`.

- Kubernetes auth in `Kv2Store` (static token is local-dev only). Dedicated `redact-gateway` role; `external-secrets` is refused. In-process token cache/renew.
- Jittered CAS (8 attempts), skip empty put, cached `/readyz` OpenBao health.
- Sample `deploy/kubernetes/redact-gateway.yaml`: minReplicas 2, HPA, PDB, startupProbe, ServiceAccount, Guaranteed 4 CPU / 4Gi, no session affinity, ESO DEK from the **secrets** OpenBao, address `openbao-tokens.openbao-tokens.svc`.
- `CENSGATE_NER_INTRA_THREADS` (default 1) so `pool × intra ≈` pod CPUs. Analyze uses `block_in_place` on the multi-thread runtime.
- Pad buckets 32/64/128/256/512 were already on main; this PR does not change default `NER_MODEL`.
- `scripts/bench-gateway-ner.sh` + `docs/gateway/openbao-tokens-spike.md`. Do **not** quote the 32× Presidio `redact-api` number on the NER gateway.
- DistilBERT remains gated (`scripts/validate-distilbert-ner.sh`). `--quantize` now runs dynamic INT8.
- Docs no longer advertise NER `DATE_TIME`. Pattern packs still own dates.

Companion cluster: `censgate/cloud-infrastructure` branch `coder-openbao-tokens-6085`.

## Test plan

- `cargo test --package redact-ner --lib` — 19 passed (pad buckets, pool, intra_threads).
- `cargo test --package redact-gateway` — 141 lib + integration including mock KV CAS, skip-empty-put, Kubernetes-auth login cache, and refuse `external-secrets`.
- `cargo test --package redact-api` — 11 passed (1 ignored NER fixture).
- `scripts/bench-gateway-ner.sh` skips cleanly when `GATEWAY_URL` is unset.
- `scripts/validate-distilbert-ner.sh` does not change `NER_MODEL`.
- Live OpenBao / AKS numbers are the SPIKE, not claimed here.