### PR TITLE
Stabilize PERSON spans and reuse possessive tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- PERSON spans from hybrid identity no longer keep a trailing `'s` / `’s`,
+  and adjacent same-type fragments of one word (ONNX split names) merge
+  before tokenize. The vault reuses one PERSON token for the same
+  normalized surface (`Nimbus` / `Nimbus's` / `nimbus`) in a session.
+
 ## [0.12.0] - 2026-09-05
 
 Crate/image release of the NER serving-path and `vault_kv2` Kubernetes-auth

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-09-06
+
 ### Fixed
 
 - PERSON spans from hybrid identity no longer keep a trailing `'s` / `’s`,

--- a/crates/redact-gateway/src/redact/token.rs
+++ b/crates/redact-gateway/src/redact/token.rs
@@ -146,6 +146,8 @@ impl TokenSession {
         existing: Vec<TokenMapping>,
     ) -> Self {
         let mut session = Self::new(id, tenant, dek);
+        let mut existing = existing;
+        existing.sort_by_key(|m| token_index(&m.token).unwrap_or(usize::MAX));
         for mapping in existing {
             if let Some(index) = token_index(&mapping.token) {
                 let counter = session
@@ -155,15 +157,7 @@ impl TokenSession {
                 *counter = (*counter).max(index);
             }
             if let Ok(plaintext) = session.dek.open(&mapping.sealed_value) {
-                session
-                    .by_value
-                    .insert(plaintext.clone(), mapping.token.clone());
-                if mapping.entity_type == EntityType::Person.as_str() {
-                    let key = person_reuse_key(&plaintext);
-                    if key != plaintext {
-                        session.by_value.insert(key, mapping.token.clone());
-                    }
-                }
+                session.remember_value(&mapping.entity_type, plaintext, mapping.token.clone());
             }
             session.mappings.push(mapping);
         }
@@ -187,14 +181,8 @@ impl TokenSession {
         entity_type: &EntityType,
         plaintext: &str,
     ) -> Result<String, TokenError> {
-        if let Some(existing) = self.by_value.get(plaintext) {
-            return Ok(existing.clone());
-        }
-        if *entity_type == EntityType::Person {
-            let key = person_reuse_key(plaintext);
-            if let Some(existing) = self.by_value.get(&key) {
-                return Ok(existing.clone());
-            }
+        if let Some(existing) = self.lookup_value(entity_type, plaintext) {
+            return Ok(existing);
         }
 
         let label = entity_type.as_str().to_string();
@@ -203,13 +191,7 @@ impl TokenSession {
         let token = format!("[{label}_{counter}]");
 
         let sealed = self.dek.seal(plaintext)?;
-        self.by_value.insert(plaintext.to_string(), token.clone());
-        if *entity_type == EntityType::Person {
-            let key = person_reuse_key(plaintext);
-            if key != plaintext {
-                self.by_value.insert(key, token.clone());
-            }
-        }
+        self.remember_value(&label, plaintext.to_string(), token.clone());
         self.mappings.push(TokenMapping {
             token: token.clone(),
             entity_type: label,
@@ -232,6 +214,28 @@ impl TokenSession {
     /// Whether any token was issued.
     pub fn is_empty(&self) -> bool {
         self.mappings.is_empty()
+    }
+
+    fn lookup_value(&self, entity_type: &EntityType, plaintext: &str) -> Option<String> {
+        if *entity_type == EntityType::Person {
+            if let Some(existing) = self.by_value.get(&person_reuse_key(plaintext)) {
+                return Some(existing.clone());
+            }
+        }
+        self.by_value.get(plaintext).cloned()
+    }
+
+    /// First writer for a key wins so a resumed pair like `Nimbus` / `nimbus`
+    /// keeps one canonical PERSON token.
+    fn remember_value(&mut self, entity_type: &str, plaintext: String, token: String) {
+        self.by_value
+            .entry(plaintext.clone())
+            .or_insert_with(|| token.clone());
+        if entity_type == EntityType::Person.as_str() {
+            self.by_value
+                .entry(person_reuse_key(&plaintext))
+                .or_insert(token);
+        }
     }
 }
 
@@ -446,6 +450,34 @@ mod tests {
         let reused = resumed.token_for(&EntityType::Person, "Reed's").unwrap();
         assert_eq!(reused, "[PERSON_1]");
         assert!(resumed.is_empty(), "normalized reuse should not mint");
+    }
+
+    #[test]
+    fn resume_canonicalizes_conflicting_person_variants() {
+        let dek = Arc::new(Dek::generate().unwrap());
+        let mut original = TokenSession::new("s", "t", dek.clone());
+        let first = original.token_for(&EntityType::Person, "Nimbus").unwrap();
+        let _ = original
+            .token_for(&EntityType::EmailAddress, "lab@example.com")
+            .unwrap();
+        let mut mappings = original.take_new_mappings();
+        mappings.push(TokenMapping {
+            token: "[PERSON_9]".to_string(),
+            entity_type: "PERSON".to_string(),
+            sealed_value: dek.seal("nimbus").unwrap(),
+            created_at: chrono::Utc::now(),
+        });
+
+        let mut resumed = TokenSession::resume("s", "t", dek, mappings);
+        assert_eq!(
+            resumed.token_for(&EntityType::Person, "Nimbus's").unwrap(),
+            first
+        );
+        assert_eq!(
+            resumed.token_for(&EntityType::Person, "nimbus").unwrap(),
+            first
+        );
+        assert!(resumed.is_empty());
     }
 
     #[test]

--- a/crates/redact-gateway/src/redact/token.rs
+++ b/crates/redact-gateway/src/redact/token.rs
@@ -155,7 +155,15 @@ impl TokenSession {
                 *counter = (*counter).max(index);
             }
             if let Ok(plaintext) = session.dek.open(&mapping.sealed_value) {
-                session.by_value.insert(plaintext, mapping.token.clone());
+                session
+                    .by_value
+                    .insert(plaintext.clone(), mapping.token.clone());
+                if mapping.entity_type == EntityType::Person.as_str() {
+                    let key = person_reuse_key(&plaintext);
+                    if key != plaintext {
+                        session.by_value.insert(key, mapping.token.clone());
+                    }
+                }
             }
             session.mappings.push(mapping);
         }
@@ -182,6 +190,12 @@ impl TokenSession {
         if let Some(existing) = self.by_value.get(plaintext) {
             return Ok(existing.clone());
         }
+        if *entity_type == EntityType::Person {
+            let key = person_reuse_key(plaintext);
+            if let Some(existing) = self.by_value.get(&key) {
+                return Ok(existing.clone());
+            }
+        }
 
         let label = entity_type.as_str().to_string();
         let counter = self.counters.entry(label.clone()).or_insert(0);
@@ -190,6 +204,12 @@ impl TokenSession {
 
         let sealed = self.dek.seal(plaintext)?;
         self.by_value.insert(plaintext.to_string(), token.clone());
+        if *entity_type == EntityType::Person {
+            let key = person_reuse_key(plaintext);
+            if key != plaintext {
+                self.by_value.insert(key, token.clone());
+            }
+        }
         self.mappings.push(TokenMapping {
             token: token.clone(),
             entity_type: label,
@@ -213,6 +233,18 @@ impl TokenSession {
     pub fn is_empty(&self) -> bool {
         self.mappings.is_empty()
     }
+}
+
+/// PERSON vault keys: trim, drop a trailing `'s`, ASCII-fold. `Nimbus` and
+/// `Nimbus's` therefore share one token without a platform-side cache.
+fn person_reuse_key(plaintext: &str) -> String {
+    let trimmed = plaintext.trim();
+    let bare = ["'s", "’s", "'S", "’S"]
+        .iter()
+        .find(|suffix| trimmed.len() > suffix.len() && trimmed.ends_with(*suffix))
+        .map(|suffix| &trimmed[..trimmed.len() - suffix.len()])
+        .unwrap_or(trimmed);
+    bare.to_ascii_lowercase()
 }
 
 fn token_index(token: &str) -> Option<usize> {
@@ -386,6 +418,34 @@ mod tests {
             .unwrap();
         assert_eq!(first, again);
         assert_eq!(session.new_mappings().len(), 1);
+    }
+
+    #[test]
+    fn person_possessive_and_case_reuse_one_token() {
+        let mut session = session();
+        let first = session.token_for(&EntityType::Person, "Nimbus").unwrap();
+        let poss = session.token_for(&EntityType::Person, "Nimbus's").unwrap();
+        let folded = session.token_for(&EntityType::Person, "nimbus").unwrap();
+        assert_eq!(first, "[PERSON_1]");
+        assert_eq!(poss, first);
+        assert_eq!(folded, first);
+        assert_eq!(session.new_mappings().len(), 1);
+
+        let other = session.token_for(&EntityType::Person, "Sorrel").unwrap();
+        assert_eq!(other, "[PERSON_2]");
+    }
+
+    #[test]
+    fn resume_reuses_normalized_person() {
+        let dek = Arc::new(Dek::generate().unwrap());
+        let mut original = TokenSession::new("s", "t", dek.clone());
+        original.token_for(&EntityType::Person, "Reed").unwrap();
+        let existing = original.take_new_mappings();
+
+        let mut resumed = TokenSession::resume("s", "t", dek, existing);
+        let reused = resumed.token_for(&EntityType::Person, "Reed's").unwrap();
+        assert_eq!(reused, "[PERSON_1]");
+        assert!(resumed.is_empty(), "normalized reuse should not mint");
     }
 
     #[test]

--- a/crates/redact-ner/src/identity.rs
+++ b/crates/redact-ner/src/identity.rs
@@ -190,8 +190,66 @@ fn merge_identity(
         }
         out.push(candidate);
     }
-    out.sort_by_key(|r| (r.start, r.end));
-    out
+    stabilize_identity_spans(text, out)
+}
+
+/// Merge split same-type PERSON spans and drop possessive `'s` from the
+/// entity so `Nimbus` / `Nimbus's` share one surface for tokenization.
+fn stabilize_identity_spans(text: &str, mut spans: Vec<RecognizerResult>) -> Vec<RecognizerResult> {
+    spans.sort_by_key(|r| (r.start, r.end));
+    let mut merged: Vec<RecognizerResult> = Vec::new();
+    for span in spans {
+        if let Some(prev) = merged.last_mut() {
+            if prev.entity_type == span.entity_type
+                && same_word_adjacent(text, prev.end, span.start)
+            {
+                prev.end = prev.end.max(span.end);
+                prev.score = prev.score.max(span.score);
+                continue;
+            }
+        }
+        merged.push(span);
+    }
+    for span in &mut merged {
+        span.end = span.end.min(text.len());
+        span.start = span.start.min(span.end);
+        if span.entity_type != EntityType::Person || span.start >= span.end {
+            continue;
+        }
+        if let Some(end) = person_span_end_without_possessive(text, span.start, span.end) {
+            span.end = end;
+        }
+    }
+    merged.retain(|span| span.start < span.end && !is_possessive_only(&text[span.start..span.end]));
+    merged
+}
+
+fn same_word_adjacent(text: &str, prev_end: usize, next_start: usize) -> bool {
+    if next_start < prev_end {
+        return true;
+    }
+    if next_start == prev_end {
+        return true;
+    }
+    if next_start > text.len() || prev_end > text.len() {
+        return false;
+    }
+    let gap = &text[prev_end..next_start];
+    !gap.is_empty() && gap.chars().all(|c| c == '\'' || c == '’' || c == '-')
+}
+
+fn person_span_end_without_possessive(text: &str, start: usize, end: usize) -> Option<usize> {
+    let surface = &text[start..end];
+    for suffix in ["'s", "’s", "'S", "’S"] {
+        if surface.len() > suffix.len() && surface.ends_with(suffix) {
+            return Some(end - suffix.len());
+        }
+    }
+    None
+}
+
+fn is_possessive_only(surface: &str) -> bool {
+    matches!(surface, "'s" | "’s" | "'S" | "’S" | "'" | "’" | "s" | "S")
 }
 
 #[cfg(test)]
@@ -244,5 +302,74 @@ mod tests {
         assert_eq!(merged.len(), 1);
         assert_eq!(merged[0].entity_type, EntityType::Location);
         assert_eq!(merged[0].recognizer_name, "ctx");
+    }
+
+    const LAB_ROSTER: &str = "The lab mascot is Nimbus. Nimbus's badge is yellow. Desk neighbors are Reed, Sable, and Quill. Sorrel runs the front desk. Reed files the badges.";
+
+    fn person(start: usize, end: usize, source: &str) -> RecognizerResult {
+        RecognizerResult::new(EntityType::Person, start, end, 0.9, source)
+    }
+
+    fn find_span(text: &str, needle: &str) -> (usize, usize) {
+        let start = text.find(needle).expect(needle);
+        (start, start + needle.len())
+    }
+
+    fn surfaces(text: &str, spans: &[RecognizerResult]) -> Vec<String> {
+        spans
+            .iter()
+            .map(|s| text[s.start..s.end].to_string())
+            .collect()
+    }
+
+    #[test]
+    fn lab_roster_possessive_and_split_stabilize_to_one_token_surface() {
+        let (nimbus, nimbus_end) = find_span(LAB_ROSTER, "Nimbus.");
+        let nimbus_first = (nimbus, nimbus_end - 1);
+        let nimbus_poss = find_span(LAB_ROSTER, "Nimbus's");
+        let reed = find_span(LAB_ROSTER, "Reed,");
+        let reed = (reed.0, reed.1 - 1);
+        let sable = find_span(LAB_ROSTER, "Sable");
+        let quill = find_span(LAB_ROSTER, "Quill");
+        let sorrel = find_span(LAB_ROSTER, "Sorrel");
+        let reed_again = LAB_ROSTER.rfind("Reed").expect("second Reed");
+        let reed_again = (reed_again, reed_again + 4);
+
+        let ner = vec![
+            person(nimbus_first.0, nimbus_first.1, "ner"),
+            person(nimbus_poss.0, nimbus_poss.0 + 6, "ner"),
+            person(nimbus_poss.0 + 6, nimbus_poss.1, "ner"),
+            person(reed.0, reed.1, "ner"),
+            person(sable.0, sable.1, "ner"),
+            person(quill.0, quill.1, "ner"),
+            person(sorrel.0, sorrel.0 + 3, "ner"),
+            person(sorrel.0 + 3, sorrel.1, "ner"),
+            person(reed_again.0, reed_again.1, "ner"),
+        ];
+        let merged = merge_identity(LAB_ROSTER, Vec::new(), ner);
+        let got = surfaces(LAB_ROSTER, &merged);
+        assert_eq!(
+            got,
+            vec![
+                "Nimbus".to_string(),
+                "Nimbus".to_string(),
+                "Reed".to_string(),
+                "Sable".to_string(),
+                "Quill".to_string(),
+                "Sorrel".to_string(),
+                "Reed".to_string(),
+            ]
+        );
+        assert!(got
+            .iter()
+            .all(|s| s != "Nimbus's" && s != "'s" && s != "Sor"));
+    }
+
+    #[test]
+    fn possessive_only_ner_span_is_dropped() {
+        let text = "Nimbus's badge";
+        let ner = vec![person(0, 6, "ner"), person(6, 8, "ner")];
+        let merged = merge_identity(text, Vec::new(), ner);
+        assert_eq!(surfaces(text, &merged), vec!["Nimbus".to_string()]);
     }
 }

--- a/crates/redact-ner/tests/identity_golden.rs
+++ b/crates/redact-ner/tests/identity_golden.rs
@@ -4,7 +4,7 @@
 
 //! Golden cases for hybrid identity detection (contextual + optional ONNX NER).
 //!
-//! Contextual-only covers the household-identity paragraph and the
+//! Contextual-only covers a synthetic kennel/lab roster and the
 //! adversarial table. ONNX cases run only when `CENSGATE_NER_MODEL_PATH`
 //! points at a loadable model so CI without the artifact still stays green.
 
@@ -12,7 +12,7 @@ use redact_core::{EntityType, Recognizer};
 use redact_ner::IdentityRecognizer;
 
 /// One kennel dog + one place list. Not a household roster.
-const KENNEL_PARAGRAPH: &str = "The kennel lists one dog: Nola ( black terrier, 8 ). We live in Cedar Hollow, Caledonia ( Riverton metro area ). A colleague named Pip dropped by.";
+const KENNEL_PARAGRAPH: &str = "The kennel lists one dog: Kestrel ( black terrier, 8 ). We live in Harbor Mill, Westfield ( Elmsford metro area ). A colleague named Bram dropped by.";
 
 /// Synthetic lab roster — invented names and counts, not an operator household.
 const LAB_ROSTER: &str = "The lab mascot is Nimbus. Nimbus's badge is yellow. Desk neighbors are Reed, Sable, and Quill. Sorrel runs the front desk.";
@@ -39,13 +39,13 @@ fn kennel_paragraph_tokenizes_pet_colleague_and_places() {
     let people = types_of(&rec, KENNEL_PARAGRAPH, EntityType::Person);
     let places = types_of(&rec, KENNEL_PARAGRAPH, EntityType::Location);
 
-    assert_eq!(people, vec!["Nola".to_string(), "Pip".to_string()]);
+    assert_eq!(people, vec!["Kestrel".to_string(), "Bram".to_string()]);
     assert_eq!(
         places,
         vec![
-            "Cedar Hollow".to_string(),
-            "Caledonia".to_string(),
-            "Riverton".to_string()
+            "Harbor Mill".to_string(),
+            "Westfield".to_string(),
+            "Elmsford".to_string()
         ]
     );
     assert!(!spans(&rec, KENNEL_PARAGRAPH)
@@ -121,8 +121,8 @@ fn common_words_after_identity_cues_are_not_names() {
     assert!(spans(&rec, "we live in peace now").is_empty());
     assert!(spans(&rec, "my cat eats tuna").is_empty());
     assert_eq!(
-        types_of(&rec, "my pets: Nola and Pip are loud", EntityType::Person),
-        vec!["Nola".to_string(), "Pip".to_string()]
+        types_of(&rec, "my pets: Kestrel and Bram are loud", EntityType::Person),
+        vec!["Kestrel".to_string(), "Bram".to_string()]
     );
 }
 

--- a/crates/redact-ner/tests/identity_golden.rs
+++ b/crates/redact-ner/tests/identity_golden.rs
@@ -13,6 +13,9 @@ use redact_ner::IdentityRecognizer;
 
 const CATS_PARAGRAPH: &str = "I have two female cats: Nola ( black American short hair, 12 ) and Pip ( ginger tabby, 3 ). We live in Cedar Hollow, Caledonia ( Riverton metro area ). I have a wife and a daughter ( 11 ).";
 
+/// Synthetic lab roster — invented names and counts, not an operator household.
+const LAB_ROSTER: &str = "The lab mascot is Nimbus. Nimbus's badge is yellow. Desk neighbors are Reed, Sable, and Quill. Sorrel runs the front desk.";
+
 fn spans(rec: &IdentityRecognizer, text: &str) -> Vec<(EntityType, String)> {
     rec.analyze(text, "en")
         .unwrap()
@@ -171,5 +174,21 @@ fn onnx_org_and_bare_apple_when_model_present() {
         !ate.iter()
             .any(|(ty, s)| *ty == EntityType::Organization && s.eq_ignore_ascii_case("apple")),
         "food apple must not become ORGANIZATION: {ate:?}"
+    );
+
+    let people = types_of(&rec, LAB_ROSTER, EntityType::Person);
+    assert!(
+        people
+            .iter()
+            .all(|s| !s.contains('\'') && !s.contains('’') && s != "s"),
+        "lab-roster PERSON spans must be bare names, got {people:?}"
+    );
+    let sorrel: Vec<_> = people
+        .iter()
+        .filter(|s| s.contains("Sor") || s.contains("rel"))
+        .collect();
+    assert!(
+        sorrel.iter().all(|s| s.eq_ignore_ascii_case("Sorrel")) || sorrel.is_empty(),
+        "Sorrel must be one PERSON span if detected: {people:?}"
     );
 }

--- a/crates/redact-ner/tests/identity_golden.rs
+++ b/crates/redact-ner/tests/identity_golden.rs
@@ -11,7 +11,8 @@
 use redact_core::{EntityType, Recognizer};
 use redact_ner::IdentityRecognizer;
 
-const CATS_PARAGRAPH: &str = "I have two female cats: Nola ( black American short hair, 12 ) and Pip ( ginger tabby, 3 ). We live in Cedar Hollow, Caledonia ( Riverton metro area ). I have a wife and a daughter ( 11 ).";
+/// One kennel dog + one place list. Not a household roster.
+const KENNEL_PARAGRAPH: &str = "The kennel lists one dog: Nola ( black terrier, 8 ). We live in Cedar Hollow, Caledonia ( Riverton metro area ). A colleague named Pip dropped by.";
 
 /// Synthetic lab roster — invented names and counts, not an operator household.
 const LAB_ROSTER: &str = "The lab mascot is Nimbus. Nimbus's badge is yellow. Desk neighbors are Reed, Sable, and Quill. Sorrel runs the front desk.";
@@ -33,10 +34,10 @@ fn types_of(rec: &IdentityRecognizer, text: &str, ty: EntityType) -> Vec<String>
 }
 
 #[test]
-fn cats_paragraph_tokenizes_pets_and_places_not_american() {
+fn kennel_paragraph_tokenizes_pet_colleague_and_places() {
     let rec = IdentityRecognizer::contextual_only();
-    let people = types_of(&rec, CATS_PARAGRAPH, EntityType::Person);
-    let places = types_of(&rec, CATS_PARAGRAPH, EntityType::Location);
+    let people = types_of(&rec, KENNEL_PARAGRAPH, EntityType::Person);
+    let places = types_of(&rec, KENNEL_PARAGRAPH, EntityType::Location);
 
     assert_eq!(people, vec!["Nola".to_string(), "Pip".to_string()]);
     assert_eq!(
@@ -47,9 +48,9 @@ fn cats_paragraph_tokenizes_pets_and_places_not_american() {
             "Riverton".to_string()
         ]
     );
-    assert!(!spans(&rec, CATS_PARAGRAPH)
+    assert!(!spans(&rec, KENNEL_PARAGRAPH)
         .iter()
-        .any(|(_, t)| t == "American"));
+        .any(|(_, t)| t == "American" || t == "terrier"));
 }
 
 #[test]
@@ -128,7 +129,7 @@ fn common_words_after_identity_cues_are_not_names() {
 #[test]
 fn existing_vault_tokens_are_not_identity() {
     let rec = IdentityRecognizer::contextual_only();
-    let text = "I have two female cats: [PERSON_1] ( black American short hair, 12 ) and [PERSON_2] ( ginger tabby, 3 ). We live in [LOCATION_1], [LOCATION_2] ( [LOCATION_3] metro area ).";
+    let text = "The kennel lists one dog: [PERSON_1] ( black terrier, 8 ). The yard is in [LOCATION_1], [LOCATION_2] ( [LOCATION_3] metro area ). A colleague named [PERSON_2] dropped by.";
     assert!(
         spans(&rec, text).is_empty(),
         "sealed tokens must not be re-detected as PERSON/LOCATION: {:?}",

--- a/crates/redact-ner/tests/identity_golden.rs
+++ b/crates/redact-ner/tests/identity_golden.rs
@@ -121,7 +121,11 @@ fn common_words_after_identity_cues_are_not_names() {
     assert!(spans(&rec, "we live in peace now").is_empty());
     assert!(spans(&rec, "my cat eats tuna").is_empty());
     assert_eq!(
-        types_of(&rec, "my pets: Kestrel and Bram are loud", EntityType::Person),
+        types_of(
+            &rec,
+            "my pets: Kestrel and Bram are loud",
+            EntityType::Person
+        ),
         vec!["Kestrel".to_string(), "Bram".to_string()]
     );
 }


### PR DESCRIPTION
- [x] I have read [CLA.md](../CLA.md) and will sign the Individual CLA via the bot comment (or I have already signed). A Corporate CLA, if required, does not replace the Individual CLA.
- [x] All commits are DCO-signed (`git commit -s`)
- [x] I have read [docs/PROJECT_SCOPE.md](../docs/PROJECT_SCOPE.md); this change is in scope

**Employer time or equipment**

- [x] No — this work was not done on employer time or equipment
- [ ] Yes — my employer has authorised the contribution, or a Corporate CLA is on file

## Summary

PERSON minting was unstable: a trailing `'s` became a second PERSON span, uncommon names could split into two adjacent tokens, and the vault keyed reuse on the exact surface so `Nimbus` and `Nimbus's` minted different tokens.

This PR:

- Merges adjacent same-type fragments of one word (no whitespace) before tokenize
- Strips a trailing `'s` / `’s` from PERSON spans so the possessive stays literal text
- Reuses one PERSON token for the same normalized surface (trim, possessive strip, ASCII fold) in a session

Goldens use a **synthetic lab roster** (Nimbus, Reed, Sable, Quill, Sorrel). They do not replay operator household facts.

## Test plan

- `cargo test -p redact-ner --lib`
- `cargo test -p redact-ner --test identity_golden`
- `cargo test -p redact-gateway --lib token`