### PR TITLE
Do not treat Who as a person in Name runs the cues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Contextual identity no longer treats interrogative pronouns (`who`,
+  `what`, `when`, `where`, `why`, `how`, and `whom` / `whose`) as PERSON
+  in `Name runs the …` cues. `Who runs the front desk?` stays a question;
+  `Sorrel runs the front desk` still tokenizes Sorrel.
+
 ## [0.12.2] - 2026-09-06
 
 ### Fixed

--- a/crates/redact-ner/src/contextual_identity.rs
+++ b/crates/redact-ner/src/contextual_identity.rs
@@ -787,6 +787,14 @@ fn is_function_word(word: &str) -> bool {
             | "today"
             | "tomorrow"
             | "yesterday"
+            | "who"
+            | "whom"
+            | "whose"
+            | "what"
+            | "when"
+            | "where"
+            | "why"
+            | "how"
     )
 }
 
@@ -941,5 +949,27 @@ mod tests {
         assert_eq!(toks[0].text, "Hi");
         assert_eq!(toks[1].text, "Ada");
         assert_eq!(&text[toks[1].start..toks[1].end], "Ada");
+    }
+
+    #[test]
+    fn who_runs_the_is_not_a_person() {
+        let text = "Who runs the front desk?";
+        let mut hits = Vec::new();
+        let tokens = tokenize(text);
+        collect_name_runs_the(text, &tokens, &mut hits);
+        assert!(
+            hits.is_empty(),
+            "interrogative Who must not become PERSON: {hits:?}"
+        );
+    }
+
+    #[test]
+    fn sorrel_runs_the_is_a_person() {
+        let text = "Sorrel runs the front desk.";
+        let mut hits = Vec::new();
+        let tokens = tokenize(text);
+        collect_name_runs_the(text, &tokens, &mut hits);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(&text[hits[0].start..hits[0].end], "Sorrel");
     }
 }

--- a/crates/redact-ner/src/contextual_identity.rs
+++ b/crates/redact-ner/src/contextual_identity.rs
@@ -205,6 +205,9 @@ fn collect_name_runs_the(text: &str, tokens: &[Token<'_>], hits: &mut Vec<Hit>) 
             continue;
         }
         let prev = tokens[i - 1];
+        if is_interrogative_pronoun(prev.text) {
+            continue;
+        }
         if accept_name(prev.text, NameRule::strong_no_calendar())
             && !is_inside_skip_parens(text, prev.start)
         {
@@ -787,14 +790,13 @@ fn is_function_word(word: &str) -> bool {
             | "today"
             | "tomorrow"
             | "yesterday"
-            | "who"
-            | "whom"
-            | "whose"
-            | "what"
-            | "when"
-            | "where"
-            | "why"
-            | "how"
+    )
+}
+
+fn is_interrogative_pronoun(word: &str) -> bool {
+    matches!(
+        word.to_ascii_lowercase().as_str(),
+        "who" | "whom" | "whose" | "what" | "when" | "where" | "why" | "how"
     )
 }
 
@@ -952,15 +954,31 @@ mod tests {
     }
 
     #[test]
-    fn who_runs_the_is_not_a_person() {
-        let text = "Who runs the front desk?";
-        let mut hits = Vec::new();
-        let tokens = tokenize(text);
-        collect_name_runs_the(text, &tokens, &mut hits);
-        assert!(
-            hits.is_empty(),
-            "interrogative Who must not become PERSON: {hits:?}"
-        );
+    fn interrogative_pronouns_are_not_persons_in_name_runs_the() {
+        for pronoun in [
+            "Who", "Whom", "Whose", "What", "When", "Where", "Why", "How",
+        ] {
+            let text = format!("{pronoun} runs the front desk?");
+            let mut hits = Vec::new();
+            let tokens = tokenize(&text);
+            collect_name_runs_the(&text, &tokens, &mut hits);
+            assert!(
+                hits.is_empty(),
+                "{pronoun} runs the must not become PERSON: {hits:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn interrogative_pronouns_are_not_global_function_words() {
+        for pronoun in [
+            "who", "whom", "whose", "what", "when", "where", "why", "how",
+        ] {
+            assert!(
+                !is_function_word(pronoun),
+                "{pronoun} must stay scoped to Name runs the"
+            );
+        }
     }
 
     #[test]

--- a/crates/redact-ner/tests/identity_golden.rs
+++ b/crates/redact-ner/tests/identity_golden.rs
@@ -175,6 +175,17 @@ fn lab_roster_contextual_covers_mascot_neighbors_and_desk_lead() {
 }
 
 #[test]
+fn who_runs_the_front_desk_is_not_a_person() {
+    let rec = IdentityRecognizer::contextual_only();
+    let people = types_of(&rec, "Who runs the front desk?", EntityType::Person);
+    assert!(
+        people.is_empty(),
+        "interrogative Who must not become PERSON: {people:?}"
+    );
+    assert!(spans(&rec, "Who runs the front desk?").is_empty());
+}
+
+#[test]
 fn onnx_org_and_bare_apple_when_model_present() {
     let Some(rec) = IdentityRecognizer::from_env_optional() else {
         return;


### PR DESCRIPTION
- [x] I have read [CLA.md](../CLA.md) and will sign the Individual CLA via the bot comment (or I have already signed). A Corporate CLA, if required, does not replace the Individual CLA.
- [x] All commits are DCO-signed (`git commit -s`)
- [x] I have read [docs/PROJECT_SCOPE.md](../docs/PROJECT_SCOPE.md); this change is in scope

**Employer time or equipment**

- [x] Yes — my employer has authorised the contribution, or a Corporate CLA is on file

## Summary

`collect_name_runs_the` accepted interrogative pronouns as names, so
`Who runs the front desk?` minted a PERSON token on the durable vault.

Reject `who` / `whom` / `whose` / `what` / `when` / `where` / `why` / `how`
only in that cue. They are not added to global function words.
`Sorrel runs the front desk` still tokenizes Sorrel. No letter or
capitalization heuristics.

## Test plan

- [x] `cargo test -p redact-ner --lib who_runs_the`
- [x] `cargo test -p redact-ner --lib sorrel_runs_the`
- [x] `cargo test -p redact-ner --test identity_golden`
- [x] Golden: `Who runs the front desk?` has no PERSON spans
- [x] Existing lab-roster golden still lists Nimbus / Reed / Sable / Quill / Sorrel
